### PR TITLE
Refactored cloud drive code to make it easier to add new providers

### DIFF
--- a/src/devices/diskinterface.css
+++ b/src/devices/diskinterface.css
@@ -39,7 +39,7 @@ body.dark-mode .disk-cloud {
   color: var(--text-color-dark);
 }
 
-.disk-onedrive {
+.disk-clouddrive {
   position: absolute;
   text-align: center;
   margin-left: 24px;
@@ -48,22 +48,22 @@ body.dark-mode .disk-cloud {
   pointer-events: none;
 }
 
-.disk-onedrive-inactive {
+.disk-clouddrive-inactive {
   display: none;
   color: var(--text-color);
 }
 
-.disk-onedrive-active {
+.disk-clouddrive-active {
   display: none;
   color: #0364B8;
 }
 
-.disk-onedrive-pending {
+.disk-clouddrive-pending {
   display: none;
   color: #28A8EA;
 }
 
-.disk-onedrive-inprogress {
+.disk-clouddrive-inprogress {
   color: #0364B8;
   animation: rotate .5s linear 3;
   -webkit-animation: rotate 2s linear infinite;
@@ -78,27 +78,12 @@ body.dark-mode .disk-cloud {
   }
 }
 
-.disk-onedrive-failed {
+.disk-clouddrive-failed {
   color: darkred;
 }
 
-.disk-onedrive-paused {
+.disk-clouddrive-paused {
   color: dimgray;
-}
-
-@keyframes oneDriveSyncTransition {
-  0% {
-    color: #28A8EA;
-  }
-  33% {
-    color: #1490DF;
-  }
-  66% {
-    color: #0078D4;
-  }
-  100% {
-    color: #0364B8;
-  }
 }
 
 .imgButton {

--- a/src/emulator/utility/clouddrive.ts
+++ b/src/emulator/utility/clouddrive.ts
@@ -1,5 +1,3 @@
-import { IconDefinition } from "@fortawesome/free-solid-svg-icons"
-
 export enum CloudDriveSyncStatus {
   Inactive,
   Active,
@@ -9,26 +7,15 @@ export enum CloudDriveSyncStatus {
 }
 
 export interface CloudDrive {
+  providerName: string
   syncStatus: CloudDriveSyncStatus
   syncInterval: number
   lastSyncTime: number
-  fileName: string
-  downloadUrl: string
-  uploadUrl: string
 
-  getSyncStatus(dprops: DriveProps): CloudDriveSyncStatus
-  setSyncStatus(status: CloudDriveSyncStatus): void
-  isSyncPaused(): boolean
+  getFileName(): string
+  setFileName(fileName: string): void
 
-  getSyncInterval(): number
-  setSyncInterval(interval: number): void
-
-  getStatusMessage(dprops: DriveProps): string
-  getStatusClassName(dprops: DriveProps): string
-  getSyncIcon(dprops: DriveProps): IconDefinition
-
-  downloadFile(filter: string): Promise<boolean>
-  uploadFile(blob: Blob): Promise<void>
-  syncDrive(dprops: DriveProps): void
-  saveFile(filename: string): Promise<boolean>
+  download(filter: string): Promise<Blob|undefined>
+  upload(fileName: string, blob: Blob): Promise<boolean>
+  sync(blob: Blob): Promise<void>
 }

--- a/src/emulator/utility/onedriveclouddrive.ts
+++ b/src/emulator/utility/onedriveclouddrive.ts
@@ -1,8 +1,4 @@
-import { getBlobFromDiskData } from "../../devices/diskdrive";
-import { doSetUIDriveProps } from "../../devices/driveprops";
-import { doSetEmuDriveProps } from "../devices/drivestate";
 import { CloudDrive, CloudDriveSyncStatus } from "./clouddrive";
-import { faCloud, faCloudArrowDown, faCloudArrowUp, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 
 const applicationId = "74fef3d4-4cf3-4de9-b2d7-ef63f9add409"
 
@@ -10,95 +6,28 @@ const MAX_UPLOAD_BYTES = 4 * 1024 * 1024 // 4 MB
 export const DEFAULT_SYNC_INTERVAL = 5 * 60 * 1000
 
 export class OneDriveCloudDrive implements CloudDrive {
+  providerName = "OneDrive"
   syncStatus = CloudDriveSyncStatus.Inactive
   syncInterval = DEFAULT_SYNC_INTERVAL
   lastSyncTime = -1
-  fileName: string = ""
-  downloadUrl: string = ""
-  uploadUrl: string = ""
 
   accessToken: string = ""
   apiEndpoint: string = ""
   folderId: string = ""
+  downloadUrl: string = ""
+  uploadUrl: string = ""
+  fileName: string = ""
 
-  getSyncStatus(dprops: DriveProps): CloudDriveSyncStatus {
-    switch (this.syncStatus) {
-      case CloudDriveSyncStatus.Active:
-        if (dprops.lastWriteTime > this.lastSyncTime) {
-          this.setSyncStatus(CloudDriveSyncStatus.Pending)
-        }
-        break
-
-      case CloudDriveSyncStatus.Pending:
-        if ((Date.now() - this.lastSyncTime > this.syncInterval)) {
-          this.syncDrive(dprops)
-        }
-        break
-    }
-
-    return this.syncStatus
+  getFileName(): string {
+    return this.fileName
   }
 
-  setSyncStatus(status: CloudDriveSyncStatus): void {
-    this.syncStatus = status
+  setFileName(fileName: string): void {
+    this.fileName = fileName
+    this.uploadUrl = ""
   }
 
-  isSyncPaused(): boolean {
-    return this.syncInterval == Number.MAX_VALUE
-  }
-
-  getSyncInterval(): number {
-    return this.syncInterval
-  }
-
-  setSyncInterval(interval: number): void {
-    this.syncInterval = interval
-  }
-
-  getStatusMessage(dprops: DriveProps): string {
-    switch (this.getSyncStatus(dprops)) {
-      case CloudDriveSyncStatus.Inactive:
-        return dprops.diskData.length > 0 ? "Save Disk to OneDrive" : "Load Disk from OneDrive"
-  
-      case CloudDriveSyncStatus.Active:
-        return "OneDrive Sync Up-to-date"
-        
-      case CloudDriveSyncStatus.Pending:
-        return this.isSyncPaused() ? "OneDrive Sync Paused" : "OneDrive Sync Pending"
-        
-      case CloudDriveSyncStatus.InProgress:
-        return "OneDrive Sync In Progress"
-        
-      case CloudDriveSyncStatus.Failed:
-        return "OneDrive Sync Failed"
-    }
-  }
-
-  getStatusClassName(dprops: DriveProps): string {
-    const syncStatus = this.getSyncStatus(dprops)
-
-    if (this.isSyncPaused() && syncStatus != CloudDriveSyncStatus.Inactive && syncStatus != CloudDriveSyncStatus.InProgress) {
-      return "disk-onedrive-paused"
-    } else {
-      return `disk-onedrive-${CloudDriveSyncStatus[syncStatus].toLowerCase()}`
-    }
-  }
-
-  getSyncIcon(dprops: DriveProps): IconDefinition {
-    switch (this.getSyncStatus(dprops)) {
-      case CloudDriveSyncStatus.Inactive:
-        return dprops.diskData.length > 0 ? faCloudArrowUp : faCloudArrowDown
-  
-      case CloudDriveSyncStatus.Pending:
-      case CloudDriveSyncStatus.InProgress:
-        return faCloudArrowUp
-  
-      default:
-        return faCloud
-    }
-  }
-
-  async downloadFile(filter: string): Promise<boolean> {
+  async download(filter: string): Promise<Blob|undefined> {
     const result = await launchPicker("files", filter)
     if (result) {
       this.accessToken = result.accessToken
@@ -113,25 +42,51 @@ export class OneDriveCloudDrive implements CloudDrive {
         this.downloadUrl = file["@content.downloadUrl"]
         this.uploadUrl = `${this.apiEndpoint}drive/items/${file.id}/content`
 
-        return true
+        this.syncStatus = CloudDriveSyncStatus.InProgress
+
+        const response = await fetch(this.downloadUrl);
+        if (response.ok) {
+          this.syncStatus = CloudDriveSyncStatus.Active
+          return await response.blob()
+        } else {
+          console.log(`HTTP ${response.status}: ${response.statusText}`)
+        }
       }
+    }
+
+    return undefined
+  }
+
+  async upload(filename: string, blob: Blob): Promise<boolean> {
+    const result = await launchPicker("folders")
+
+    if (result) {
+      this.accessToken = result.accessToken
+      this.apiEndpoint = result.apiEndpoint
+
+      for (const file of result.value) {
+          this.syncStatus = CloudDriveSyncStatus.Active
+          this.folderId = file.id
+          this.fileName = filename
+          this.downloadUrl = ""
+          this.uploadUrl = ""
+          this.lastSyncTime = Date.now()
+          this.syncInterval = DEFAULT_SYNC_INTERVAL
+
+          this.uploadFile(blob)
+      }
+      return true
     }
 
     return false
   }
 
-  syncDrive(dprops: DriveProps): void {
-    this.setSyncStatus(CloudDriveSyncStatus.InProgress)
-    this.uploadFile(getBlobFromDiskData(dprops.diskData, this.fileName))
-      .then(() => {
-        dprops.diskHasChanges = false
-        doSetEmuDriveProps(dprops)
-        doSetUIDriveProps(dprops)
-      })
+  async sync(blob: Blob) {
+    this.uploadFile(blob)
   }
 
   async uploadFile(blob: Blob): Promise<void> {
-    this.setSyncStatus(CloudDriveSyncStatus.InProgress)
+    this.syncStatus = CloudDriveSyncStatus.InProgress
   
     if (this.uploadUrl == "") {
       this.uploadUrl = `${this.apiEndpoint}drive/items/${this.folderId}:/${this.fileName}:/content`
@@ -149,16 +104,16 @@ export class OneDriveCloudDrive implements CloudDrive {
         .then(async response => {
           console.log(`fetch response: ${response.status} (${response.statusText})`)
           if (response.ok) {
-            this.setSyncStatus(CloudDriveSyncStatus.Pending)
+            this.syncStatus = CloudDriveSyncStatus.Pending
             this.uploadUrl = ""
           } else {
-            this.setSyncStatus(CloudDriveSyncStatus.Failed)
+            this.syncStatus = CloudDriveSyncStatus.Failed
             console.log(response.status)
           }
         })
         .catch(error => {
           console.error(error)
-          this.setSyncStatus(CloudDriveSyncStatus.Failed)
+          this.syncStatus = CloudDriveSyncStatus.Failed
         })
         .finally(() => {
           this.lastSyncTime += 3 * 1000
@@ -185,43 +140,19 @@ export class OneDriveCloudDrive implements CloudDrive {
           const json = await response.json();
           this.downloadUrl = json["@content.downloadUrl"]
           this.uploadUrl = `${this.apiEndpoint}drive/items/${json["id"]}/content`
-          this.setSyncStatus(CloudDriveSyncStatus.Active)
+          this.syncStatus = CloudDriveSyncStatus.Active
         } else {
-          this.setSyncStatus(CloudDriveSyncStatus.Failed)
+          this.syncStatus = CloudDriveSyncStatus.Failed
           console.log(response.status)
         }
       })
       .catch(error => {
         console.error(error)
-        this.setSyncStatus(CloudDriveSyncStatus.Failed)
+        this.syncStatus = CloudDriveSyncStatus.Failed
       })
       .finally(() => {
         this.lastSyncTime = Date.now()
       })
-  }
-
-  async saveFile(filename: string): Promise<boolean> {
-    const result = await launchPicker("folders")
-
-    if (result) {
-      this.accessToken = result.accessToken
-      this.apiEndpoint = result.apiEndpoint
-
-      for (const file of result.value) {
-          this.setSyncStatus(CloudDriveSyncStatus.Active)
-          this.folderId = file.id
-          this.fileName = filename
-          this.downloadUrl = ""
-          this.uploadUrl = ""
-          this.lastSyncTime = Date.now()
-          this.syncInterval = DEFAULT_SYNC_INTERVAL
-      }
-      return true
-    }
-    
-    // handle failure
-
-    return false
   }
 }
 


### PR DESCRIPTION
**How to add new cloud drive providers:**
1. Create new class which implements `CloudDrive` interface
2. Add new menu lable to `menuNames[2]` for your provider (e.g., "Load Disk From FooDrive") in `diskdrive.tsx`
3. Add new menu ID to `menuNames[2]` for your provider  in `diskdrive.tsx`
4. Add new load handler to `handleMenuClose()` (e.g., `loadDiskFromCloud(new FooDrive())`) in `diskdrive.tsx`
5. Add new save handler to `handleMenuClose()` (e.g., `saveDiskToCloud(new FooDrive())`) in `diskdrive.tsx`

**Changes Made:**
- Simplified `CloudDrive` interface to four properties and five methods
- Moved all UI-related code out of `OneDriveCloudDrive` and into `DiskDrive`
- Removed hard-coded references to OneDrive from `diskinterface.css`

**Tests Performed:**
- Verfied OneDrive load, save, and auto-sync scenarios all work
- Verified on Windows and MacOS

**Issues Resolved:**
- n/a