### PR TITLE
Boredsenseless/sync perf improvements

### DIFF
--- a/src/devices/diskdrive.tsx
+++ b/src/devices/diskdrive.tsx
@@ -1,12 +1,12 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { crc32, FLOPPY_DISK_SUFFIXES, HARD_DRIVE_SUFFIXES, uint32toBytes } from "../emulator/utility/utility"
 import { imageList } from "./assets"
 import { handleSetDiskData, handleGetDriveProps, handleSetDiskWriteProtected, doSetUIDriveProps, handleSetDiskOrFileFromBuffer } from "./driveprops"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { doSetEmuDriveNewData, doSetEmuDriveProps, getDriveFileNameByIndex } from "../emulator/devices/drivestate"
 import { CloudDrive, CloudDriveSyncStatus } from "../emulator/utility/clouddrive"
 import { faRotate } from "@fortawesome/free-solid-svg-icons"
 import { OneDriveCloudDrive } from "../emulator/utility/onedriveclouddrive"
+import { doSetEmuDriveNewData, doSetEmuDriveProps, getDriveFileNameByIndex } from "../emulator/devices/drivestate"
 
 export const getBlobFromDiskData = (diskData: Uint8Array, filename: string) => {
   // Only WOZ requires a checksum. Other formats should be ready to download.
@@ -72,46 +72,7 @@ const DiskDrive = (props: DiskDriveProps) => {
     setCloudDrive(undefined)
   }
 
-  const getCloudDriveStatusMessage = () => {
-    if (!cloudDrive) return ""
-    
-    switch (getCloudDriveSyncStatus()) {
-      case CloudDriveSyncStatus.Inactive:
-        return dprops.diskData.length > 0 ? `Save Disk to ${cloudDrive.providerName}` : `Load Disk from ${cloudDrive.providerName}`
-  
-      case CloudDriveSyncStatus.Active:
-        return `${cloudDrive.providerName} Sync Up-to-date`
-        
-      case CloudDriveSyncStatus.Pending:
-        return isCloudDriveSyncPaused() ? `${cloudDrive.providerName} Sync Paused` : `${cloudDrive.providerName} Sync Pending`
-        
-      case CloudDriveSyncStatus.InProgress:
-        return `${cloudDrive.providerName} Sync In Progress`
-        
-      case CloudDriveSyncStatus.Failed:
-        return `${cloudDrive.providerName} Sync Failed`
-    }
-  }
-
-  const getCloudDriveStatusClassName = () => {
-    if (!cloudDrive) return "disk-clouddrive-inactive"
-
-    const syncStatus = getCloudDriveSyncStatus()
-
-    if (isCloudDriveSyncPaused() && syncStatus != CloudDriveSyncStatus.Inactive && syncStatus != CloudDriveSyncStatus.InProgress) {
-      return "disk-clouddrive-paused"
-    } else {
-      return `disk-clouddrive-${CloudDriveSyncStatus[syncStatus].toLowerCase()}`
-    }
-  }
-
-  const getDiskDriveLabel = () => {
-    return (cloudDrive && cloudDrive.lastSyncTime > 0)
-      ? `Last synced: ${new Date(cloudDrive.lastSyncTime).toLocaleString()}`
-      : (filename + (dprops.diskHasChanges ? ' (modified)' : ''))
-  }
-
-  const getCloudDriveSyncStatus = (): CloudDriveSyncStatus => {
+  const cloudSyncStatus = useMemo(() => {
     if (!cloudDrive) return CloudDriveSyncStatus.Inactive
 
     switch (cloudDrive?.syncStatus) {
@@ -129,11 +90,38 @@ const DiskDrive = (props: DiskDriveProps) => {
     }
 
     return cloudDrive.syncStatus
-  }
+  }, [cloudDrive?.syncStatus, dprops.lastWriteTime, cloudDrive?.lastSyncTime, cloudDrive?.syncInterval])
 
-  const isCloudDriveSyncPaused = () => {
-    return cloudDrive?.syncInterval == Number.MAX_VALUE
-  }
+  const cloudDriveStatusClassName = useMemo(() => {
+    if (!cloudDrive) return "disk-clouddrive-inactive"
+
+    const syncStatus = cloudDrive?.syncStatus
+
+    if (cloudDrive?.syncInterval == Number.MAX_VALUE
+      && syncStatus != CloudDriveSyncStatus.Inactive
+      && syncStatus != CloudDriveSyncStatus.InProgress) {
+      return "disk-clouddrive-paused"
+    } else {
+      return `disk-clouddrive-${CloudDriveSyncStatus[syncStatus].toLowerCase()}`
+    }
+  }, [cloudSyncStatus, cloudDrive?.syncInterval])
+
+  const diskDriveLabel = useMemo(() => {
+    var label = (dprops.filename + (dprops.diskHasChanges ? ' (modified)' : ''))
+
+    if (cloudDrive && cloudDrive.lastSyncTime > 0) {
+      label += `\nSynced ${new Date(cloudDrive.lastSyncTime).toLocaleString()}`
+    }
+
+    return label
+  }, [cloudDrive?.lastSyncTime, dprops.diskHasChanges])
+
+  const driveFileName = useMemo(() => {
+    if (cloudDrive && dprops.filename != cloudDrive.getFileName()) {
+      cloudDrive?.setFileName(`apple2ts.${dprops.filename}`)
+    }
+    return dprops.filename
+  }, [dprops.filename]) 
 
   const loadDiskFromCloud = async (newCloudDrive: CloudDrive) => {
     const filter = dprops.index >= 2 ? FLOPPY_DISK_SUFFIXES : HARD_DRIVE_SUFFIXES
@@ -143,31 +131,21 @@ const DiskDrive = (props: DiskDriveProps) => {
       const buffer = await new Response(blob).arrayBuffer()
 
       handleSetDiskOrFileFromBuffer(dprops.index, buffer, newCloudDrive.getFileName())
-      doSetEmuDriveNewData(dprops, true)
-
-      const newFileName = getDriveFileNameByIndex(dprops.index)
-      if (newFileName != newCloudDrive.getFileName()) {
-        newCloudDrive.setFileName(`apple2ts.${newFileName}`)
-      }
-5
       setCloudDrive(newCloudDrive)
     }
   }
 
   const saveDiskToCloud = async (newCloudDrive: CloudDrive) => {
-    const blob = getBlobFromDiskData(dprops.diskData, dprops.filename)
+    const blob = getBlobFromDiskData(dprops.diskData, driveFileName)
     if (await newCloudDrive?.upload(dprops.filename, blob)) {
-        dprops.diskHasChanges = false
-        doSetEmuDriveProps(dprops)
-        doSetUIDriveProps(dprops)
-
         setCloudDrive(newCloudDrive)
+        updateCloudDrive(newCloudDrive)
     }
   }
 
-  const updateCloudDrive = async () => {
-    const blob = getBlobFromDiskData(dprops.diskData, dprops.filename)
-    if (await cloudDrive?.sync(blob)) {
+  const updateCloudDrive = async (newCloudDrive: CloudDrive|undefined = cloudDrive) => {
+    const blob = getBlobFromDiskData(dprops.diskData, driveFileName)
+    if (await newCloudDrive?.sync(blob)) {
       dprops.diskHasChanges = false
       doSetEmuDriveProps(dprops)
       doSetUIDriveProps(dprops)
@@ -194,7 +172,7 @@ const DiskDrive = (props: DiskDriveProps) => {
     const y = Math.min(event.clientY, window.innerHeight - 200)
     setPosition({ x: event.clientX, y: y })
 
-    if (!cloudDrive || getCloudDriveSyncStatus() == CloudDriveSyncStatus.Inactive) {
+    if (!cloudDrive || cloudSyncStatus == CloudDriveSyncStatus.Inactive) {
       if (dprops.filename.length > 0) {
         setMenuOpen(0)
       } else {
@@ -266,12 +244,11 @@ const DiskDrive = (props: DiskDriveProps) => {
           <img className="disk-image"
             src={img1} alt={filename}
             id={dprops.index === 2 ? "tour-floppy-disks" : ""}
-            title={getDiskDriveLabel()}
+            title={diskDriveLabel}
             onClick={handleMenuClick} />
             <FontAwesomeIcon
               icon={faRotate}
-              className={"fa-fw disk-clouddrive " + getCloudDriveStatusClassName()}
-              title={getCloudDriveStatusMessage()}>
+              className={`fa-fw disk-clouddrive ${cloudDriveStatusClassName}`}>
             </FontAwesomeIcon>
         </span>
       </span>

--- a/src/devices/diskdrive.tsx
+++ b/src/devices/diskdrive.tsx
@@ -114,6 +114,10 @@ const DiskDrive = (props: DiskDriveProps) => {
   }, [cloudDrive?.lastSyncTime, dprops.diskHasChanges])
 
   const driveFileName = useMemo(() => {
+    if (dprops.filename == '') {
+      setCloudDrive(undefined)
+    }
+    
     if (cloudDrive && dprops.filename != cloudDrive.getFileName()) {
       cloudDrive?.setFileName(`apple2ts.${dprops.filename}`)
     }

--- a/src/devices/diskinterface.css
+++ b/src/devices/diskinterface.css
@@ -43,7 +43,7 @@ body.dark-mode .disk-cloud {
   position: absolute;
   text-align: center;
   margin-left: 24px;
-  margin-top: 12px;
+  margin-top: 13px;
   font-size: 36px;
   pointer-events: none;
 }

--- a/src/emulator/utility/onedriveclouddrive.ts
+++ b/src/emulator/utility/onedriveclouddrive.ts
@@ -71,7 +71,6 @@ export class OneDriveCloudDrive implements CloudDrive {
           this.lastSyncTime = Date.now()
           this.syncInterval = DEFAULT_SYNC_INTERVAL
 
-          // return await this.sync(blob)
           return true
       }
     }

--- a/src/emulator/utility/onedriveclouddrive.ts
+++ b/src/emulator/utility/onedriveclouddrive.ts
@@ -71,7 +71,8 @@ export class OneDriveCloudDrive implements CloudDrive {
           this.lastSyncTime = Date.now()
           this.syncInterval = DEFAULT_SYNC_INTERVAL
 
-          return await this.sync(blob)
+          // return await this.sync(blob)
+          return true
       }
     }
 


### PR DESCRIPTION
**Changes Made:**
- Replaced sync status-related functions in `diskdrive.tsx` with `UseEffect` hooks to eliminate constant property updates which were causing performance issues
- Added `setInterval` timer to initiate cloud drive syncs rather than rely on expensive property updates
- Fixed bug where loading built-in disk images would not reset cloud drive status
- Moved call to `sync()` in `OneDriveCloudDrive.Upload()` to `DiskDrive` to ensure progress UI is displayed correctly

**Tests Performed:**
- Verified property changes only happen as expected
- Verified perf improvements while playing Aztec
- Verfied OneDrive load, save, and auto-sync scenarios all work
- Verified on Windows and MacOS

Issues Resolved:
- n/a