### PR TITLE
Add Ramworks expanded memory

### DIFF
--- a/src/emulator/memory.test.ts
+++ b/src/emulator/memory.test.ts
@@ -209,3 +209,66 @@ test('testC800', () => {
   memGet(0xC200)
   expect(memGet(0xC800)).not.toEqual(0x02)
 })
+
+test('test RAMWorks', () => {
+  memoryReset()
+
+  // check regular zp
+  memSet(0x00C0, 0xDE)
+  expect(memGet(0x00C0)).toEqual(0xDE)
+ 
+  // altzp
+  memSet(0xC009,0)
+  expect(memGet(0x00C0)).not.toEqual(0xDE)
+  memSet(0x00C0, 0x01)
+  expect(memGet(0x00C0)).toEqual(0x01)
+  // ramworks bank 0 is alt
+  memSet(0xC073,0x00)
+  expect(memGet(0x00C0)).toEqual(0x01)
+
+  // switch to ramworks bank 1
+  memSet(0xC073, 0x01)
+  expect(memGet(0x00C0)).not.toEqual(0x01)
+  memSet(0x00C0, 0x02)
+  expect(memGet(0x00C0)).toEqual(0x02)
+
+  // switch off altzp
+  memSet(0xC008,0)
+  expect(memGet(0x00C0)).not.toEqual(0x02)
+  expect(memGet(0x00C0)).toEqual(0xDE)
+
+  // switch to ramworks bank 2
+  memSet(0xC073, 0x02)
+  // since altzp is still off
+  expect(memGet(0x00C0)).toEqual(0xDE)
+  // altzp on
+  memSet(0xC009,0)
+  expect(memGet(0x00C0)).not.toEqual(0xDE)
+  memSet(0x00C0, 0x03)
+  expect(memGet(0x00C0)).toEqual(0x03)
+
+  memSet(0xC073,0x00)
+  memSet(0x00C0, 0x00)
+  memSet(0xC073,0x01)
+  memSet(0x00C0, 0x01)
+  memSet(0xC073,0x02)
+  memSet(0x00C0, 0x02)
+  memSet(0xC073,0x03)
+  memSet(0x00C0, 0x03)
+
+  memSet(0xC073,0x00)
+  expect(memGet(0x00C0)).toEqual(0x00)
+  memSet(0xC073,0x01)
+  expect(memGet(0x00C0)).toEqual(0x01)
+  memSet(0xC073,0x02)
+  expect(memGet(0x00C0)).toEqual(0x02)
+  memSet(0xC073,0x03)
+  expect(memGet(0x00C0)).toEqual(0x03)
+
+  // switch off altzp
+  memSet(0xC008,0)
+  expect(memGet(0x00C0)).toEqual(0xDE)
+
+  memSet(0xC009,0)
+  expect(memGet(0x00C0)).toEqual(0x03)
+})

--- a/src/emulator/softswitches.ts
+++ b/src/emulator/softswitches.ts
@@ -106,7 +106,7 @@ export const SWITCHES = {
     resetJoystick(cycleCount)
     memSetC000(0xC070, rand())
   }),
-  BANKSEL: NewSwitch(0xC073, 0),  // Applied Engineering RAMWorks (ignored)
+  //BANKSEL: NewSwitch(0xC073, 0),  // Applied Engineering RAMWorks (ignored)
   LASER128EX: NewSwitch(0xC074, 0),  // used by Total Replay (ignored)
   READBSR2: NewSwitch(0xC080, 0),
   WRITEBSR2: NewSwitch(0xC081, 0),


### PR DESCRIPTION
Seems to work with RAMWorks enabled software like AppleWorks and the RAMWerks test package.  Still need to add support for saving the ramworks bank in save state.
 