### PR TITLE
Fixed first-time upload bug for OneDrive

### DIFF
--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -99,7 +99,7 @@ const DiskDrive = (props: DiskDriveProps) => {
     } else {
       return `disk-clouddrive-${CLOUD_SYNC[syncStatus].toLowerCase()}`
     }
-  }, [dprops.cloudData])
+  }, [dprops.cloudData, dprops.cloudData?.syncStatus, dprops.cloudData?.syncInterval])
 
   const diskDriveLabel = useMemo(() => {
     let label = (dprops.filename + (dprops.diskHasChanges ? ' (modified)' : ''))

--- a/src/ui/devices/onedriveclouddrive.ts
+++ b/src/ui/devices/onedriveclouddrive.ts
@@ -9,7 +9,7 @@ const applicationId = "74fef3d4-4cf3-4de9-b2d7-ef63f9add409"
 export class OneDriveCloudDrive implements CloudProvider {
 
   async download(filter: string): Promise<[Blob, CloudData]|null> {
-    const result = await launchPicker("files", filter)
+    const result = await launchPicker('share', 'files', filter)
     const file = result?.value[0]
     if (file) {
       const cloudData: CloudData = {
@@ -40,21 +40,20 @@ export class OneDriveCloudDrive implements CloudProvider {
   }
 
   async upload(filename: string, blob: Blob): Promise<CloudData | null> {
-    const result = await launchPicker("folders")
+    const result = await launchPicker('save', 'folders')
     const file = result?.value && result.value[0]
     if (file) {
       const cloudData: CloudData = {
         providerName: "OneDrive",
-        syncStatus: CLOUD_SYNC.ACTIVE,
+        syncStatus: CLOUD_SYNC.PENDING,
         syncInterval: DEFAULT_SYNC_INTERVAL,
-        lastSyncTime: Date.now(),
+        lastSyncTime: -1,
         fileName: filename,
         accessToken: result.accessToken,
         itemId: file.id,
         apiEndpoint: result.apiEndpoint,
         parentID: "",
       }
-      this.sync(blob, cloudData)
       return cloudData
     } else {
       console.error(`result message: ${result?.message} errorCode: ${result?.errorCode}`)
@@ -154,11 +153,11 @@ export class OneDriveCloudDrive implements CloudProvider {
   }
 }
 
-const launchPicker = async (view: string, filter?: string) => {
+const launchPicker = async (action: string, view: string, filter?: string) => {
   return new Promise<OneDriveResult | null>((resolve, reject) => {
     const odOptions: OneDriveOpenOptions = {
         clientId: applicationId,
-        action: "share",
+        action: action,
         multiSelect: false,
         openInNewWindow: true,
         viewType: view,
@@ -217,11 +216,11 @@ interface Thumbnail {
 
 interface OneDriveOpenOptions {
   clientId: string
-  action: "download" | "share" | "query"
+  action: string // 'download' | 'share' | 'query' | 'save'
   multiSelect: boolean
   fileName?: string
   openInNewWindow: boolean
-  viewType: string
+  viewType: string // 'files' | 'folders'
   advanced: {
       filter?: string
       endpointHint?: string

--- a/src/ui/inputparams.ts
+++ b/src/ui/inputparams.ts
@@ -39,7 +39,7 @@ export const handleInputParams = () => {
 
   const colorMode = params.get('color')
   if (colorMode) {
-    const colors = ['color', 'nofringe', 'green', 'amber', 'white']
+    const colors = ['color', 'nofringe', 'green', 'amber', 'white', 'inverse']
     const mode = colors.indexOf(colorMode)
     if (mode >= 0) passColorMode(mode as COLOR_MODE)
   }

--- a/src/ui/panels/defaulthelptext.ts
+++ b/src/ui/panels/defaulthelptext.ts
@@ -51,7 +51,7 @@ defaultHelpText += `
 address=1234 (hex load address for binary files)
 basic=<a href="https://www.urlencoder.org" target="_blank" rel="noopener noreferrer">urlencoded BASIC program</a>
 capslock=off
-color=color|nofringe|green|amber|white
+color=color|nofringe|green|amber|white|inverse
 debug=on
 ramdisk=64|512|1024|4096|8192
 run=false (do not run BASIC program)


### PR DESCRIPTION
**Changes Made:**
- Fixed bug where first-time upload of OneDrive was stuck "in progress" due to OneDrive upload returning immediately after session was created
- Fixed bug where uploads to OneDrive root folder failed due to incorrect picker action ('share'  should be 'save' for upload scenarios)
- Added missing `color=inverse` query param support

**Tests Performed:**
- Verfied OneDrive load, save, and auto-sync scenarios all work
- Verified all sync status states update as expected
- Verified on Windows and MacOS

**Issues Resolved:**
- n/a