### PR TITLE
Merge Mouse and Clock to single Card

### DIFF
--- a/src/emulator/assembler.test.ts
+++ b/src/emulator/assembler.test.ts
@@ -23,13 +23,22 @@ test('parseAssembly address modes', () => {
 test('parseAssembly with labels', () => {
   expect(parseAssembly(addr, ["ABC EQU $FA", " LDA ABC"])).toEqual([0xA5, 0xFA])
   expect(parseAssembly(addr, ["ABC EQU $1234", " LDA ABC"])).toEqual([0xAD, 0x34, 0x12])
+  expect(parseAssembly(addr, ["ABC EQU $1234", " LDA ABC,X"])).toEqual([0xBD, 0x34, 0x12])
+  expect(parseAssembly(addr, ["ABC EQU $1234", " LDA ABC,Y"])).toEqual([0xB9, 0x34, 0x12])
+  expect(parseAssembly(addr, ["ABC EQU $12", " LDA ABC,X"])).toEqual([0xB5, 0x12])
+  expect(parseAssembly(addr, ["ABC EQU $12", " LDX ABC,Y"])).toEqual([0xB6, 0x12])
 })
   
 test('parseAssembly with labels and math', () => {
   expect(parseAssembly(addr, ["ABC EQU $FA", " LDA ABC+10"])).toEqual([0xAD, 0x04, 0x01])
   expect(parseAssembly(addr, ["ABC EQU $FA", " LDA ABC+#10"])).toEqual([0xAD, 0x04, 0x01])
+  expect(parseAssembly(addr, ["ABC EQU $01", " LDX ABC+#5,Y"])).toEqual([0xB6, 0x06])
   expect(parseAssembly(addr, ["ABC EQU $1234", " LDA ABC+3"])).toEqual([0xAD, 0x37, 0x12])
   expect(parseAssembly(addr, ["ABC EQU $1234", " LDA ABC-76"])).toEqual([0xAD, 0xE8, 0x11])
+  expect(parseAssembly(addr, ["ABC EQU $1234", " LDA ABC-76,X"])).toEqual([0xBD, 0xE8, 0x11])
+  expect(parseAssembly(addr, ["ABC EQU $0102", "ABC2 EQU ABC+1", " LDA ABC2,X"])).toEqual([0xBD, 0x03, 0x01])
+  expect(parseAssembly(addr, ["ABC EQU $0102+1", " LDA ABC,X"])).toEqual([0xBD, 0x03, 0x01])
+  expect(parseAssembly(addr, ["ABC EQU $0102+1", " LDA ABC+1,X"])).toEqual([0xBD, 0x04, 0x01])
 })
 
 test('parseAssembly with labels and promote/demote zp and abs', () => {
@@ -44,4 +53,25 @@ test('parseAssembly with labels and wraparound', () => {
 
 test('parseAssembly with labels immediate mode', () => {
   expect(parseAssembly(addr, ["ABC EQU $FA", " LDA #ABC"])).toEqual([0xA9, 0xFA])
+  expect(parseAssembly(addr, ["ABC EQU $C0DE", " LDA <ABC"])).toEqual([0xA9, 0xDE])
+  expect(parseAssembly(addr, ["ABC EQU $C0DE", " LDA >ABC"])).toEqual([0xA9, 0xC0])
+})
+
+test('parseAssembly define byte/word', () => {
+  expect(parseAssembly(addr, [" DB $01"])).toEqual([0x01])
+  expect(parseAssembly(addr, [" DW $0102"])).toEqual([0x02, 0x01])
+  expect(parseAssembly(addr, ["ABC EQU $01", " DB ABC"])).toEqual([0x01])
+  expect(parseAssembly(addr, ["ABC EQU $0102", " DW ABC"])).toEqual([0x02, 0x01])
+})
+
+test('parseAssembly define storage', () => {
+  expect(parseAssembly(addr, [" DS $01"])).toEqual([0x00])
+  expect(parseAssembly(addr, [" DS 4"])).toEqual([0x00, 0x00, 0x00, 0x00])
+})
+
+test('parseAssembly define ASCii string', () => {
+  expect(parseAssembly(addr, [" ASC \"ABCDEF\""])).toEqual([0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0x00])
+  expect(parseAssembly(addr, ["STR DA \"ABCDEF\""])).toEqual([0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0x00])
+  expect(parseAssembly(addr, [" ASC 'ABCDEF'"])).toEqual([0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x00])
+  expect(parseAssembly(addr, ["STR DA 'ABCDEF'"])).toEqual([0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x00])
 })

--- a/src/emulator/assembler.ts
+++ b/src/emulator/assembler.ts
@@ -12,7 +12,20 @@ type CodeLine = {
 type LabelOperand = {
   label: string,
   operation: string,
-  value: number
+  value: number,
+  idx: string
+}
+
+const splitOperand = (operand: string) => {
+  let idx = operand.split(',')
+  const s = idx[0].split(/([+-])/)
+  const codeLine: LabelOperand = {
+    label: s[0] ? s[0] : '',
+    operation: s[1] ? s[1] : '',
+    value: s[2] ? parseInt(s[2].replace('#','').replace('$','0x')) : 0,
+    idx: idx[1] ? idx[1] : ''
+  }
+  return codeLine
 }
 
 const parseNumberOptionalAddressMode = (operand: string): [MODE, number] => {
@@ -44,23 +57,25 @@ const parseNumberOptionalAddressMode = (operand: string): [MODE, number] => {
       operand = "0x" + operand.substring(1)
     }
     value = parseInt(operand)
+
+    const valueOperand = splitOperand(operand)
+    if (valueOperand.operation && valueOperand.value) {
+      switch (valueOperand.operation) {
+        case '+': value += valueOperand.value
+          break;
+        case '-': value -= valueOperand.value
+          break;
+        default:
+          throw new Error("Unknown operation in operand: " + operand);
+      }
+      value = (value % 65536 + 65536) % 65536
+    }
   }
 
   return [mode, value]
 }
 
-
 let labels: { [key: string]: number } = {};
-
-const splitOperand = (operand: string) => {
-  const s = operand.split(/([+-])/)
-  const codeLine: LabelOperand = {
-    label: s[0] ? s[0] : '',
-    operation: s[1] ? s[1] : '',
-    value: s[2] ? parseInt(s[2].replace('#','').replace('$','0x')) : 0
-  }
-  return codeLine
-}
 
 const getOperandModeValue =
   (pc: number, instr: string, operand: string, pass: 1 | 2): [MODE, number] => {
@@ -71,13 +86,20 @@ const getOperandModeValue =
     }
     const labelOperand = splitOperand(operand)
     if (labelOperand.label) {
-      // See if we have an immediate value, like #CONST
-      const isImmediate = labelOperand.label.startsWith('#')
+      // See if we have an immediate value, like #CONST, <CONST >CONST
+      const lb = labelOperand.label.startsWith('<')
+      const hb = labelOperand.label.startsWith('>')
+      const isImmediate = labelOperand.label.startsWith('#') || hb || lb
       if (isImmediate) {
         labelOperand.label = labelOperand.label.substring(1)
       }
       if (labelOperand.label in labels) {
         value = labels[labelOperand.label]
+        if (hb) {
+          value = (value >> 8) & 0xff
+        } else if (lb) {
+          value = value & 0xff
+        }
       } else if (pass === 2) {
         throw new Error("Missing label: " + labelOperand.label);
       }
@@ -101,6 +123,8 @@ const getOperandModeValue =
           mode = MODE.IMM
         } else {
           mode = (value >= 0 && value <= 255) ? MODE.ZP_REL : MODE.ABS
+          mode = (labelOperand.idx === 'X') ? (mode === MODE.ABS ? MODE.ABS_X : MODE.ZP_X) : mode
+          mode = (labelOperand.idx === 'Y') ? (mode === MODE.ABS ? MODE.ABS_Y : MODE.ZP_Y) : mode
         }
       }
     }
@@ -123,14 +147,15 @@ const handleLabel = (parts: CodeLine, pc: number) => {
     throw new Error("Redefined label: " + parts.label)
   }
   if (parts.instr === 'EQU') {
-    const [mode, value] = parseNumberOptionalAddressMode(parts.operand)
+    //const [mode, value] = parseNumberOptionalAddressMode(parts.operand)
+    const [mode, value] = getOperandModeValue(pc, parts.instr, parts.operand, 2)
     if (mode !== MODE.ABS && mode !== MODE.ZP_REL) {
       throw new Error("Illegal EQU value: " + parts.operand)
     }
-    // console.log(`LABEL=${parts.label} VALUE=${value}`)
+    // console.log(`LABEL=${parts.label} VALUE=${value.toString(16)}`)
     labels[parts.label] = value
   } else {
-    // console.log(`LABEL=${parts.label} PC=${pc}`)
+    // console.log(`LABEL=${parts.label} PC=${pc.toString(16)}`)
     labels[parts.label] = pc
   }
 }
@@ -179,18 +204,57 @@ const parseOnce = (start: number, code: Array<string>, pass: 1 | 2): Array<numbe
       return
     }
 
-    const [mode, value] = getOperandModeValue(pc, codeLine.instr, codeLine.operand, pass)
+    let newInstructions: Array<number> = []
+    let mode: MODE
+    let value: number
 
-    if (pass === 2 && isRelativeInstr(codeLine.instr) && (value < 0 || value > 255)) {
-      throw new Error(`Branch instruction out of range: ${line} value: ${value} pass: ${pass}`);
-    }
+    // Check psdudo-ops first
+    // ASC is merlin syntax, and so is '' vs ""
+    if (codeLine.instr === 'ASC' || codeLine.instr === 'DA') {
+      let operand = codeLine.operand
+      let hb = 0x00
+      if (operand.startsWith('"') && operand.endsWith('"')) {
+        hb = 0x80
+      } else if (operand.startsWith('\'') && operand.endsWith('\'')) {
+        hb = 0x00
+      } else {
+        throw new Error("Invalid string: " + operand);
+      }
 
-    const match = pcodes.findIndex(pc => pc && pc.name === codeLine.instr && pc.mode === mode)
-    if (match < 0) {
-      throw new Error(`Unknown instruction: ${codeLine.instr} mode=${mode} pass=${pass}`);
+      operand = operand.substring(1, operand.length-1)
+      for(let i=0;i<operand.length;i++) {
+        newInstructions.push(operand.charCodeAt(i) | hb)
+      }
+      newInstructions.push(0x00)
+      pc += (operand.length + 1)
+    } else {
+      [mode, value] = getOperandModeValue(pc, codeLine.instr, codeLine.operand, pass)
+
+      if (codeLine.instr === 'DB') {
+        newInstructions.push(value & 0xff)
+        pc++
+      } else if (codeLine.instr === 'DW') {
+        newInstructions.push(value & 0xff)
+        newInstructions.push((value >> 8) & 0xff)
+        pc+=2
+      } else if (codeLine.instr === 'DS') {
+        for(let i=0;i<value;i++) {
+          newInstructions.push(0x00)
+          pc++
+        }
+      } else {
+        if (pass === 2 && isRelativeInstr(codeLine.instr) && (value < 0 || value > 255)) {
+          throw new Error(`Branch instruction out of range: ${line} value: ${value} pass: ${pass}`);
+        }
+
+        const match = pcodes.findIndex(pc => pc && pc.name === codeLine.instr && pc.mode === mode)
+        if (match < 0) {
+          throw new Error(`Unknown instruction: ${codeLine.instr} mode=${mode} pass=${pass}`);
+        }
+        newInstructions = getHexCodesForInstruction(match, value)
+        pc += pcodes[match].PC
+      }
     }
-    const newInstructions = getHexCodesForInstruction(match, value)
-    pc += pcodes[match].PC
 
     if (doOutput && pass === 2) {
       newInstructions.forEach(i => {output += ` ${toHex(i)}`});
@@ -198,6 +262,12 @@ const parseOnce = (start: number, code: Array<string>, pass: 1 | 2): Array<numbe
     }
     instructions.push(...newInstructions)
   });
+
+  if (doOutput && pass === 2) {
+    let output = ""
+    instructions.forEach(i => {output += ` ${toHex(i)}`});
+    console.log(output)
+  }
 
   return instructions
 }

