### PR TITLE
add support for SD MIDI ][+ extra IO ports

### DIFF
--- a/src/emulator/devices/passport/passport.ts
+++ b/src/emulator/devices/passport/passport.ts
@@ -79,12 +79,15 @@ const handleMIDIIO = (addr: number, val = -1): number => {
       T3LSB:        0x07, 
       ACIASTATCTRL: 0x08,
       ACIADATA:     0x09,
-      DRUMSET:      0x0e,
-      DRUMCLEAR:    0x0f,
+      SDMIDICTRL:   0x0C, // SD MIDI ][+ Card uses these registers in addition to 08,09
+      SDMIDIDATA:   0x0D, //             to access ACIA.  Confirmed by Ian Kim.
+      DRUMSET:      0x0E,
+      DRUMCLEAR:    0x0F,
   }
 
   let result = -1
   switch (addr & 0x0f) {
+    case REG.SDMIDIDATA:
     case REG.ACIADATA:
         if(val >= 0)
         {
@@ -98,6 +101,7 @@ const handleMIDIIO = (addr: number, val = -1): number => {
         }
         break
 
+    case REG.SDMIDICTRL:
     case REG.ACIASTATCTRL:
         if(val >= 0)
         {
@@ -120,7 +124,7 @@ const handleMIDIIO = (addr: number, val = -1): number => {
       }
       else
       {
-        console.log("Read Timer Control1: error")
+        //console.log("Read Timer Control1: error")
         result = 0x00
       }
       break;


### PR DESCRIPTION
Ian Kim's "SD MIDI ][+" Midi board supports passport midi ports as well as two additional ports for the 6850 ACIA.  This change adds support for those ports in order to support his MIDI player: https://quick09.tistory.com/1510.
