### PR TITLE
Added support for COLOR_MODE.INVERSEBLACKANDWHITE

### DIFF
--- a/src/emulator/utility/utility.ts
+++ b/src/emulator/utility/utility.ts
@@ -78,6 +78,7 @@ export enum COLOR_MODE {
   GREEN,
   AMBER,
   BLACKANDWHITE,
+  INVERSEBLACKANDWHITE
 }
 
 export enum ARROW {
@@ -99,7 +100,7 @@ export type MouseEventSimple = {
 }
 
 export const colorToName = (mode: COLOR_MODE) => {
-  return ["Color", "Color (no fringe)", "Green", "Amber", "Black and White"][mode]
+  return ["Color", "Color (no fringe)", "Green", "Amber", "Black and White", "Black and White (inverse)"][mode]
 }
 
 export const nameToColorMode = (name: string) => {
@@ -108,6 +109,7 @@ export const nameToColorMode = (name: string) => {
     case "Green": return COLOR_MODE.GREEN
     case "Amber": return COLOR_MODE.AMBER
     case "Black and White": return COLOR_MODE.BLACKANDWHITE
+    case "Black and White (inverse)": return COLOR_MODE.INVERSEBLACKANDWHITE
     default: return COLOR_MODE.COLOR
   }
 }

--- a/src/graphics.ts
+++ b/src/graphics.ts
@@ -76,7 +76,7 @@ const processTextPage = (ctx: CanvasRenderingContext2D,
   const jstart = mixedMode ? 20 : 0
   const doFlashCycle = (Math.trunc(frameCount / 15) % 2) === 0
   const isAltCharSet = handleGetAltCharSet()
-  const colorFill = ['#FFFFFF', '#FFFFFF', TEXT_GREEN, TEXT_AMBER, TEXT_WHITE][colorMode]
+  const colorFill = ['#FFFFFF', '#FFFFFF', TEXT_GREEN, TEXT_AMBER, TEXT_WHITE, TEXT_WHITE][colorMode]
 
   for (let j = jstart; j < 24; j++) {
     const yoffset = ymarginPx + (j + 1)*cheight - 3
@@ -91,7 +91,7 @@ const processTextPage = (ctx: CanvasRenderingContext2D,
 //      const v = String.fromCharCode(v1 < 127 ? v1 : v1 === 0x83 ? 0xEBE7 : (v1 + 0xE000))
       ctx.fillStyle = colorFill
       hiddenContext.fillStyle = colorFill
-      if (doInverse) {
+      if (doInverse || colorMode == COLOR_MODE.INVERSEBLACKANDWHITE) {
         // Inverse characters
         ctx.fillRect(xmarginPx + i*cwidth, ymarginPx + j*cheight, 1.08*cwidth, 1.03*cheight)
         ctx.fillStyle = "#000000"
@@ -162,6 +162,7 @@ const processLoRes = (hiddenContext: CanvasRenderingContext2D,
 };
 
 const BLACK = 0
+const WHITE = 3
 
 const getDoubleHiresColors = (hgrPage: Uint8Array, colorMode: COLOR_MODE) => {
   const nlines = hgrPage.length / 80
@@ -202,9 +203,10 @@ const processHiRes = (hiddenContext: CanvasRenderingContext2D,
   const doubleRes = hgrPage.length === 12800 || hgrPage.length === 15360
   const isColor = colorMode === COLOR_MODE.COLOR || colorMode === COLOR_MODE.NOFRINGE
   const noDelayMode = handleGetNoDelayMode()
+  const fillColor = colorMode === COLOR_MODE.INVERSEBLACKANDWHITE ? WHITE : BLACK
   const hgrColors = doubleRes ? getDoubleHiresColors(hgrPage, colorMode) :
-    (isColor ? getHiresColors(hgrPage, nlines, colorMode, noDelayMode, false, true) :
-    getHiresGreen(hgrPage, nlines))
+    (isColor ? getHiresColors(hgrPage, nlines, colorMode, noDelayMode, false, true, fillColor) :
+    getHiresGreen(hgrPage, nlines, fillColor))
   const hgrRGBA = convertColorsToRGBA(hgrColors, colorMode, doubleRes)
   const hgrDataStretched = new Uint8ClampedArray(4 * 560 * nlines * 2)
   for (let j = 0; j < nlines; j++) {

--- a/src/img/icons.tsx
+++ b/src/img/icons.tsx
@@ -60,6 +60,12 @@ export const getColorModeSVG = (colorMode: COLOR_MODE) => {
         <rect width={10} height={14} x={10} fill="#F0F0F0" />
       </svg>
       break;
+    case COLOR_MODE.INVERSEBLACKANDWHITE:
+      svgRect = <svg>
+        <rect width={10} height={14} fill="#F0F0F0" />
+        <rect width={10} height={14} x={10} fill="#000000" />
+      </svg>
+      break;
     default:
       svgRect = <svg>
         <rect width={5} height={14} fill="#00ff00" />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/baf84d70-ad2b-463f-a132-7b5ce8151cbd)
![image](https://github.com/user-attachments/assets/af5d39b7-1b6d-4d71-99ce-b5c1e8f953b5)
![image](https://github.com/user-attachments/assets/78b336ca-1e3c-47c8-8503-f274ae0fe996)

**Changes made:**
- Added `INVERSEBLACKANDWHITE` to `COLOR_MODE` enum
- Added "Black and White (inverse)" option to Display Settings dropdown
- Added inverted (white/black) color mode icon to Display Settings button

**Tests performed:**
- Verified all text and graphics modes work as expected (including lores, highres, and double highres)
- Verified invert works correctly with scanlines

**Issues resolved:**
- Implemented #91