--- a/src/emulator/clock.ts
+++ b/src/emulator/clock.ts
@@ -33,7 +33,7 @@ export const enableClockCard = (enable = true, slot = 2) => {
   setSlotDriver(slot, code, addr, handleClockRead)
 }
 
-const handleClockRead = () => {
+export const handleClockRead = () => {
   // from prodos8 manual:
   // The ProDOS clock driver expects the clock card to send an ASCII string to the GETLN input buffer ($200).
   // This string must have the following format (including the commas):

--- a/src/emulator/motherboard.ts
+++ b/src/emulator/motherboard.ts
@@ -14,7 +14,6 @@ import { code } from "./assemblycode"
 import { handleGameSetup } from "./game_mappings"
 import { clearInterrupts, doSetDebug, doSetRunToRTS, processInstruction } from "./cpu6502"
 import { enableSerialCard } from "./serial"
-import { enableClockCard } from "./clock"
 import { enableMouseCard } from "./mouse"
 import { enableMockingboard, resetMockingboard } from "./mockingboard"
 import { resetMouse, onMouseVBL } from "./mouse"
@@ -129,7 +128,6 @@ const configureMachine = () => {
   if (didConfiguration) return
   didConfiguration = true
   enableSerialCard()
-  enableClockCard()
   enableMouseCard(true, 2)
   enableMockingboard(true, 4)
   enableMockingboard(true, 5)

--- a/src/emulator/mouse.ts
+++ b/src/emulator/mouse.ts
@@ -1,37 +1,261 @@
 // Mouse Driver for Apple2TS - Copyright 2023 Michael Morrison <codebythepound@gmail.com>
 
+import { parseAssembly } from "./assembler"
 import { setSlotDriver, setSlotIOCallback, memGet, memSet } from "./memory"
 import { MouseEventSimple } from "./utility"
 import { interruptRequest } from "./cpu6502"
 import { s6502 } from "./instructions"
 import { passShowMouse } from "./worker2main"
 
-//  Custom ROM
-const driver = new Uint8Array([
-  0x60, 0x60, 0x60, 0x00, 0x00, 0x38, 0x00, 0x18, 0x00, 0x00, 0x00, 
-  0x01, 0x20, 0x1d, 0x1d, 0x1d, 0x1d, 0x00, 0x28, 0x36, 0xb6, 0xc6, 
-  0xaa, 0x92, 0xce, 0xd5, 0x23, 0x00, 0x21, 0xa2, 0x03, 0x38, 0x60, 
-  0x18, 0x60, 0x9e, 0xb8, 0x04, 0x18, 0x60, 0xc9, 0x10, 0xb0, 0x09, 
-  0x99, 0x85, 0xc0, 0xb9, 0x85, 0xc0, 0x9d, 0x38, 0x07, 0x60, 0xa4, 
-  0x06, 0xa9, 0x60, 0x85, 0x06, 0x20, 0x06, 0x00, 0x84, 0x06, 0xba, 
-  0xbd, 0x00, 0x01, 0xaa, 0x0a, 0x0a, 0x0a, 0x0a, 0xa8, 0xa9, 0x04, 
-  0x99, 0x86, 0xc0, 0xb9, 0x84, 0xc0, 0x29, 0x0e, 0x38, 0xf0, 0xdd, 
-  0x1d, 0xb8, 0x06, 0x9d, 0xb8, 0x06, 0x18, 0x60, 0xbd, 0xb8, 0x03, 
-  0x99, 0x80, 0xc0, 0xbd, 0x38, 0x04, 0x99, 0x82, 0xc0, 0xbd, 0xb8, 
-  0x04, 0x99, 0x81, 0xc0, 0xbd, 0x38, 0x05, 0x99, 0x83, 0xc0, 0x60, 
-  0xb9, 0x80, 0xc0, 0x9d, 0xb8, 0x03, 0xb9, 0x82, 0xc0, 0x9d, 0x38, 
-  0x04, 0xb9, 0x81, 0xc0, 0x9d, 0xb8, 0x04, 0xb9, 0x83, 0xc0, 0x9d, 
-  0x38, 0x05, 0x60, 0x29, 0x01, 0x9d, 0xb8, 0x05, 0xda, 0xda, 0xa2, 
-  0xc0, 0xa9, 0x9f, 0x48, 0x80, 0xc0, 0xfa, 0xa9, 0x06, 0x1d, 0xb8, 
-  0x05, 0x99, 0x86, 0xc0, 0x60, 0xda, 0xa9, 0xaf, 0x48, 0x80, 0xb0, 
-  0xa9, 0x08, 0x99, 0x86, 0xc0, 0x60, 0xa9, 0x01, 0x99, 0x86, 0xc0, 
-  0xb9, 0x84, 0xc0, 0x29, 0xf1, 0x9d, 0xb8, 0x06, 0x18, 0x80, 0xb3, 
-  0xa9, 0x02, 0x99, 0x86, 0xc0, 0x18, 0x80, 0xab, 0xa9, 0x05, 0x99, 
-  0x86, 0xc0, 0x18, 0x60, 0xa9, 0x00, 0x99, 0x86, 0xc0, 0xb9, 0x85, 
-  0xc0, 0x9d, 0x38, 0x07, 0x80, 0xd4, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 
-  0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 
-  0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 
-  0xd6, 0xd6, 0xd6])
+const mouseDriver = `
+Cx00	rts	        ; BASIC support provided in JS
+Cx01	rts         ; Temporarily required for hack basic support in JS
+Cx02	db $00
+Cx03	db $00
+Cx04	db $00
+Cx05	db $38      ; Pascal ID Byte
+Cx06	db $00
+Cx07	db $18      ; Pascal ID Byte
+Cx08	db $00
+Cx09	db $00
+Cx0a	db $00
+Cx0b	db $01      ; Pascal Generic Signature
+Cx0c	db $20      ; $2x = Pascal XY Pointing Device, ID=x0 apple mouse
+Cx0d	db <PASCAL  ; init
+Cx0e	db <PASCAL  ; read
+Cx0f	db <PASCAL  ; write
+Cx10	db <PASCAL  ; status
+Cx11	db $00      ; Pascal optional routines follow
+
+Cx12    db <SETMOUSE
+Cx13    db <SERVEMOUSE
+Cx14    db <READMOUSE
+Cx15    db <CLEARMOUSE
+Cx16    db <POSMOUSE
+Cx17    db <CLAMPMOUSE
+Cx18    db <HOMEMOUSE
+Cx19    db <INITMOUSE
+Cx1a    db <GETCLAMP
+Cx1b    db <UNDOCUMENTED      ; applemouse has methods here
+Cx1c    db <TIMEDATA
+Cx1d    db <UNDOCUMENTED      ; not sure if some will call them 
+Cx1e    db <UNDOCUMENTED
+Cx1f    db <UNDOCUMENTED
+
+;
+; All methods (except SERVEMOUSE) entered with X = Cn, Y = n0
+;
+; $0478 + slot        Low byte of absolute X position
+; $04F8 + slot        Low byte of absolute Y position
+; $0578 + slot        High byte of absolute X position
+; $05F8 + slot        High byte of absolute Y position
+; $0678 + slot        Reserved and used by the firmware
+; $06F8 + slot        Reserved and used by the firmware
+; $0778 + slot        Button 0/1 interrupt status byte
+; $07F8 + slot        Mode byte
+; 
+; The interrupt status byte is defined as follows:
+; 
+; Bit 7 6 5 4 3 2 1 0
+;     | | | | | | | |
+;     | | | | | | | \---  Previously, button 1 was up (0) or down (1)
+;     | | | | | | \-----  Movement interrupt
+;     | | | | | \-------  Button 0/1 interrupt
+;     | | | | \---------  VBL interrupt
+;     | | | \-----------  Currently, button 1 is up (0) or down (1)
+;     | | \-------------  X/Y moved since last READMOUSE
+;     | \---------------  Previously, button 0 was up (0) or down (1)
+;     \-----------------  Currently, button 0 is up (0) or down (1)
+; 
+; (Button 1 is not physically present on the mouse, and is probably only
+; supported for an ADB mouse on the IIgs.)
+; 
+; 
+; The mode byte is defined as follows.
+; 
+; Bit 7 6 5 4 3 2 1 0
+;     | | | | | | | |
+;     | | | | | | | \---  Mouse off (0) or on (1)
+;     | | | | | | \-----  Interrupt if mouse is moved
+;     | | | | | \-------  Interrupt if button is pressed
+;     | | | | \---------  Interrupt on VBL
+;     | | | \-----------  Reserved
+;     | | \-------------  Reserved
+;     | \---------------  Reserved
+;     \-----------------  Reserved
+; 
+
+SLOWX   EQU $0478-$c0 ; + Cs        Low byte of absolute X position
+SLOWY   EQU $04F8-$c0 ; + Cs        Low byte of absolute Y position
+SHIGHX  EQU $0578-$c0 ; + Cs        High byte of absolute X position
+SHIGHY  EQU $05F8-$c0 ; + Cs        High byte of absolute Y position
+STEMPA  EQU $0678-$c0 ; + Cs        Reserved and used by the firmware
+STEMPB  EQU $06F8-$c0 ; + Cs        Reserved and used by the firmware
+SBUTTON EQU $0778-$c0 ; + Cs        Button 0/1 interrupt status byte
+SMODE   EQU $07F8-$c0 ; + Cs        Mode byte
+
+LOWX   EQU $c080 ; + s0        Low byte of absolute X position
+HIGHX  EQU $c081 ; + s0        High byte of absolute X position
+LOWY   EQU $c082 ; + s0        Low byte of absolute Y position
+HIGHY  EQU $c083 ; + s0        High byte of absolute Y position
+BUTTON EQU $c084 ; + s0        Button 0/1 interrupt status byte
+MODE   EQU $c085 ; + s0        Mode byte
+CLAMP  EQU $c086 ; + s0        clamp value
+
+CMD    EQU $c08a ; + slot        Command reg
+INIT   EQU $0    ;               initialize
+READ   EQU $1    ;               read mouse and update regs, clear ints
+CLEAR  EQU $2    ;               clear mouse and update regs, clear ints
+GCLAMP EQU $3    ;               get mouse clamping
+SERVE  EQU $4    ;               check/serve mouse int
+HOME   EQU $5    ;               set to clamping window upper left
+CLAMPX EQU $6    ;               clamp x values to x -> y
+CLAMPY EQU $7    ;               clamp y values to x -> y
+POS    EQU $8    ;               set positions
+UNDOC  EQU $9    ;               calling an undocumented entry
+
+PASCAL
+    ldx #$03        ; return error for pascal
+
+UNDOCUMENTED
+    sec
+    rts
+                    ; Technote #2
+TIMEDATA            ; A bit 0: 1 - 50hz, 0 = 60hz VBL
+    clc
+    rts
+                    ; Technote #7
+                    ; Return 8 clamping bytes one at a time to $578
+GETCLAMP
+    lda $478        ; index byte, starting at $4E according to technote
+    sta CLAMP,y     ; indicates which byte in the order we want
+    lda #GCLAMP
+    sta CMD,y
+    lda CLAMP,y
+    sta $578
+    clc             ; In this order: minXH, minYH, minXL, minYL
+    rts             ;                maxXH, maxYH, maxXL, maxYL
+
+SETMOUSE 
+    cmp #$10
+    bcs return      ; invalid
+    sta MODE,y      ; set mode
+    lda MODE,y      ; reread to ensure valid
+    sta SMODE,x
+return 
+    rts
+
+SERVEMOUSE 
+    ldy $06
+    lda #$60
+    sta $06
+    jsr $0006       ; start by finding our slot - not entered with X,Y set
+    sty $06
+    tsx
+    lda $100,x
+    tax             ; X = Cs
+    asl
+    asl
+    asl
+    asl
+    tay             ; Y = s0
+
+    lda #SERVE
+    sta CMD,y
+
+    lda BUTTON,y 
+    and #$0e
+    sec
+    beq return      ; exit without changing anything
+
+    ora SBUTTON,x
+    sta SBUTTON,x
+    clc             ; claim it
+    rts
+
+copyin 
+    lda SLOWX,x
+    sta LOWX,y
+    lda SLOWY,x
+    sta LOWY,y
+    lda SHIGHX,x
+    sta HIGHX,y
+    lda SHIGHY,x
+    sta HIGHY,y
+    rts
+
+copyout 
+    lda LOWX,y
+    sta SLOWX,x
+    lda LOWY,y
+    sta SLOWY,x
+    lda HIGHX,y
+    sta SHIGHX,x
+    lda HIGHY,y
+    sta SHIGHY,x
+    rts
+
+CLAMPMOUSE 
+    and #$1
+    sta STEMPA,x
+    phx
+    phx
+    ldx #$c0      ; note load from screen hole 0, not slot
+
+    lda <cmcont-1
+    pha
+    bra copyin
+
+cmcont 
+    plx
+    lda #CLAMPX  ; a = 1 for Y
+    ora STEMPA,x
+    sta CMD,y
+    rts
+
+POSMOUSE 
+    phx
+    lda <pmcont-1
+    pha
+    bra copyin
+
+pmcont 
+    lda #POS
+    sta CMD,y
+    rts
+
+READMOUSE 
+    lda #READ
+    sta CMD,y
+
+    lda BUTTON,y
+    and #$F1        ; mask off interrupts
+    sta SBUTTON,x
+    clc
+    bra copyout
+
+CLEARMOUSE 
+    lda #CLEAR
+    sta CMD,y
+    clc
+    bra copyout
+
+HOMEMOUSE 
+    lda #HOME
+    sta CMD,y
+    clc
+    rts
+
+INITMOUSE 
+    lda #INIT
+    sta CMD,y
+
+    lda MODE,y
+    sta SMODE,x
+    bra READMOUSE
+
+    ; should leave about 13 bytes
+`
 
 export const resetMouse = () => {
   mousex = 0
@@ -74,11 +298,21 @@ let servestatus = 0
 let command = 0
 
 let slot = 5
-const basicEntry = 0x00
 const CSWL = 0x36 // Character output SWitch
 const CSWH = 0x37
 const KSWL = 0x38 // Keyboard input SWitch
 const KSWH = 0x39
+
+const slotROM = () => {
+  const driver = new Uint8Array(256).fill(0)
+  const pcode = parseAssembly(0x0, mouseDriver.split("\n"))
+  driver.set(pcode, 0)
+  // d6 at FB is required for a mouse driver
+  driver[0xFB] = 0xd6
+  // I think this is a ROM version value
+  driver[0xFF] = 0x01
+  return driver
+}
 
 export const enableMouseCard = (enable = true, aslot = 5) => {
   if (!enable)
@@ -88,7 +322,7 @@ export const enableMouseCard = (enable = true, aslot = 5) => {
 
   //console.log('AppleMouse compatible in slot', slot)
   const basicAddr = 0xc000 + slot * 0x100
-  setSlotDriver(slot, driver, basicAddr + basicEntry,  handleBasic)
+  setSlotDriver(slot, slotROM(), basicAddr, handleBasic)
   setSlotIOCallback(slot, handleMouse)
 
   resetMouse()
@@ -131,8 +365,9 @@ export const enableMouseCard = (enable = true, aslot = 5) => {
 // HIGHY  EQU $c083 ; + s0        High byte of absolute Y position
 // BUTTON EQU $c084 ; + s0        Button 0/1 interrupt status byte
 // MODE   EQU $c085 ; + s0        Mode // byte
+// CLAMP  EQU $c086 ; + s0        Mode // byte
 // 
-// CMD    EQU $c086 ; + slot        Command reg
+// CMD    EQU $c08a ; + slot        Command reg
 // INIT   EQU $0    ;               initialize
 // READ   EQU $1    ;               read mouse and update regs, clear ints
 // CLEAR  EQU $2    ;               clear mouse and update regs, clear ints
@@ -247,7 +482,7 @@ export const MouseCardEvent = (event: MouseEventSimple) => {
         istatus |= 0x02
       }
     }
-    //console.log("XYB: ", mousex, " ", mousey, " ", bstatus.toString(16))
+    console.log("XYB: ", mousex, " ", mousey, " ", bstatus.toString(16))
   }
 }
 
@@ -343,14 +578,15 @@ const handleMouse: AddressCallback = (addr:number, value: number): number => {
       HIGHY:    0x03,
       STATUS:   0x04,
       MODE:     0x05,
-      COMMAND:  0x06,
+      CLAMP:    0x06,
+      COMMAND:  0x0a,
   }
 
   const CMD = {
     INIT:   0,    //               initialize
     READ:   1,    //               read mouse and update regs, clear ints
     CLEAR:  2,    //               clear mouse and update regs, clear ints
-    GETCLAMP: 3,  //               get mouse clamping
+    GCLAMP: 3,    //               get mouse clamping
     SERVE:  4,    //               check/serve mouse int
     HOME:   5,    //               set to clamping window upper left
     CLAMPX: 6,    //               clamp x values to x -> y
@@ -362,7 +598,8 @@ const handleMouse: AddressCallback = (addr:number, value: number): number => {
     case REG.LOWX:
         if (isRead === false) {
           tmpmousex = (tmpmousex & 0xff00) | value
-          console.log('lowx', tmpmousex)
+          tmpmousex &= 0xffff
+          //console.log('lowx', tmpmousex)
         }
         else {
           return mousex & 0xff
@@ -371,7 +608,8 @@ const handleMouse: AddressCallback = (addr:number, value: number): number => {
     case REG.HIGHX:
         if (isRead === false) {
           tmpmousex = (((value<<8) | (tmpmousex & 0x00ff)))
-          console.log('highx', tmpmousex)
+          tmpmousex &= 0xffff
+          //console.log('highx', tmpmousex)
         }
         else {
           return (mousex >> 8) & 0xff
@@ -380,7 +618,8 @@ const handleMouse: AddressCallback = (addr:number, value: number): number => {
     case REG.LOWY:
         if (isRead === false) {
           tmpmousey = (tmpmousey & 0xff00) | value
-          console.log('lowy', tmpmousey)
+          tmpmousey &= 0xffff
+          //console.log('lowy', tmpmousey)
         }
         else {
           return mousey & 0xff
@@ -389,7 +628,8 @@ const handleMouse: AddressCallback = (addr:number, value: number): number => {
     case REG.HIGHY:
         if (isRead === false) {
           tmpmousey = (((value<<8) | (tmpmousey & 0x00ff)))
-          console.log('highy', tmpmousey)
+          tmpmousey &= 0xffff
+          //console.log('highy', tmpmousey)
         }
         else {
           return (mousey >> 8) & 0xff
@@ -405,6 +645,38 @@ const handleMouse: AddressCallback = (addr:number, value: number): number => {
         }
         else {
           return mode
+        }
+        break
+
+    case REG.CLAMP:
+        if (isRead === false) {
+          clampidx = 0x4e - value
+        }
+        else {
+          // returned In this order: minXH, minYH, minXL, minYL
+          //                         maxXH, maxYH, maxXL, maxYL
+          switch (clampidx)
+          {
+            case 0:
+              return (clampxmin>>8)&0xff
+            case 1:
+              return (clampymin>>8)&0xff
+            case 2:
+              return clampxmin&0xff
+            case 3:
+              return clampymin&0xff
+            case 4:
+              return (clampxmax>>8)&0xff
+            case 5:
+              return (clampymax>>8)&0xff
+            case 6:
+              return clampxmax&0xff
+            case 7:
+              return clampymax&0xff
+            default:
+              console.log("AppleMouse: invalid clamp index: " + clampidx)
+              return 0
+          }
         }
         break
 
@@ -473,22 +745,26 @@ const handleMouse: AddressCallback = (addr:number, value: number): number => {
               // deassert
               interruptRequest(slot, false)
               break
+            case CMD.GCLAMP:      //              get clamping values
+              // set int flags
+              console.log('cmd.gclamp')
+              break
             case CMD.HOME:       //               set to clamping window upper left
               console.log('cmd.home')
               mousex = clampxmin
               mousey = clampymin
               break
-            //case CMD.CLAMP:      //               set mouse clamping
-            //  break
             case CMD.CLAMPX:     //               clamp x values to x -> y
               console.log('cmd.clampx')
-              clampxmin = tmpmousex
+              clampxmin = tmpmousex > 32767 ? tmpmousex - 65536 : tmpmousex
               clampxmax = tmpmousey
+              console.log(clampxmin + " -> " + clampxmax)
               break
             case CMD.CLAMPY:     //               clamp y values to x -> y
               console.log('cmd.clampy')
-              clampymin = tmpmousex
+              clampymin = tmpmousex > 32767 ? tmpmousex - 65536 : tmpmousex
               clampymax = tmpmousey
+              console.log(clampymin + " -> " + clampymax)
               break
             case CMD.GETCLAMP:     //
               console.log('cmd.getclamp')


### PR DESCRIPTION
Extend assembler to add db,dw,ds,asc,<>,math on labels; add tests for same.
Add mouse assembly to the mouse.ts driver to make it easier to extend.
Combine mouse and prodos clock to use single slot.

