### PR TITLE
Added support for UI themes and created new "Minimal" theme

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "Apple2TS",
   "description": "Apple II Emulator in TypeScript. Emulates an enhanced Apple IIe with 128k of memory, a hard drive, two floppy disk drives, and gamepad support. Written in TypeScript, using the React JS library, and hosted on Github Pages. Chris Torrence, CT6502",
   "id": "/",
-  "start_url": ".",
+  "start_url": "",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#BFBB98",

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -90,7 +90,7 @@ type MachineState = {
   showScanlines: boolean,
   cout: number,
   cpuSpeed: number,
-  darkMode: boolean,
+  theme: UI_THEME,
   disassembly: string,
   extraRamSize: number,
   helpText: string,

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -92,6 +92,19 @@ export enum ARROW {
   DOWN
 }
 
+export enum UI_THEME {
+  CLASSIC,
+  DARK,
+  MINIMAL
+}
+
+export const themeToName = (theme: UI_THEME) => {
+  return [
+    'Classic',
+    'Dark',
+    'Minimal'][theme]
+}
+
 export type MouseEventSimple = {
   x : number; // 0.0 -> 1.0
   y : number; // 0.0 -> 1.0
@@ -424,6 +437,15 @@ export const isHardDriveImage = (filename: string) => {
   return f.endsWith(".hdv") || f.endsWith(".po") || f.endsWith(".2mg")
 }
 
-export const isProgressiveFullscreen = () => {
-  return document.documentElement.classList.contains('pwafs');
+export const handleSetTheme = (theme: UI_THEME) => {
+  if (theme == UI_THEME.DARK) {
+    document.body.classList.add("dark-mode")
+  } else {
+    document.body.classList.remove("dark-mode")
+  }
+  if (theme == UI_THEME.MINIMAL) {
+    document.documentElement.classList.add('theme-minimal')
+  } else {
+    document.documentElement.classList.remove('theme-minimal')
+  }
 }

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -100,9 +100,9 @@ export enum UI_THEME {
 
 export const themeToName = (theme: UI_THEME) => {
   return [
-    'Classic',
-    'Dark',
-    'Minimal'][theme]
+    "Classic",
+    "Dark",
+    "Minimal"][theme]
 }
 
 export type MouseEventSimple = {
@@ -444,8 +444,8 @@ export const handleSetTheme = (theme: UI_THEME) => {
     document.body.classList.remove("dark-mode")
   }
   if (theme == UI_THEME.MINIMAL) {
-    document.documentElement.classList.add('theme-minimal')
+    document.documentElement.classList.add("theme-minimal")
   } else {
-    document.documentElement.classList.remove('theme-minimal')
+    document.documentElement.classList.remove("theme-minimal")
   }
 }

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -423,3 +423,7 @@ export const isHardDriveImage = (filename: string) => {
   const f = filename.toLowerCase()
   return f.endsWith(".hdv") || f.endsWith(".po") || f.endsWith(".2mg")
 }
+
+export const isProgressiveFullscreen = () => {
+  return document.documentElement.classList.contains('pwafs');
+}

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -383,7 +383,7 @@ body.dark-mode .divider {
   user-select: none;
 }
 
-@scope (.pwafs) {
+@scope (.theme-minimal) {
   :root {
     touch-action: pan-x pan-y;
     height: 100%
@@ -412,10 +412,10 @@ body.dark-mode .divider {
   .footer-item {
     position: fixed;
     width: 100%;
-    bottom: 1.33%;
+    bottom: 1.5%;
     color: white;
     text-align: center;
-    font-size: max(0.66cqw, 6pt);
+    font-size: max(0.66cqw, 5pt);
   }
 
   #reportIssue {

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -386,7 +386,7 @@ body.dark-mode .divider {
 @scope (.theme-minimal) {
   :root {
     touch-action: pan-x pan-y;
-    height: 100%
+    height: 100%;
   }
 
   html {

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -382,3 +382,42 @@ body.dark-mode .divider {
   cursor: default;
   user-select: none;
 }
+
+/* @media (display-mode: standalone) and (hover: none) and (min-width: 1024px) and (max-height: 1366px) { */
+@media all {
+  :root {
+    touch-action: pan-x pan-y;
+    height: 100%
+  }
+
+  html {
+    position: fixed;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  body {
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+    overflow-x: hidden;
+    overflow-y: hidden;
+    background-color: black;
+    margin: 0px;
+  }
+
+  .main-canvas {
+    margin: 0px;
+  }
+
+  .footer-item {
+    position: absolute;
+    bottom: 24px;
+    left: 24px;
+    color: white;
+  }
+
+  .default-font {
+    color: white;
+  }
+}

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -383,7 +383,6 @@ body.dark-mode .divider {
   user-select: none;
 }
 
-/* @media (display-mode: standalone) and (hover: none) and (min-width: 1024px) and (max-height: 1366px) { */
 @scope (.pwafs) {
   :root {
     touch-action: pan-x pan-y;
@@ -394,6 +393,10 @@ body.dark-mode .divider {
     position: fixed;
     height: 100%;
     overflow: hidden;
+  }
+
+  a {
+    display: none;
   }
 
   body {
@@ -412,12 +415,12 @@ body.dark-mode .divider {
 
   .footer-item {
     position: absolute;
-    bottom: 24px;
-    left: 24px;
+    bottom: -32px;
+    right: 25%;
     color: white;
   }
 
-  .default-font {
-    color: white;
+  #control-panel {
+    margin-bottom: 4px;
   }
 }

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -412,10 +412,12 @@ body.dark-mode .divider {
   .footer-item {
     position: fixed;
     width: 100%;
-    bottom: 1.5%;
+    bottom: 1.25em;
     color: white;
     text-align: center;
     font-size: max(0.66cqw, 5pt);
+    -webkit-text-fill-color: black;
+    -webkit-text-stroke: 1px;
   }
 
   #reportIssue {

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -410,10 +410,12 @@ body.dark-mode .divider {
   }
 
   .footer-item {
-    position: absolute;
-    bottom: -24px;
-    right: 25%;
+    position: fixed;
+    width: 100%;
+    bottom: 1.33%;
     color: white;
+    text-align: center;
+    font-size: max(0.66cqw, 6pt);
   }
 
   #reportIssue {

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -416,7 +416,7 @@ body.dark-mode .divider {
     color: white;
     text-align: center;
     font-size: max(0.66cqw, 5pt);
-    -webkit-text-fill-color: black;
+    -webkit-text-fill-color: white;
     -webkit-text-stroke: 1px;
   }
 

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -384,7 +384,7 @@ body.dark-mode .divider {
 }
 
 /* @media (display-mode: standalone) and (hover: none) and (min-width: 1024px) and (max-height: 1366px) { */
-@media all {
+@scope (.pwafs) {
   :root {
     touch-action: pan-x pan-y;
     height: 100%

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -395,10 +395,6 @@ body.dark-mode .divider {
     overflow: hidden;
   }
 
-  a {
-    display: none;
-  }
-
   body {
     height: 100%;
     overflow: hidden;
@@ -415,12 +411,12 @@ body.dark-mode .divider {
 
   .footer-item {
     position: absolute;
-    bottom: -32px;
+    bottom: -24px;
     right: 25%;
     color: white;
   }
 
-  #control-panel {
-    margin-bottom: 4px;
+  #reportIssue {
+    display: none;
   }
 }

--- a/src/ui/canvas.css
+++ b/src/ui/canvas.css
@@ -69,7 +69,7 @@ body.dark-mode .hgr-view-text {
   z-index: 1;
 }
 
-@scope (.pwafs) {
+@scope (.theme-minimal) {
   .hidden-textarea {
     pointer-events: none;
   }

--- a/src/ui/canvas.css
+++ b/src/ui/canvas.css
@@ -68,9 +68,3 @@ body.dark-mode .hgr-view-text {
   background-size: 100% 4px;
   z-index: 1;
 }
-
-@scope (.theme-minimal) {
-  .hidden-textarea {
-    pointer-events: none;
-  }
-}

--- a/src/ui/canvas.css
+++ b/src/ui/canvas.css
@@ -62,11 +62,21 @@ body.dark-mode .hgr-view-text {
   top: var(--scanlines-top);
   width: var(--scanlines-width);
   height: var(--scanlines-height);
-  background: linear-gradient(
-      to bottom,
+  background: linear-gradient(to bottom,
       transparent 50%,
-      rgba(0, 0, 0, 0.3) 51%
-  );
+      rgba(0, 0, 0, 0.3) 51%);
   background-size: 100% 4px;
   z-index: 1;
+}
+
+@scope (.pwafs) {
+  .canvas-text {
+    margin-top: 23px;
+    margin-left: -1px;
+    /* border: 1px solid red; */
+  }
+
+  .hidden-textarea {
+    pointer-events: none;
+  }
 }

--- a/src/ui/canvas.css
+++ b/src/ui/canvas.css
@@ -70,12 +70,6 @@ body.dark-mode .hgr-view-text {
 }
 
 @scope (.pwafs) {
-  .canvas-text {
-    margin-top: 23px;
-    margin-left: -1px;
-    /* border: 1px solid red; */
-  }
-
   .hidden-textarea {
     pointer-events: none;
   }

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -421,7 +421,7 @@ const Apple2Canvas = (props: DisplayProps) => {
 
             if (handleGetTheme() == UI_THEME.MINIMAL) {
               scanlinesLeft = (window.innerWidth - scanlinesWidth) / 2
-              scanlinesTop = (window.innerHeight - scanlinesHeight) / 2
+              scanlinesTop = ((window.innerHeight - scanlinesHeight) / 2) - 10
               canvas.style.marginLeft = `${scanlinesLeft - width * xmargin}px`
               canvas.style.marginTop = `${scanlinesTop - height * ymargin}px`
             }

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -13,8 +13,9 @@ import {
   handleGetCout,
   handleUseOpenAppleKey,
   handleGetShowScanlines,
+  handleGetTheme,
 } from "./main2worker"
-import { ARROW, RUN_MODE, convertAppleKey, MouseEventSimple, COLOR_MODE, toHex, isProgressiveFullscreen } from "../common/utility"
+import { ARROW, RUN_MODE, convertAppleKey, MouseEventSimple, COLOR_MODE, toHex, UI_THEME } from "../common/utility"
 import { ProcessDisplay, getCanvasSize, getOverrideHiresPixels, handleGetOverrideHires, canvasCoordToNormScreenCoord, screenBytesToCanvasPixels, screenCoordToCanvasCoord, nRowsHgrMagnifier, nColsHgrMagnifier, xmargin, ymargin } from "./graphics"
 import { checkGamepad, handleArrowKey } from "./devices/gamepad"
 import { handleCopyToClipboard } from "./copycanvas"
@@ -418,7 +419,7 @@ const Apple2Canvas = (props: DisplayProps) => {
             let scanlinesLeft = canvas.offsetLeft + width * xmargin
             let scanlinesTop = canvas.offsetTop + height * ymargin
 
-            if (isProgressiveFullscreen()) {
+            if (handleGetTheme() == UI_THEME.MINIMAL) {
               scanlinesLeft = (window.innerWidth - scanlinesWidth) / 2
               scanlinesTop = (window.innerHeight - scanlinesHeight) / 2
               canvas.style.marginLeft = `${scanlinesLeft - width * xmargin}px`
@@ -455,7 +456,7 @@ const Apple2Canvas = (props: DisplayProps) => {
 
   const isTouchDevice = "ontouchstart" in document.documentElement
   const isCanvasFullScreen = document.fullscreenElement === myCanvas?.current?.parentElement
-  const noBackgroundImage = isTouchDevice || isCanvasFullScreen || isProgressiveFullscreen();
+  const noBackgroundImage = isTouchDevice || isCanvasFullScreen || handleGetTheme() == UI_THEME.MINIMAL;
 
   // if (!isCanvasFullScreen && myCanvas && myCanvas.current) {
   //   myCanvas.current.requestFullscreen()
@@ -466,10 +467,10 @@ const Apple2Canvas = (props: DisplayProps) => {
   // Make keyboard events work on touch devices by using a hidden textarea.
   const isAndroidDevice = /Android/i.test(navigator.userAgent)
   const txt = isAndroidDevice ?
-    <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={isProgressiveFullscreen()}
+    <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={handleGetTheme() == UI_THEME.MINIMAL}
       onInput={handleOnInput} /> :
     (isTouchDevice ?
-      <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={isProgressiveFullscreen()}
+      <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={handleGetTheme() == UI_THEME.MINIMAL}
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
       /> : <span></span>)

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -413,18 +413,22 @@ const Apple2Canvas = (props: DisplayProps) => {
             const canvas = entry.target as HTMLCanvasElement
             const width = canvas.offsetWidth
             const height = canvas.offsetHeight
-            const scanlinesLeft = canvas.offsetLeft + width * xmargin
-            const scanlinesTop = canvas.offsetTop + height * ymargin
             const scanlinesWidth = width - 2 * width * xmargin
             const scanlinesHeight = height - 2 * height * ymargin
+            let scanlinesLeft = canvas.offsetLeft + width * xmargin
+            let scanlinesTop = canvas.offsetTop + height * ymargin
+
+            if (isProgressiveFullscreen()) {
+              scanlinesLeft = (window.innerWidth - scanlinesWidth) / 2
+              scanlinesTop = (window.innerHeight - scanlinesHeight) / 2
+              canvas.style.marginLeft = `${scanlinesLeft - width * xmargin}px`
+              canvas.style.marginTop = `${scanlinesTop - height * ymargin}px`
+            }
 
             document.body.style.setProperty('--scanlines-left', `${scanlinesLeft}px`)
-            document.body.style.setProperty('--scanlines-top', `${scanlinesTop}}px`)
+            document.body.style.setProperty('--scanlines-top', `${scanlinesTop}px`)
             document.body.style.setProperty('--scanlines-width', `${scanlinesWidth}px`)
             document.body.style.setProperty('--scanlines-height', `${scanlinesHeight}px`)
-
-            // canvas.style.marginLeft = `${(window.innerWidth - scanlinesWidth) / 2}}px`
-            // canvas.style.marginTop = `${(window.innerHeight - scanlinesHeight) / 2}px`
           }
         }).observe(canvas)
         document.body.style.setProperty("--scanlines-display", handleGetShowScanlines() ? "block" : "none")

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -467,10 +467,10 @@ const Apple2Canvas = (props: DisplayProps) => {
   // Make keyboard events work on touch devices by using a hidden textarea.
   const isAndroidDevice = /Android/i.test(navigator.userAgent)
   const txt = isAndroidDevice ?
-    <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={handleGetTheme() == UI_THEME.MINIMAL}
+    <textarea className="hidden-textarea" hidden={false} ref={myText}
       onInput={handleOnInput} /> :
     (isTouchDevice ?
-      <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={handleGetTheme() == UI_THEME.MINIMAL}
+      <textarea className="hidden-textarea" hidden={false} ref={myText}
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
       /> : <span></span>)

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -14,7 +14,7 @@ import {
   handleUseOpenAppleKey,
   handleGetShowScanlines,
 } from "./main2worker"
-import { ARROW, RUN_MODE, convertAppleKey, MouseEventSimple, COLOR_MODE, toHex } from "../common/utility"
+import { ARROW, RUN_MODE, convertAppleKey, MouseEventSimple, COLOR_MODE, toHex, isProgressiveFullscreen } from "../common/utility"
 import { ProcessDisplay, getCanvasSize, getOverrideHiresPixels, handleGetOverrideHires, canvasCoordToNormScreenCoord, screenBytesToCanvasPixels, screenCoordToCanvasCoord, nRowsHgrMagnifier, nColsHgrMagnifier, xmargin, ymargin } from "./graphics"
 import { checkGamepad, handleArrowKey } from "./devices/gamepad"
 import { handleCopyToClipboard } from "./copycanvas"
@@ -443,7 +443,7 @@ const Apple2Canvas = (props: DisplayProps) => {
 
   const isTouchDevice = "ontouchstart" in document.documentElement
   const isCanvasFullScreen = document.fullscreenElement === myCanvas?.current?.parentElement
-  const noBackgroundImage = isTouchDevice || isCanvasFullScreen;
+  const noBackgroundImage = isTouchDevice || isCanvasFullScreen || isProgressiveFullscreen();
 
   // if (!isCanvasFullScreen && myCanvas && myCanvas.current) {
   //   myCanvas.current.requestFullscreen()

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -408,10 +408,8 @@ const Apple2Canvas = (props: DisplayProps) => {
       scanlinesTop = ((window.innerHeight - scanlinesHeight) / 2) - 10
 
       if (handleGetIsDebugging()) {
-        const debugSection = document.getElementsByClassName('flyout-bottom-right')[0] as HTMLElement
+        const debugSection = document.getElementsByClassName("flyout-bottom-right")[0] as HTMLElement
         if (debugSection) {
-          console.log(`debugSection.offsetLeft=${debugSection.offsetLeft}`)
-          console.log(`scanlinesWidth=${scanlinesWidth}`)
           scanlinesLeft = Math.max(Math.min(scanlinesLeft, debugSection.offsetLeft - scanlinesWidth - 18), 0)
         }
       }
@@ -420,10 +418,10 @@ const Apple2Canvas = (props: DisplayProps) => {
       canvas.style.marginTop = `${scanlinesTop - height * ymargin}px`
     }
 
-    document.body.style.setProperty('--scanlines-left', `${scanlinesLeft}px`)
-    document.body.style.setProperty('--scanlines-top', `${scanlinesTop}px`)
-    document.body.style.setProperty('--scanlines-width', `${scanlinesWidth}px`)
-    document.body.style.setProperty('--scanlines-height', `${scanlinesHeight}px`)
+    document.body.style.setProperty("--scanlines-left", `${scanlinesLeft}px`)
+    document.body.style.setProperty("--scanlines-top", `${scanlinesTop}px`)
+    document.body.style.setProperty("--scanlines-width", `${scanlinesWidth}px`)
+    document.body.style.setProperty("--scanlines-height", `${scanlinesHeight}px`)
 
     return canvas.style.marginLeft
   }

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -416,7 +416,7 @@ const Apple2Canvas = (props: DisplayProps) => {
             document.body.style.setProperty("--scanlines-left", (canvas.offsetLeft + width * xmargin) + "px")
             document.body.style.setProperty("--scanlines-top", (canvas.offsetTop + height * ymargin) + "px")
             document.body.style.setProperty("--scanlines-width", (width - 2 * width * xmargin) + "px")
-            document.body.style.setProperty("--scanlines-height", (height - 2 * height * ymargin)+ "px")
+            document.body.style.setProperty("--scanlines-height", (height - 2 * height * ymargin) + "px")
           }
         }).observe(canvas)
         document.body.style.setProperty("--scanlines-display", handleGetShowScanlines() ? "block" : "none")
@@ -454,10 +454,10 @@ const Apple2Canvas = (props: DisplayProps) => {
   // Make keyboard events work on touch devices by using a hidden textarea.
   const isAndroidDevice = /Android/i.test(navigator.userAgent)
   const txt = isAndroidDevice ?
-    <textarea className="hidden-textarea" hidden={false} ref={myText}
+    <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={true}
       onInput={handleOnInput} /> :
     (isTouchDevice ?
-      <textarea className="hidden-textarea" hidden={false} ref={myText}
+      <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={true}
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
       /> : <span></span>)

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -454,10 +454,10 @@ const Apple2Canvas = (props: DisplayProps) => {
   // Make keyboard events work on touch devices by using a hidden textarea.
   const isAndroidDevice = /Android/i.test(navigator.userAgent)
   const txt = isAndroidDevice ?
-    <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={true}
+    <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={isProgressiveFullscreen()}
       onInput={handleOnInput} /> :
     (isTouchDevice ?
-      <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={true}
+      <textarea className="hidden-textarea" hidden={false} ref={myText} readOnly={isProgressiveFullscreen()}
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
       /> : <span></span>)

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -413,10 +413,18 @@ const Apple2Canvas = (props: DisplayProps) => {
             const canvas = entry.target as HTMLCanvasElement
             const width = canvas.offsetWidth
             const height = canvas.offsetHeight
-            document.body.style.setProperty("--scanlines-left", (canvas.offsetLeft + width * xmargin) + "px")
-            document.body.style.setProperty("--scanlines-top", (canvas.offsetTop + height * ymargin) + "px")
-            document.body.style.setProperty("--scanlines-width", (width - 2 * width * xmargin) + "px")
-            document.body.style.setProperty("--scanlines-height", (height - 2 * height * ymargin) + "px")
+            const scanlinesLeft = canvas.offsetLeft + width * xmargin
+            const scanlinesTop = canvas.offsetTop + height * ymargin
+            const scanlinesWidth = width - 2 * width * xmargin
+            const scanlinesHeight = height - 2 * height * ymargin
+
+            document.body.style.setProperty('--scanlines-left', `${scanlinesLeft}px`)
+            document.body.style.setProperty('--scanlines-top', `${scanlinesTop}}px`)
+            document.body.style.setProperty('--scanlines-width', `${scanlinesWidth}px`)
+            document.body.style.setProperty('--scanlines-height', `${scanlinesHeight}px`)
+
+            // canvas.style.marginLeft = `${(window.innerWidth - scanlinesWidth) / 2}}px`
+            // canvas.style.marginTop = `${(window.innerHeight - scanlinesHeight) / 2}px`
           }
         }).observe(canvas)
         document.body.style.setProperty("--scanlines-display", handleGetShowScanlines() ? "block" : "none")

--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -1,4 +1,4 @@
-import { handleSetTheme, lockedKeyStyle, themeToName, UI_THEME } from "../../common/utility"
+import { lockedKeyStyle, themeToName, UI_THEME } from "../../common/utility"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
   faVolumeHigh,
@@ -9,7 +9,7 @@ import {
   faUpDownLeftRight,
   faSlash,
   faSync,
-  faPaintBrush,
+  faPalette,
 } from "@fortawesome/free-solid-svg-icons"
 import { MockingboardWaveform } from "../devices/mockingboardwaveform"
 import { MidiDeviceSelect } from "../devices/midiselect"
@@ -54,10 +54,8 @@ const ConfigButtons = (props: DisplayProps) => {
   const handleThemeClose = (theme = -1) => {
     setDroplistOpen(false)
     if (theme >= 0 && theme != handleGetTheme()) {
-      if (window.confirm('Reload the emulator and apply this theme now?')) {
-        setPreferenceTheme(theme)
-        window.location.reload()
-      }
+      setPreferenceTheme(theme)
+      window.location.reload()
     }
   }
 
@@ -117,7 +115,7 @@ const ConfigButtons = (props: DisplayProps) => {
     <button className="push-button"
       title="Dark Mode"
       onClick={handleClick}>
-      <FontAwesomeIcon icon={faPaintBrush} />
+      <FontAwesomeIcon icon={faPalette} />
     </button>
 
     {droplistOpen &&

--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -55,7 +55,9 @@ const ConfigButtons = (props: DisplayProps) => {
     setDroplistOpen(false)
     if (theme >= 0 && theme != handleGetTheme()) {
       setPreferenceTheme(theme)
-      window.location.reload()
+      const url = new URL(window.location.href)
+      url.searchParams.delete('theme')
+      window.location.href = url.toString()
     }
   }
 

--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -113,7 +113,8 @@ const ConfigButtons = (props: DisplayProps) => {
     <MachineConfig updateDisplay={props.updateDisplay} />
 
     <button className="push-button"
-      title="Dark Mode"
+      id="tour-theme-button"
+      title={`${themeToName(handleGetTheme())} Theme`}
       onClick={handleClick}>
       <FontAwesomeIcon icon={faPalette} />
     </button>

--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -54,10 +54,12 @@ const ConfigButtons = (props: DisplayProps) => {
   const handleThemeClose = (theme = -1) => {
     setDroplistOpen(false)
     if (theme >= 0 && theme != handleGetTheme()) {
-      setPreferenceTheme(theme)
-      const url = new URL(window.location.href)
-      url.searchParams.delete('theme')
-      window.location.href = url.toString()
+      if (window.confirm("Reload the emulator and apply this theme now?")) {
+        setPreferenceTheme(theme)
+        const url = new URL(window.location.href)
+        url.searchParams.delete("theme")
+        window.location.href = url.toString()
+      }
     }
   }
 

--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -53,13 +53,11 @@ const ConfigButtons = (props: DisplayProps) => {
 
   const handleThemeClose = (theme = -1) => {
     setDroplistOpen(false)
-    if (theme >= 0) {
-      window.setTimeout(() => {
+    if (theme >= 0 && theme != handleGetTheme()) {
+      if (window.confirm('Reload the emulator and apply this theme now?')) {
         setPreferenceTheme(theme)
-        handleSetTheme(theme)
-        props.updateDisplay()
-        window.dispatchEvent(new Event("resize"))
-      }, 100)
+        window.location.reload()
+      }
     }
   }
 

--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -9,7 +9,7 @@ import KeyboardButtons from "./keyboardbuttons"
 const ControlPanel = (props: DisplayProps) => {
   return (
     <Flyout icon={faWrench} width="auto" position="top-left">
-      <span id="control-panel" className="flex-column">
+      <span className="flex-column">
         <span className="flex-row wrap" id="tour-controlbuttons">
           <ControlButtons {...props} />
           <DebugButtons />

--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -1,3 +1,5 @@
+import { faWrench } from "@fortawesome/free-solid-svg-icons"
+import Flyout from "../flyout"
 import ConfigButtons from "./configbuttons"
 import ControlButtons from "./controlbuttons"
 import DebugButtons from "./debugbuttons"
@@ -6,15 +8,17 @@ import KeyboardButtons from "./keyboardbuttons"
 
 const ControlPanel = (props: DisplayProps) => {
   return (
-    <span className="flex-column">
-      <span className="flex-row wrap" id="tour-controlbuttons">
-        <ControlButtons {...props} />
-        <DebugButtons />
-        <FullScreenButton />
+    <Flyout icon={faWrench} width="auto" position="top-left">
+      <span id="control-panel" className="flex-column">
+        <span className="flex-row wrap" id="tour-controlbuttons">
+          <ControlButtons {...props} />
+          <DebugButtons />
+          <FullScreenButton />
+        </span>
+        <ConfigButtons {...props} />
+        <KeyboardButtons {...props} />
       </span>
-      <ConfigButtons {...props} />
-      <KeyboardButtons {...props} />
-    </span>
+    </Flyout>
   )
 }
 

--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -8,7 +8,7 @@ import KeyboardButtons from "./keyboardbuttons"
 
 const ControlPanel = (props: DisplayProps) => {
   return (
-    <Flyout icon={faWrench} width="auto" position="top-left">
+    <Flyout icon={faWrench} minWidth={1290} position="top-left">
       <span className="flex-column">
         <span className="flex-row wrap" id="tour-controlbuttons">
           <ControlButtons {...props} />

--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -5,10 +5,17 @@ import ControlButtons from "./controlbuttons"
 import DebugButtons from "./debugbuttons"
 import FullScreenButton from "./fullscreenbutton"
 import KeyboardButtons from "./keyboardbuttons"
+import { useState } from "react"
 
 const ControlPanel = (props: DisplayProps) => {
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
+
   return (
-    <Flyout icon={faWrench} minWidth={1290} position="top-left">
+    <Flyout
+      icon={faWrench}
+      isOpen={() => { return isFlyoutOpen }}
+      onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
+      position="top-left">
       <span className="flex-column">
         <span className="flex-row wrap" id="tour-controlbuttons">
           <ControlButtons {...props} />

--- a/src/ui/controls/debugbuttons.tsx
+++ b/src/ui/controls/debugbuttons.tsx
@@ -1,7 +1,8 @@
-import { RUN_MODE } from "../../common/utility"
+import { RUN_MODE, UI_THEME } from "../../common/utility"
 import {
   passGoBackInTime, passGoForwardInTime,
-  handleCanGoBackward, handleCanGoForward, passTimeTravelSnapshot, handleGetIsDebugging, handleGetRunMode
+  handleCanGoBackward, handleCanGoForward, passTimeTravelSnapshot, handleGetIsDebugging, handleGetRunMode,
+  handleGetTheme
 } from "../main2worker"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
@@ -23,30 +24,30 @@ const DebugButtons = () => {
   const notStarted = runMode === RUN_MODE.IDLE || runMode === RUN_MODE.NEED_BOOT
   return <span className="flex-row">
     <div className="flex-row" id="tour-snapshot">
-    <button className="push-button"
-      title={"Go Back in Time"}
-      onClick={passGoBackInTime}
-      disabled={notStarted || !handleCanGoBackward()}>
-      <FontAwesomeIcon icon={faFastBackward} />
-    </button>
-    <button className="push-button"
-      title={"Take a Snapshot"}
-      onClick={passTimeTravelSnapshot}
-      disabled={notStarted}>
-      <FontAwesomeIcon icon={faCamera} />
-    </button>
-    <button className="push-button"
-      title={"Go Forward in Time"}
-      onClick={passGoForwardInTime}
-      disabled={notStarted || !handleCanGoForward()}>
-      <FontAwesomeIcon icon={faFastForward} />
-    </button>
-    <button className="push-button"
-      title={"Save State with Snapshots"}
-      onClick={() => handleFileSave(true)}
-      disabled={notStarted}>
-      <FontAwesomeIcon icon={faLayerGroup} />
-    </button>
+      <button className="push-button"
+        title={"Go Back in Time"}
+        onClick={passGoBackInTime}
+        disabled={notStarted || !handleCanGoBackward()}>
+        <FontAwesomeIcon icon={faFastBackward} />
+      </button>
+      <button className="push-button"
+        title={"Take a Snapshot"}
+        onClick={passTimeTravelSnapshot}
+        disabled={notStarted}>
+        <FontAwesomeIcon icon={faCamera} />
+      </button>
+      <button className="push-button"
+        title={"Go Forward in Time"}
+        onClick={passGoForwardInTime}
+        disabled={notStarted || !handleCanGoForward()}>
+        <FontAwesomeIcon icon={faFastForward} />
+      </button>
+      <button className="push-button"
+        title={"Save State with Snapshots"}
+        onClick={() => handleFileSave(true)}
+        disabled={notStarted}>
+        <FontAwesomeIcon icon={faLayerGroup} />
+      </button>
     </div>
     <button className="push-button" id="tour-pause-button"
       title={runMode === RUN_MODE.PAUSED ? "Resume" : "Pause"}
@@ -59,11 +60,12 @@ const DebugButtons = () => {
         <FontAwesomeIcon icon={faPlay} /> :
         <FontAwesomeIcon icon={faPause} />}
     </button>
-    <button className="push-button" id="tour-debug-button"
-      title="Toggle Debug"
-      onClick={() => setPreferenceDebugMode(!handleGetIsDebugging())}>
-      <FontAwesomeIcon icon={handleGetIsDebugging() ? faBug : faBugSlash} />
-    </button>
+    {handleGetTheme() != UI_THEME.MINIMAL &&
+      <button className="push-button" id="tour-debug-button"
+        title="Toggle Debug"
+        onClick={() => setPreferenceDebugMode(!handleGetIsDebugging())}>
+        <FontAwesomeIcon icon={handleGetIsDebugging() ? faBug : faBugSlash} />
+      </button>}
   </span>
 }
 

--- a/src/ui/controls/fullscreenbutton.tsx
+++ b/src/ui/controls/fullscreenbutton.tsx
@@ -7,17 +7,19 @@ const FullScreenButton = () => {
   const isTouchDevice = "ontouchstart" in document.documentElement
   return (
     <button className="push-button" title="Full Screen"
-      style={{ display: isTouchDevice ? "none" : "" }}
+      // style={{ display: isTouchDevice ? "none" : "" }}
       onClick={() => {
         const canvas = document.getElementById("apple2canvas") as HTMLCanvasElement
         const context = canvas.getContext("2d")
         if (context) {
           try {
+            alert(canvas?.parentElement?.outerHTML)
             canvas?.parentElement?.requestFullscreen()
             canvas.width = window.outerWidth
             canvas.height = window.outerHeight
-          } catch {
+          } catch (ex) {
             // do nothing
+            alert(ex)
           }
         }
       }

--- a/src/ui/controls/fullscreenbutton.tsx
+++ b/src/ui/controls/fullscreenbutton.tsx
@@ -7,19 +7,17 @@ const FullScreenButton = () => {
   const isTouchDevice = "ontouchstart" in document.documentElement
   return (
     <button className="push-button" title="Full Screen"
-      // style={{ display: isTouchDevice ? "none" : "" }}
+      style={{ display: isTouchDevice ? "none" : "" }}
       onClick={() => {
         const canvas = document.getElementById("apple2canvas") as HTMLCanvasElement
         const context = canvas.getContext("2d")
         if (context) {
           try {
-            alert(canvas?.parentElement?.outerHTML)
             canvas?.parentElement?.requestFullscreen()
             canvas.width = window.outerWidth
             canvas.height = window.outerHeight
-          } catch (ex) {
+          } catch {
             // do nothing
-            alert(ex)
           }
         }
       }

--- a/src/ui/devices/diskinterface.css
+++ b/src/ui/devices/diskinterface.css
@@ -73,6 +73,7 @@ body.dark-mode .disk-cloud {
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(359deg);
   }

--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -1,24 +1,28 @@
 import "./diskinterface.css"
 import DiskDrive from "./diskdrive"
 import { DiskImageChooser } from "./diskimagechooser"
+import Flyout from "../flyout"
+import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons"
 
 const DiskInterface = (props: DisplayProps) => {
   return (
-    <div className="flex-row wrap">
-      <span className="flex-row">
-        <DiskImageChooser {...props} />
-        <DiskDrive index={0} renderCount={props.renderCount}
-          setShowFileOpenDialog={props.setShowFileOpenDialog} />
-        <DiskDrive index={1} renderCount={props.renderCount}
-          setShowFileOpenDialog={props.setShowFileOpenDialog} />
-      </span>
-      <span className="flex-row">
-        <DiskDrive index={2} renderCount={props.renderCount}
-          setShowFileOpenDialog={props.setShowFileOpenDialog} />
-        <DiskDrive index={3} renderCount={props.renderCount}
-          setShowFileOpenDialog={props.setShowFileOpenDialog} />
-      </span>
-    </div>
+    <Flyout icon={faFloppyDisk} width="auto" position="bottom-left">
+      <div className="flex-row wrap">
+        <span className="flex-row">
+          <DiskImageChooser {...props} />
+          <DiskDrive index={0} renderCount={props.renderCount}
+            setShowFileOpenDialog={props.setShowFileOpenDialog} />
+          <DiskDrive index={1} renderCount={props.renderCount}
+            setShowFileOpenDialog={props.setShowFileOpenDialog} />
+        </span>
+        <span className="flex-row">
+          <DiskDrive index={2} renderCount={props.renderCount}
+            setShowFileOpenDialog={props.setShowFileOpenDialog} />
+          <DiskDrive index={3} renderCount={props.renderCount}
+            setShowFileOpenDialog={props.setShowFileOpenDialog} />
+        </span>
+      </div>
+    </Flyout>
   )
 }
 

--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -6,7 +6,7 @@ import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons"
 
 const DiskInterface = (props: DisplayProps) => {
   return (
-    <Flyout icon={faFloppyDisk} width="auto" position="bottom-left">
+    <Flyout icon={faFloppyDisk} minWidth={1290} position="bottom-left">
       <div className="flex-row wrap">
         <span className="flex-row">
           <DiskImageChooser {...props} />

--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -18,7 +18,7 @@ const DiskInterface = (props: DisplayProps) => {
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="bottom-left">
-      <div className={`${isMinimalTheme ? 'flex-column' : 'flex-row'} wrap`}>
+      <div className={`${isMinimalTheme ? "flex-column" : "flex-row"} wrap`}>
         <span className="flex-row wrap">
           <DiskImageChooser {...props} />
           <DiskDrive index={0} renderCount={props.renderCount}

--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -3,23 +3,36 @@ import DiskDrive from "./diskdrive"
 import { DiskImageChooser } from "./diskimagechooser"
 import Flyout from "../flyout"
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons"
+import ImageWriter from "./imagewriter"
+import { handleGetTheme } from "../main2worker"
+import { UI_THEME } from "../../common/utility"
+import { useState } from "react"
 
 const DiskInterface = (props: DisplayProps) => {
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(true)
+  const isMinimalTheme = handleGetTheme() == UI_THEME.MINIMAL
+
   return (
-    <Flyout icon={faFloppyDisk} minWidth={1290} position="bottom-left">
-      <div className="flex-row wrap">
-        <span className="flex-row">
+    <Flyout
+      icon={faFloppyDisk}
+      isOpen={() => { return isFlyoutOpen }}
+      onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
+      position="bottom-left">
+      <div className={`${isMinimalTheme ? 'flex-column' : 'flex-row'} wrap`}>
+        <span className="flex-row wrap">
           <DiskImageChooser {...props} />
           <DiskDrive index={0} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
           <DiskDrive index={1} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
         </span>
-        <span className="flex-row">
+        <span className="flex-row wrap">
+          {isMinimalTheme && <ImageWriter />}
           <DiskDrive index={2} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
           <DiskDrive index={3} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
+          {!isMinimalTheme && <ImageWriter />}
         </span>
       </div>
     </Flyout>

--- a/src/ui/devices/imagewriter.tsx
+++ b/src/ui/devices/imagewriter.tsx
@@ -3,6 +3,8 @@ import iwiion from "./img/iwiion.png"
 import iwiioff from "./img/iwiioff.png"
 import PrinterDialog from "./printerdialog"
 import { ImageWriterII, registerSetPrinting } from "./iwii"
+import Flyout from "../flyout"
+import { faPrint } from "@fortawesome/free-solid-svg-icons"
 
 const ImageWriter = () => {
   const [open, setOpen] = useState(false)
@@ -27,20 +29,22 @@ const ImageWriter = () => {
   const img1 = printingTimeout ? iwiion : iwiioff
 
   return (
-    <span className="flex-column">
-      <img className="disk-image"
-        style={{ borderWidth: 0 }}
-        src={img1} alt="iwii"
-        title="ImageWriter II"
-        height="57px"
-        onClick={() => { setOpen(true) }} />
-      <PrinterDialog
-        open={open}
-        onClose={() => { setOpen(false) }}
-        canvas={canvas}
-        printer={ImageWriterII}
-      />
-    </span>
+    <Flyout icon={faPrint} width="auto" position="bottom-right">
+      <span className="flex-column">
+        <img className="disk-image"
+          style={{ borderWidth: 0 }}
+          src={img1} alt="iwii"
+          title="ImageWriter II"
+          height="57px"
+          onClick={() => { setOpen(true) }} />
+        <PrinterDialog
+          open={open}
+          onClose={() => { setOpen(false) }}
+          canvas={canvas}
+          printer={ImageWriterII}
+        />
+      </span>
+    </Flyout>
   )
 }
 

--- a/src/ui/devices/imagewriter.tsx
+++ b/src/ui/devices/imagewriter.tsx
@@ -29,7 +29,7 @@ const ImageWriter = () => {
   const img1 = printingTimeout ? iwiion : iwiioff
 
   return (
-    <Flyout icon={faPrint} width="auto" position="bottom-right">
+    <Flyout icon={faPrint} minWidth={1290} position="bottom-right">
       <span className="flex-column">
         <img className="disk-image"
           style={{ borderWidth: 0 }}

--- a/src/ui/devices/imagewriter.tsx
+++ b/src/ui/devices/imagewriter.tsx
@@ -3,8 +3,6 @@ import iwiion from "./img/iwiion.png"
 import iwiioff from "./img/iwiioff.png"
 import PrinterDialog from "./printerdialog"
 import { ImageWriterII, registerSetPrinting } from "./iwii"
-import Flyout from "../flyout"
-import { faPrint } from "@fortawesome/free-solid-svg-icons"
 
 const ImageWriter = () => {
   const [open, setOpen] = useState(false)
@@ -29,22 +27,20 @@ const ImageWriter = () => {
   const img1 = printingTimeout ? iwiion : iwiioff
 
   return (
-    <Flyout icon={faPrint} minWidth={1290} position="bottom-right">
-      <span className="flex-column">
-        <img className="disk-image"
-          style={{ borderWidth: 0 }}
-          src={img1} alt="iwii"
-          title="ImageWriter II"
-          height="57px"
-          onClick={() => { setOpen(true) }} />
-        <PrinterDialog
-          open={open}
-          onClose={() => { setOpen(false) }}
-          canvas={canvas}
-          printer={ImageWriterII}
-        />
-      </span>
-    </Flyout>
+    <span className="flex-column">
+      <img className="disk-image"
+        style={{ borderWidth: 0 }}
+        src={img1} alt="iwii"
+        title="ImageWriter II"
+        height="57px"
+        onClick={() => { setOpen(true) }} />
+      <PrinterDialog
+        open={open}
+        onClose={() => { setOpen(false) }}
+        canvas={canvas}
+        printer={ImageWriterII}
+      />
+    </span>
   )
 }
 

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -35,6 +35,7 @@ const DisplayApple2 = () => {
   const [showFileOpenDialog, setShowFileOpenDialog] = useState({ show: false, index: 0 })
   const [worker, setWorker] = useState<Worker | null>(null)
   const righthandSectionRef = useRef<HTMLDivElement>(null)
+  const handleInputParamsResult = handleInputParams()
 
   // We need to create our worker here so it has access to our properties
   // such as cpu speed and help text. Otherwise, if the emulator changed
@@ -85,8 +86,7 @@ const DisplayApple2 = () => {
     // preloadAssets()
     passSpeedMode(0)
     loadPreferences()
-    const hasBasicProgram = handleInputParams()
-    handleFragment(updateDisplay, hasBasicProgram)
+    handleFragment(updateDisplay, handleInputParamsResult.hasBasicProgram)
     //    window.addEventListener('beforeunload', (event) => {
     // Cancel the event as stated by the standard.
     //      event.preventDefault();
@@ -98,6 +98,10 @@ const DisplayApple2 = () => {
       passSetRunMode(RUN_MODE.NEED_BOOT)
       setTimeout(() => { passSetRunMode(RUN_MODE.NEED_RESET) }, 500)
       setTimeout(() => { passSetRunMode(RUN_MODE.PAUSED) }, 1000)
+    }
+
+    if (handleInputParamsResult.experiments.includes('pwafs')) {
+      document.documentElement.classList.add('pwafs')
     }
   }
 
@@ -178,21 +182,21 @@ const DisplayApple2 = () => {
       <span className={narrow ? "flex-column-gap" : "flex-row-gap"} style={{ alignItems: "inherit" }}>
         <div className={isLandscape ? "flex-row" : "flex-column"}>
           <Apple2Canvas {...props} />
-          {/* <div className="flex-row-gap wrap"
+          <div className="flex-row-gap wrap"
             style={{ paddingLeft: "2px" }}>
             <ControlPanel {...props} />
             <DiskInterface {...props} />
             <ImageWriter />
           </div>
-          {!isLandscape && status} */}
+          {!isLandscape && status}
         </div>
         {isLandscape && status}
-        {/* {narrow && <div className="divider"></div>}
+        {narrow && <div className="divider"></div>}
         <span className="flex-column" ref={righthandSectionRef}>
           {handleGetIsDebugging() ? <DebugSection /> :
             <HelpPanel narrow={narrow}
               helptext={handleGetHelpText()} />}
-        </span> */}
+        </span>
       </span>
       <FileInput {...props} />
     </div>

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -9,7 +9,7 @@ import {
   handleGetMemSize,
   passHelpText,
   handleGetHelpText,
-  handleGetDarkMode,
+  handleGetTheme,
   passSetRunMode
 } from "./main2worker"
 import Apple2Canvas from "./canvas"
@@ -23,7 +23,7 @@ import FileInput from "./fileinput"
 import { RestoreSaveState } from "./savestate"
 import { handleFragment, handleInputParams } from "./inputparams"
 import { loadPreferences } from "./localstorage"
-import { isProgressiveFullscreen, RUN_MODE, TEST_DEBUG } from "../common/utility"
+import { handleSetTheme, RUN_MODE, TEST_DEBUG, UI_THEME } from "../common/utility"
 
 const DisplayApple2 = () => {
   const [myInit, setMyInit] = useState(false)
@@ -99,10 +99,6 @@ const DisplayApple2 = () => {
       setTimeout(() => { passSetRunMode(RUN_MODE.NEED_RESET) }, 500)
       setTimeout(() => { passSetRunMode(RUN_MODE.PAUSED) }, 1000)
     }
-
-    if (handleInputParamsResult.experiments.includes('pwafs')) {
-      document.documentElement.classList.add('pwafs')
-    }
   }
 
   const handleCtrlDown = (ctrlKeyMode: number) => {
@@ -152,11 +148,8 @@ const DisplayApple2 = () => {
     setShowFileOpenDialog: handleShowFileOpenDialog,
   }
 
-  if (handleGetDarkMode()) {
-    document.body.classList.add("dark-mode")
-  } else {
-    document.body.classList.remove("dark-mode")
-  }
+  const theme = handleGetTheme()
+  handleSetTheme(theme)
 
   const isTouchDevice = "ontouchstart" in document.documentElement
   const height = window.innerHeight ? window.innerHeight : (window.outerHeight - 120)
@@ -191,7 +184,7 @@ const DisplayApple2 = () => {
           {!isLandscape && status}
         </div>
         {isLandscape && status}
-        {narrow && !isProgressiveFullscreen() && <div className="divider"></div>}
+        {narrow && theme != UI_THEME.MINIMAL && <div className="divider"></div>}
         <span className="flex-column" ref={righthandSectionRef}>
           {handleGetIsDebugging() ? <DebugSection /> :
             <HelpPanel narrow={narrow}

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -23,7 +23,7 @@ import FileInput from "./fileinput"
 import { RestoreSaveState } from "./savestate"
 import { handleFragment, handleInputParams } from "./inputparams"
 import { loadPreferences } from "./localstorage"
-import { RUN_MODE, TEST_DEBUG } from "../common/utility"
+import { isProgressiveFullscreen, RUN_MODE, TEST_DEBUG } from "../common/utility"
 
 const DisplayApple2 = () => {
   const [myInit, setMyInit] = useState(false)
@@ -174,7 +174,7 @@ const DisplayApple2 = () => {
     <span>{currentSpeed} MHz, {memSize}</span>
     <br />
     <span>Apple2TS ©{new Date().getFullYear()} Chris Torrence&nbsp;
-      <a href="https://github.com/ct6502/apple2ts/issues">Report an Issue</a></span>
+      <a id="reportIssue" href="https://github.com/ct6502/apple2ts/issues">Report an Issue</a></span>
   </div>
 
   return (
@@ -191,7 +191,7 @@ const DisplayApple2 = () => {
           {!isLandscape && status}
         </div>
         {isLandscape && status}
-        {narrow && <div className="divider"></div>}
+        {narrow && !isProgressiveFullscreen() && <div className="divider"></div>}
         <span className="flex-column" ref={righthandSectionRef}>
           {handleGetIsDebugging() ? <DebugSection /> :
             <HelpPanel narrow={narrow}

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -178,21 +178,21 @@ const DisplayApple2 = () => {
       <span className={narrow ? "flex-column-gap" : "flex-row-gap"} style={{ alignItems: "inherit" }}>
         <div className={isLandscape ? "flex-row" : "flex-column"}>
           <Apple2Canvas {...props} />
-          <div className="flex-row-gap wrap"
+          {/* <div className="flex-row-gap wrap"
             style={{ paddingLeft: "2px" }}>
             <ControlPanel {...props} />
             <DiskInterface {...props} />
             <ImageWriter />
           </div>
-          {!isLandscape && status}
+          {!isLandscape && status} */}
         </div>
         {isLandscape && status}
-        {narrow && <div className="divider"></div>}
+        {/* {narrow && <div className="divider"></div>}
         <span className="flex-column" ref={righthandSectionRef}>
           {handleGetIsDebugging() ? <DebugSection /> :
             <HelpPanel narrow={narrow}
               helptext={handleGetHelpText()} />}
-        </span>
+        </span> */}
       </span>
       <FileInput {...props} />
     </div>

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -18,7 +18,6 @@ import DiskInterface from "./devices/diskinterface"
 import { useRef, useState } from "react"
 import HelpPanel from "./panels/helppanel"
 import DebugSection from "./panels/debugsection"
-import ImageWriter from "./devices/imagewriter"
 import FileInput from "./fileinput"
 import { RestoreSaveState } from "./savestate"
 import { handleFragment, handleInputParams } from "./inputparams"
@@ -179,16 +178,14 @@ const DisplayApple2 = () => {
             style={{ paddingLeft: "2px" }}>
             <ControlPanel {...props} />
             <DiskInterface {...props} />
-            <ImageWriter />
           </div>
           {!isLandscape && status}
         </div>
         {isLandscape && status}
         {narrow && theme != UI_THEME.MINIMAL && <div className="divider"></div>}
         <span className="flex-column" ref={righthandSectionRef}>
-          {handleGetIsDebugging() ? <DebugSection /> :
-            <HelpPanel narrow={narrow}
-              helptext={handleGetHelpText()} />}
+          {(handleGetIsDebugging() || theme == UI_THEME.MINIMAL) && <DebugSection />}
+          {(!handleGetIsDebugging() || theme == UI_THEME.MINIMAL) && <HelpPanel narrow={narrow} helptext={handleGetHelpText()} />}
         </span>
       </span>
       <FileInput {...props} />

--- a/src/ui/flyout.css
+++ b/src/ui/flyout.css
@@ -20,7 +20,7 @@
     border-width: 1px;
     border-style: solid;
     border-top-style: none;
-    padding-bottom: 2px;
+    padding-bottom: 0px;
     z-index: 4;
   }
 
@@ -34,7 +34,7 @@
     border-width: 1px;
     border-style: solid;
     border-top-style: none;
-    padding-bottom: 2px;
+    padding-bottom: 0px;
     z-index: 3;
   }
 

--- a/src/ui/flyout.css
+++ b/src/ui/flyout.css
@@ -14,7 +14,7 @@
   .flyout-top-left {
     top: -1000px;
     height: auto;
-    left: 18px;
+    left: 48px;
     transition: top 0.5s ease;
     transition: bottom 0.5s ease;
     transition: left 0.5s ease;
@@ -32,7 +32,7 @@
   .flyout-top-right {
     top: -1000px;
     height: auto;
-    right: 18px;
+    right: 48px;
     transition: top 0.3s ease;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
@@ -47,7 +47,7 @@
   .flyout-bottom-left {
     bottom: -1000px;
     height: auto;
-    left: 18px;
+    left: 48px;
     transition: bottom 0.3s ease;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
@@ -61,7 +61,7 @@
   .flyout-bottom-right {
     bottom: -1000px;
     height: auto;
-    right: 8px;
+    right: 48px;
     transition: bottom 0.3s ease;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;

--- a/src/ui/flyout.css
+++ b/src/ui/flyout.css
@@ -1,0 +1,80 @@
+.flyout-button {
+  display: none;
+}
+
+@scope (.pwafs) {
+  .flyout {
+    position: fixed;
+    background-color: #aba7a2;
+    padding-left: 2px;
+    padding-right: 7px;
+    z-index: 99;
+  }
+
+  .flyout-top-left {
+    top: -1000px;
+    height: auto;
+    left: 18px;
+    transition: top 0.3s ease;
+    border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+    border-color: #000000;
+    border-width: 1px;
+    border-style: solid;
+    border-top-style: none;
+    padding-bottom: 2px;
+  }
+
+  .flyout-top-right {
+    top: -1000px;
+    height: auto;
+    right: 18px;
+    transition: top 0.3s ease;
+    border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+    border-color: #000000;
+    border-width: 1px;
+    border-style: solid;
+    border-top-style: none;
+    padding-bottom: 2px;
+  }
+
+  .flyout-bottom-left {
+    bottom: -1000px;
+    height: auto;
+    left: 18px;
+    transition: bottom 0.3s ease;
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    border-width: 1px;
+    border-style: solid;
+    border-bottom-style: none;
+    padding-top: 0px;
+  }
+
+  .flyout-bottom-right {
+    bottom: -1000px;
+    height: auto;
+    right: 18px;
+    transition: bottom 0.3s ease;
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    border-width: 1px;
+    border-style: solid;
+    border-bottom-style: none;
+    padding-top: 0px;
+  }
+
+  .flyout-button {
+    display: block;
+    color: #000000;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    padding-left: 0px;
+    padding-right: 0px;
+    font-size: 18pt;
+    cursor: pointer;
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/src/ui/flyout.css
+++ b/src/ui/flyout.css
@@ -2,7 +2,7 @@
   display: none;
 }
 
-@scope (.pwafs) {
+@scope (.theme-minimal) {
   .flyout {
     position: fixed;
     background-color: #aba7a2;
@@ -12,13 +12,8 @@
   }
 
   .flyout-top-left {
-    top: -1000px;
     height: auto;
     left: 48px;
-    transition: top 0.5s ease;
-    transition: bottom 0.5s ease;
-    transition: left 0.5s ease;
-    transition: right 0.5s ease;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     border-color: #000000;
@@ -30,10 +25,8 @@
   }
 
   .flyout-top-right {
-    top: -1000px;
     height: auto;
     right: 48px;
-    transition: top 0.3s ease;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     border-color: #000000;
@@ -45,10 +38,8 @@
   }
 
   .flyout-bottom-left {
-    bottom: -1000px;
     height: auto;
     left: 48px;
-    transition: bottom 0.3s ease;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
     border-width: 1px;
@@ -59,10 +50,8 @@
   }
 
   .flyout-bottom-right {
-    bottom: -1000px;
     height: auto;
     right: 48px;
-    transition: bottom 0.3s ease;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
     border-width: 1px;

--- a/src/ui/flyout.css
+++ b/src/ui/flyout.css
@@ -8,11 +8,11 @@
     background-color: #aba7a2;
     padding-left: 2px;
     padding-right: 7px;
-    z-index: 99;
   }
 
   .flyout-top-left {
     height: auto;
+    top: 0px;
     left: 48px;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
@@ -26,7 +26,8 @@
 
   .flyout-top-right {
     height: auto;
-    right: 48px;
+    top: 0px;
+    right: 14px;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     border-color: #000000;
@@ -39,6 +40,7 @@
 
   .flyout-bottom-left {
     height: auto;
+    bottom: 0px;
     left: 48px;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
@@ -51,7 +53,8 @@
 
   .flyout-bottom-right {
     height: auto;
-    right: 48px;
+    bottom: 0px;
+    right: 14px;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
     border-width: 1px;

--- a/src/ui/flyout.css
+++ b/src/ui/flyout.css
@@ -15,7 +15,10 @@
     top: -1000px;
     height: auto;
     left: 18px;
-    transition: top 0.3s ease;
+    transition: top 0.5s ease;
+    transition: bottom 0.5s ease;
+    transition: left 0.5s ease;
+    transition: right 0.5s ease;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     border-color: #000000;
@@ -23,6 +26,7 @@
     border-style: solid;
     border-top-style: none;
     padding-bottom: 2px;
+    z-index: 4;
   }
 
   .flyout-top-right {
@@ -37,6 +41,7 @@
     border-style: solid;
     border-top-style: none;
     padding-bottom: 2px;
+    z-index: 3;
   }
 
   .flyout-bottom-left {
@@ -50,12 +55,13 @@
     border-style: solid;
     border-bottom-style: none;
     padding-top: 0px;
+    z-index: 2;
   }
 
   .flyout-bottom-right {
     bottom: -1000px;
     height: auto;
-    right: 18px;
+    right: 8px;
     transition: bottom 0.3s ease;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
@@ -63,6 +69,7 @@
     border-style: solid;
     border-bottom-style: none;
     padding-top: 0px;
+    z-index: 1;
   }
 
   .flyout-button {
@@ -70,7 +77,7 @@
     color: #000000;
     padding-top: 2px;
     padding-bottom: 2px;
-    padding-left: 0px;
+    padding-left: 4px;
     padding-right: 0px;
     font-size: 18pt;
     cursor: pointer;

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -9,7 +9,8 @@ const Flyout = (props: {
   buttonId?: string,
   position: string,
   isOpen: () => boolean | undefined,
-  onClick: () => void | undefined
+  onClick: () => void | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   children: any
 }) => {
   const className = `flyout-${props.position}`
@@ -17,7 +18,7 @@ const Flyout = (props: {
   const isMinimalTheme = handleGetTheme() == UI_THEME.MINIMAL
 
   const isTopPosition = () => {
-    return props.position.search('top') >= 0
+    return props.position.search("top") >= 0
   }
 
   const getArrowIcon = (): IconDefinition => {
@@ -29,24 +30,28 @@ const Flyout = (props: {
   }
 
   const isTouchDevice = "ontouchstart" in document.documentElement
-  const isLeftPosition = props.position.indexOf('left') >= 0
+  const isLeftPosition = props.position.indexOf("left") >= 0
 
   return (
     <div
       className={`flyout ${className}`}
       style={{
-        left: isMinimalTheme && isLeftPosition ? (!isFlyoutOpen || !isTouchDevice ? '14px' : '48px') : '',
-        width: isMinimalTheme && !isFlyoutOpen ? 'max(8vw, 72px)' : 'auto',
-        opacity: isMinimalTheme && !isFlyoutOpen ? '33%' : '100%'
+        left: isMinimalTheme && isLeftPosition ? (!isFlyoutOpen || !isTouchDevice ? "14px" : "48px") : "",
+        width: isMinimalTheme && !isFlyoutOpen ? "max(8vw, 72px)" : "auto",
+        opacity: isMinimalTheme && !isFlyoutOpen ? "33%" : "100%"
       }}>
-      {isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ''}
+      {isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ""}
       <div
-        id={props.buttonId ?? ''}
+        id={props.buttonId ?? ""}
         className="flyout-button"
-        onClick={() => { props.onClick && props.onClick() }}>
+        onClick={() => {
+          if (props.onClick) {
+            props.onClick()
+          }
+        }}>
         <FontAwesomeIcon icon={getArrowIcon()}></FontAwesomeIcon>
       </div>
-      {!isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ''}
+      {!isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ""}
     </div>
   )
 }

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -28,10 +28,14 @@ const Flyout = (props: {
     }
   }
 
+  const isTouchDevice = "ontouchstart" in document.documentElement
+  const isLeftPosition = props.position.indexOf('left') >= 0
+
   return (
     <div
       className={`flyout ${className}`}
       style={{
+        left: isMinimalTheme && isLeftPosition ? (!isFlyoutOpen || !isTouchDevice ? '14px' : '48px') : '',
         width: isMinimalTheme && !isFlyoutOpen ? '72px' : 'auto',
         opacity: isMinimalTheme && !isFlyoutOpen ? '33%' : '100%'
       }}>

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -31,7 +31,7 @@ const Flyout = (props: {
       if (isTopPosition()) {
         panel.style.top = `calc(-${panel.offsetHeight}px + 18pt + 12px)`
       } else {
-        panel.style.bottom = `calc(-${panel.offsetHeight}px + 18pt + 8px)`
+        panel.style.bottom = `calc(-${panel.offsetHeight}px + 18pt + 20px)`
       }
       panel.style.opacity = '33%'
 

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -1,0 +1,82 @@
+import "./flyout.css"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCircleArrowDown, faCircleArrowUp, IconDefinition } from "@fortawesome/free-solid-svg-icons"
+import { useEffect, useState } from "react"
+import { isProgressiveFullscreen } from "../common/utility"
+
+const Flyout = (props: {
+  icon: IconDefinition,
+  width: string,
+  position: string,
+  children: any
+}) => {
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+  const className = `flyout-${props.position}`
+  const width = props.width ?? ''
+
+  const isTopPosition = () => {
+    return props.position.search('top') >= 0
+  }
+
+  const handleResizeImmediate = (newIsFlyoutOpen: boolean) => {
+    const panel = document.getElementsByClassName(className)[0] as HTMLElement
+    if (newIsFlyoutOpen) {
+      if (isTopPosition()) {
+        panel.style.top = '0px'
+      } else {
+        panel.style.bottom = '0px'
+      }
+      panel.style.opacity = '100%'
+    } else {
+      if (isTopPosition()) {
+        panel.style.top = `calc(-${panel.offsetHeight}px + 18pt + 12px)`
+      } else {
+        panel.style.bottom = `calc(-${panel.offsetHeight}px + 18pt + 8px)`
+      }
+      panel.style.opacity = '33%'
+
+      const hiddenText = document.getElementsByClassName('hidden-textarea')[0] as HTMLElement
+      if (hiddenText) {
+        hiddenText.focus()
+      }
+    }
+  }
+
+  const handleResize = () => {
+    handleResizeImmediate(isFlyoutOpen)
+  }
+
+  useEffect(() => {
+    if (isProgressiveFullscreen()) {
+      window.addEventListener('resize', handleResize);
+      handleResize()
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    }
+  }, []);
+
+  const getArrowIcon = (): IconDefinition => {
+    if (isFlyoutOpen) {
+      return isTopPosition() ? faCircleArrowUp : faCircleArrowDown
+    } else {
+      return props.icon
+    }
+  }
+
+  return (
+    <div className={`flyout ${className}`} style={{ width: width }}>
+      {isTopPosition() ? props.children : ''}
+      <div className="flyout-button" onClick={() => {
+        handleResizeImmediate(!isFlyoutOpen)
+        setIsFlyoutOpen(!isFlyoutOpen)
+      }}>
+        <FontAwesomeIcon icon={getArrowIcon()}
+        ></FontAwesomeIcon>
+      </div>
+      {!isTopPosition() ? props.children : ''}
+    </div>
+  )
+}
+
+export default Flyout

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -36,21 +36,14 @@ const Flyout = (props: {
       className={`flyout ${className}`}
       style={{
         left: isMinimalTheme && isLeftPosition ? (!isFlyoutOpen || !isTouchDevice ? '14px' : '48px') : '',
-        width: isMinimalTheme && !isFlyoutOpen ? '72px' : 'auto',
+        width: isMinimalTheme && !isFlyoutOpen ? 'max(8vw, 72px)' : 'auto',
         opacity: isMinimalTheme && !isFlyoutOpen ? '33%' : '100%'
       }}>
       {isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ''}
       <div
         id={props.buttonId ?? ''}
         className="flyout-button"
-        onClick={() => {
-          props.onClick && props.onClick()
-
-          // const hiddenText = document.getElementsByClassName('hidden-textarea')[0] as HTMLElement
-          // if (hiddenText) {
-          //   hiddenText.focus()
-          // }
-        }}>
+        onClick={() => { props.onClick && props.onClick() }}>
         <FontAwesomeIcon icon={getArrowIcon()}></FontAwesomeIcon>
       </div>
       {!isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ''}

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -6,13 +6,12 @@ import { isProgressiveFullscreen } from "../common/utility"
 
 const Flyout = (props: {
   icon: IconDefinition,
-  width: string,
+  minWidth: number,
   position: string,
   children: any
 }) => {
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(props.minWidth < window.innerWidth);
   const className = `flyout-${props.position}`
-  const width = props.width ?? ''
 
   const isTopPosition = () => {
     return props.position.search('top') >= 0
@@ -27,7 +26,7 @@ const Flyout = (props: {
         panel.style.bottom = '0px'
       }
 
-      panel.style.width = width
+      panel.style.width = 'auto'
       panel.style.opacity = '100%'
     } else {
       if (isTopPosition()) {
@@ -69,8 +68,8 @@ const Flyout = (props: {
   }
 
   return (
-    <div className={`flyout ${className}`} style={{ width: width }}>
-      {isFlyoutOpen && isTopPosition() ? props.children : ''}
+    <div className={`flyout ${className}`}>
+      {isTopPosition() && (isFlyoutOpen || !isProgressiveFullscreen()) ? props.children : ''}
       <div className="flyout-button" onClick={() => {
         handleResizeImmediate(!isFlyoutOpen)
         setIsFlyoutOpen(!isFlyoutOpen)
@@ -78,7 +77,7 @@ const Flyout = (props: {
         <FontAwesomeIcon icon={getArrowIcon()}
         ></FontAwesomeIcon>
       </div>
-      {isFlyoutOpen && !isTopPosition() ? props.children : ''}
+      {!isTopPosition() && (isFlyoutOpen || !isProgressiveFullscreen()) ? props.children : ''}
     </div>
   )
 }

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -26,13 +26,17 @@ const Flyout = (props: {
       } else {
         panel.style.bottom = '0px'
       }
+
+      panel.style.width = width
       panel.style.opacity = '100%'
     } else {
       if (isTopPosition()) {
-        panel.style.top = `calc(-${panel.offsetHeight}px + 18pt + 12px)`
+        panel.style.top = '0px'
       } else {
-        panel.style.bottom = `calc(-${panel.offsetHeight}px + 18pt + 20px)`
+        panel.style.bottom = '0px'
       }
+
+      panel.style.width = '80px'
       panel.style.opacity = '33%'
 
       const hiddenText = document.getElementsByClassName('hidden-textarea')[0] as HTMLElement
@@ -66,7 +70,7 @@ const Flyout = (props: {
 
   return (
     <div className={`flyout ${className}`} style={{ width: width }}>
-      {isTopPosition() ? props.children : ''}
+      {isFlyoutOpen && isTopPosition() ? props.children : ''}
       <div className="flyout-button" onClick={() => {
         handleResizeImmediate(!isFlyoutOpen)
         setIsFlyoutOpen(!isFlyoutOpen)
@@ -74,7 +78,7 @@ const Flyout = (props: {
         <FontAwesomeIcon icon={getArrowIcon()}
         ></FontAwesomeIcon>
       </div>
-      {!isTopPosition() ? props.children : ''}
+      {isFlyoutOpen && !isTopPosition() ? props.children : ''}
     </div>
   )
 }

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -1,68 +1,24 @@
 import "./flyout.css"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCircleArrowDown, faCircleArrowUp, IconDefinition } from "@fortawesome/free-solid-svg-icons"
-import { useEffect, useState } from "react"
 import { handleGetTheme } from "./main2worker"
 import { UI_THEME } from "../common/utility"
 
 const Flyout = (props: {
   icon: IconDefinition,
-  minWidth: number,
+  buttonId?: string,
   position: string,
+  isOpen: () => boolean | undefined,
+  onClick: () => void | undefined
   children: any
 }) => {
-  const isFlyoutOpenDefault = () => {
-    return props.minWidth < window.innerWidth
-  }
-
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(isFlyoutOpenDefault())
   const className = `flyout-${props.position}`
+  const isFlyoutOpen = props.isOpen && props.isOpen()
+  const isMinimalTheme = handleGetTheme() == UI_THEME.MINIMAL
 
   const isTopPosition = () => {
     return props.position.search('top') >= 0
   }
-
-  const handleResizeImmediate = (newIsFlyoutOpen: boolean) => {
-    const panel = document.getElementsByClassName(className)[0] as HTMLElement
-    const isMinimalTheme = handleGetTheme() == UI_THEME.MINIMAL
-
-    if (isMinimalTheme) {
-      if (newIsFlyoutOpen) {
-        panel.style.width = 'auto'
-        panel.style.opacity = '100%'
-      } else {
-        panel.style.width = '80px'
-        panel.style.opacity = '33%'
-
-        const hiddenText = document.getElementsByClassName('hidden-textarea')[0] as HTMLElement
-        if (hiddenText) {
-          hiddenText.focus()
-        }
-      }
-    } else {
-      panel.style.width = 'auto'
-      panel.style.opacity = '100%'
-      setIsFlyoutOpen(isFlyoutOpenDefault())
-    }
-
-    if (isTopPosition()) {
-      panel.style.top = '0px'
-    } else {
-      panel.style.bottom = '0px'
-    }
-  }
-
-  const handleResize = () => {
-    handleResizeImmediate(isFlyoutOpen)
-  }
-
-  useEffect(() => {
-    window.addEventListener('resize', handleResize)
-    handleResize()
-    return () => {
-      window.removeEventListener('resize', handleResize)
-    };
-  }, []);
 
   const getArrowIcon = (): IconDefinition => {
     if (isFlyoutOpen) {
@@ -73,14 +29,25 @@ const Flyout = (props: {
   }
 
   return (
-    <div className={`flyout ${className}`}>
-      {isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ''}
-      <div className="flyout-button" onClick={() => {
-        handleResizeImmediate(!isFlyoutOpen)
-        setIsFlyoutOpen(!isFlyoutOpen)
+    <div
+      className={`flyout ${className}`}
+      style={{
+        width: isMinimalTheme && !isFlyoutOpen ? '72px' : 'auto',
+        opacity: isMinimalTheme && !isFlyoutOpen ? '33%' : '100%'
       }}>
-        <FontAwesomeIcon icon={getArrowIcon()}
-        ></FontAwesomeIcon>
+      {isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ''}
+      <div
+        id={props.buttonId ?? ''}
+        className="flyout-button"
+        onClick={() => {
+          props.onClick && props.onClick()
+
+          // const hiddenText = document.getElementsByClassName('hidden-textarea')[0] as HTMLElement
+          // if (hiddenText) {
+          //   hiddenText.focus()
+          // }
+        }}>
+        <FontAwesomeIcon icon={getArrowIcon()}></FontAwesomeIcon>
       </div>
       {!isTopPosition() && (isFlyoutOpen || handleGetTheme() != UI_THEME.MINIMAL) ? props.children : ''}
     </div>

--- a/src/ui/inputparams.ts
+++ b/src/ui/inputparams.ts
@@ -1,8 +1,8 @@
 import { handleSetDiskFromURL, setDefaultBinaryAddress } from "./devices/driveprops"
 import { audioEnable } from "./devices/speaker"
-import { COLOR_MODE } from "../common/utility"
+import { COLOR_MODE, UI_THEME } from "../common/utility"
 import { useGlobalContext } from "./globalcontext"
-import { passCapsLock, passSetDebug, passSpeedMode, passColorMode, passSetRamWorks, passDarkMode, passPasteText, passShowScanlines } from "./main2worker"
+import { passCapsLock, passSetDebug, passSpeedMode, passColorMode, passSetRamWorks, passTheme, passPasteText, passShowScanlines } from "./main2worker"
 
 export type HandleInputParamsResult = {
   hasBasicProgram: boolean
@@ -67,8 +67,21 @@ export const handleInputParams = (): HandleInputParamsResult => {
     }
   }
 
-  if (params.get("theme") === "dark") {
-    passDarkMode(true)
+  const theme = params.get("theme")
+  if (theme) {
+    switch (theme.toLocaleLowerCase()) {
+      case 'classic':
+        passTheme(UI_THEME.CLASSIC)
+        break
+
+      case 'dark':
+        passTheme(UI_THEME.DARK)
+        break
+
+      case 'minimal':
+        passTheme(UI_THEME.MINIMAL)
+        break
+    }
   }
 
   const address = params.get("address")
@@ -85,9 +98,7 @@ export const handleInputParams = (): HandleInputParamsResult => {
   if (experiments) {
     experiments.split(',').forEach((experiment) => {
       switch (experiment) {
-        case 'pwafs':
-          result.experiments.push(experiment.toLowerCase())
-          break
+        // Experiments go here
       }
     });
   }

--- a/src/ui/inputparams.ts
+++ b/src/ui/inputparams.ts
@@ -17,7 +17,7 @@ export const handleInputParams = (): HandleInputParamsResult => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { setRunTour } = useGlobalContext()
 
-  let result: HandleInputParamsResult = {
+  const result: HandleInputParamsResult = {
     hasBasicProgram: false,
     experiments: []
   }
@@ -70,15 +70,15 @@ export const handleInputParams = (): HandleInputParamsResult => {
   const theme = params.get("theme")
   if (theme) {
     switch (theme.toLocaleLowerCase()) {
-      case 'classic':
+      case "classic":
         passTheme(UI_THEME.CLASSIC)
         break
 
-      case 'dark':
+      case "dark":
         passTheme(UI_THEME.DARK)
         break
 
-      case 'minimal':
+      case "minimal":
         passTheme(UI_THEME.MINIMAL)
         break
     }
@@ -94,13 +94,9 @@ export const handleInputParams = (): HandleInputParamsResult => {
     setRunTour(tour)
   }
 
-  const experiments = params.get('exp')
+  const experiments = params.get("exp")
   if (experiments) {
-    experiments.split(',').forEach((experiment) => {
-      switch (experiment) {
-        // Experiments go here
-      }
-    });
+    // Experiments go here
   }
 
   const run = params.get("run")

--- a/src/ui/inputparams.ts
+++ b/src/ui/inputparams.ts
@@ -4,13 +4,23 @@ import { COLOR_MODE } from "../common/utility"
 import { useGlobalContext } from "./globalcontext"
 import { passCapsLock, passSetDebug, passSpeedMode, passColorMode, passSetRamWorks, passDarkMode, passPasteText, passShowScanlines } from "./main2worker"
 
-export const handleInputParams = () => {
+export type HandleInputParamsResult = {
+  hasBasicProgram: boolean
+  experiments: string[]
+}
+
+export const handleInputParams = (): HandleInputParamsResult => {
   // Most parameters are case insensitive. The only exception is the BASIC
   // parameter, where we want to preserve the case of the program.
   const params = new URLSearchParams(window.location.search.toLowerCase())
   const porig = new URLSearchParams(window.location.search)
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { setRunTour } = useGlobalContext()
+
+  let result: HandleInputParamsResult = {
+    hasBasicProgram: false,
+    experiments: []
+  }
 
   if (params.get("capslock") === "off") {
     passCapsLock(false)
@@ -71,11 +81,22 @@ export const handleInputParams = () => {
     setRunTour(tour)
   }
 
+  const experiments = params.get('exp')
+  if (experiments) {
+    experiments.split(',').forEach((experiment) => {
+      switch (experiment) {
+        case 'pwafs':
+          result.experiments.push(experiment.toLowerCase())
+          break
+      }
+    });
+  }
+
   const run = params.get("run")
   const doRun = !(run === "0" || run === "false")
   // Use the original case of the BASIC program.
   const basic = porig.get("basic") || porig.get("BASIC")
-  const hasBasicProgram = basic !== null
+  result.hasBasicProgram = basic !== null
   if (basic) {
     const trimmed = basic.trim()
     const hasLineNumbers = /^[0-9]/.test(trimmed) || /[\n\r][0-9]/.test(trimmed)
@@ -84,7 +105,7 @@ export const handleInputParams = () => {
     setTimeout(() => { passPasteText(basic + cmd) }, 1500)
   }
 
-  return hasBasicProgram
+  return result
 }
 
 // Examples:

--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -1,7 +1,6 @@
 import { changeMockingboardMode } from "./devices/mockingboard_audio"
-import { COLOR_MODE } from "../common/utility"
-import { passCapsLock, passColorMode, passShowScanlines, passDarkMode, passSetDebug, passSetMachineName, passSetRamWorks, passSpeedMode } from "./main2worker"
-
+import { COLOR_MODE, UI_THEME } from "../common/utility"
+import { passCapsLock, passColorMode, passShowScanlines, passTheme, passSetDebug, passSetMachineName, passSetRamWorks, passSpeedMode } from "./main2worker"
 
 export const setPreferenceCapsLock = (mode = true) => {
   if (mode === true) {
@@ -30,13 +29,13 @@ export const setPreferenceShowScanlines = (mode = true) => {
   passShowScanlines(mode)
 }
 
-export const setPreferenceDarkMode = (mode = false) => {
-  if (mode === false) {
-    localStorage.removeItem("darkMode")
+export const setPreferenceTheme = (theme: UI_THEME = UI_THEME.CLASSIC) => {
+  if (theme === UI_THEME.CLASSIC) {
+    localStorage.removeItem("theme")
   } else {
-    localStorage.setItem("darkMode", JSON.stringify(mode))
+    localStorage.setItem("theme", JSON.stringify(theme))
   }
-  passDarkMode(mode)
+  passTheme(theme)
 }
 
 export const setPreferenceDebugMode = (mode = false) => {
@@ -112,12 +111,24 @@ export const loadPreferences = () => {
     }
   }
 
+  // Keep for backwards-compatibility
   const darkMode = localStorage.getItem("darkMode")
   if (darkMode) {
     try {
-      passDarkMode(JSON.parse(darkMode))
+      if (JSON.parse(darkMode)) {
+        passTheme(UI_THEME.DARK)
+      }
     } catch {
-      localStorage.removeItem("darkMode")
+    }
+    localStorage.removeItem("darkMode")
+  }
+
+  const theme = localStorage.getItem("theme")
+  if (theme) {
+    try {
+      passTheme(JSON.parse(theme))
+    } catch {
+      localStorage.removeItem("theme")
     }
   }
 
@@ -172,7 +183,7 @@ export const resetPreferences = () => {
   setPreferenceCapsLock()
   setPreferenceColorMode()
   setPreferenceShowScanlines()
-  setPreferenceDarkMode()
+  setPreferenceTheme()
   setPreferenceMockingboardMode()
   setPreferenceMachineName()
   setPreferenceRamWorks()

--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -119,6 +119,7 @@ export const loadPreferences = () => {
         passTheme(UI_THEME.DARK)
       }
     } catch {
+      localStorage.removeItem("darkMode")
     }
     localStorage.removeItem("darkMode")
   }

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -1,4 +1,4 @@
-import { RUN_MODE, DRIVE, MSG_WORKER, MSG_MAIN, MouseEventSimple, default6502State, COLOR_MODE, TEST_DEBUG } from "../common/utility"
+import { RUN_MODE, DRIVE, MSG_WORKER, MSG_MAIN, MouseEventSimple, default6502State, COLOR_MODE, TEST_DEBUG, UI_THEME } from "../common/utility"
 import { clickSpeaker, emulatorSoundEnable } from "./devices/speaker"
 import { startupTextPage } from "./panels/startuptextpage"
 import { doRumble } from "./devices/gamepad"
@@ -81,9 +81,9 @@ export const passCapsLock = (lock: boolean) => {
   machineState.capsLock = lock
 }
 
-export const passDarkMode = (mode: boolean) => {
+export const passTheme = (theme: UI_THEME) => {
   // See comment under passColorMode
-  machineState.darkMode = mode
+  machineState.theme = theme
 }
 
 export const passArrowKeysAsJoystick = (joystick: boolean) => {
@@ -223,7 +223,7 @@ let machineState: MachineState = {
   showScanlines: false,
   cout: 0,
   cpuSpeed: 0,
-  darkMode: false,
+  theme: UI_THEME.CLASSIC,
   disassembly: "",
   extraRamSize: 64,
   helpText: "",
@@ -259,7 +259,7 @@ export const doOnMessage = (e: MessageEvent): {speed: number, helptext: string} 
       newState.colorMode = machineState.colorMode
       newState.showScanlines = machineState.showScanlines
       newState.capsLock = machineState.capsLock
-      newState.darkMode = machineState.darkMode
+      newState.theme = machineState.theme
       newState.helpText = machineState.helpText
       newState.useOpenAppleKey = machineState.useOpenAppleKey
       machineState = newState
@@ -459,8 +459,8 @@ export const handleGetCapsLock = () => {
   return machineState.capsLock
 }
 
-export const handleGetDarkMode = () => {
-  return machineState.darkMode
+export const handleGetTheme = () => {
+  return machineState.theme
 }
 
 export const handleGetArrowKeysAsJoystick = () => {

--- a/src/ui/panels/debugsection.css
+++ b/src/ui/panels/debugsection.css
@@ -1,12 +1,3 @@
-@scope (.theme-minimal) {
-  .debug-section {
-    max-width: 90cqw;
-    max-height: 90cqh;
-    overflow-x: auto;
-    overflow-y: auto;
-  }
-}
-
 .hex-field {
   font-family: monospace;
   font-size: 10pt;
@@ -511,4 +502,13 @@ body.dark-mode .memory-map td {
 
 body.dark-mode .icon-text {
   color: var(--text-color);
+}
+
+@scope (.theme-minimal) {
+  .debug-section {
+    max-width: 85cqw;
+    max-height: 75cqh;
+    overflow-x: auto;
+    overflow-y: auto;
+  }
 }

--- a/src/ui/panels/debugsection.css
+++ b/src/ui/panels/debugsection.css
@@ -1,3 +1,12 @@
+@scope (.theme-minimal) {
+  .debug-section {
+    max-width: 90cqw;
+    max-height: 90cqh;
+    overflow-x: auto;
+    overflow-y: auto;
+  }
+}
+
 .hex-field {
   font-family: monospace;
   font-size: 10pt;
@@ -432,9 +441,11 @@ body.dark-mode .memtable-highlight {
   0% {
     background-color: var(--highlight);
   }
+
   50% {
     background-color: var(--highlight);
   }
+
   100% {
     background-color: initial;
   }
@@ -444,9 +455,11 @@ body.dark-mode .memtable-highlight {
   0% {
     background-color: var(--highlight-dark);
   }
+
   50% {
     background-color: var(--highlight-dark);
   }
+
   100% {
     background-color: initial;
   }

--- a/src/ui/panels/debugsection.css
+++ b/src/ui/panels/debugsection.css
@@ -506,7 +506,7 @@ body.dark-mode .icon-text {
 
 @scope (.theme-minimal) {
   .debug-section {
-    max-width: 50cqw;
+    max-width: 50vw;
     max-height: 75cqh;
     overflow-x: auto;
     overflow-y: auto;

--- a/src/ui/panels/debugsection.css
+++ b/src/ui/panels/debugsection.css
@@ -506,7 +506,7 @@ body.dark-mode .icon-text {
 
 @scope (.theme-minimal) {
   .debug-section {
-    max-width: 85cqw;
+    max-width: 50cqw;
     max-height: 75cqh;
     overflow-x: auto;
     overflow-y: auto;

--- a/src/ui/panels/debugsection.tsx
+++ b/src/ui/panels/debugsection.tsx
@@ -19,7 +19,7 @@ const DebugSection = () => {
       position="bottom-right"
       isOpen={handleGetIsDebugging}
       onClick={() => setPreferenceDebugMode(!handleGetIsDebugging())}
-      buttonId={handleGetTheme() == UI_THEME.MINIMAL ? 'tour-debug-button' : ''}>
+      buttonId={handleGetTheme() == UI_THEME.MINIMAL ? "tour-debug-button" : ""}>
       <div className="flex-column-gap debug-section">
         <State6502Controls />
         <div className="flex-row-gap">

--- a/src/ui/panels/debugsection.tsx
+++ b/src/ui/panels/debugsection.tsx
@@ -6,26 +6,38 @@ import MemoryDump from "./memorydump"
 import BreakpointsView from "./breakpointsview"
 import MemoryMap from "./memorymap"
 import StackDump from "./stackdump"
+import Flyout from "../flyout"
+import { faBug } from "@fortawesome/free-solid-svg-icons"
+import { handleGetIsDebugging, handleGetTheme } from "../main2worker"
+import { UI_THEME } from "../../common/utility"
+import { setPreferenceDebugMode } from "../localstorage"
 
 const DebugSection = () => {
   return (
-    <div className="flex-column-gap">
-      <State6502Controls />
-      <div className="flex-row-gap">
-        <DisassemblyPanel />
-        <div className="flex-column-gap">
-          <div className="flex-row-gap round-rect-border"  id="tour-debug-info">
-            <StackDump />
-            <MemoryMap />
+    <Flyout
+      icon={faBug}
+      position="bottom-right"
+      isOpen={handleGetIsDebugging}
+      onClick={() => setPreferenceDebugMode(!handleGetIsDebugging())}
+      buttonId={handleGetTheme() == UI_THEME.MINIMAL ? 'tour-debug-button' : ''}>
+      <div className="flex-column-gap debug-section">
+        <State6502Controls />
+        <div className="flex-row-gap">
+          <DisassemblyPanel />
+          <div className="flex-column-gap">
+            <div className="flex-row-gap round-rect-border" id="tour-debug-info">
+              <StackDump />
+              <MemoryMap />
+            </div>
+            <MemoryDump />
           </div>
-          <MemoryDump />
+        </div>
+        <div className="flex-row-gap">
+          <BreakpointsView />
+          <TimeTravelPanel />
         </div>
       </div>
-      <div className="flex-row-gap">
-        <BreakpointsView />
-        <TimeTravelPanel />
-      </div>
-    </div>
+    </Flyout>
   )
 }
 

--- a/src/ui/panels/defaulthelptext.ts
+++ b/src/ui/panels/defaulthelptext.ts
@@ -58,7 +58,7 @@ run=false (do not run BASIC program)
 scanlines=on
 sound=off
 speed=fast|warp
-theme=dark
+theme=classic|dark|minimal
 tour=main|debug|settings
 #urltodiskimage
 

--- a/src/ui/panels/helppanel.css
+++ b/src/ui/panels/helppanel.css
@@ -10,6 +10,10 @@
   max-width: 600px;
 }
 
+@scope (.pwafs) {
+  .help-parent {}
+}
+
 .help-paper {
   position: relative;
   background-color: #f0f0f0;

--- a/src/ui/panels/helppanel.css
+++ b/src/ui/panels/helppanel.css
@@ -11,6 +11,15 @@
 }
 
 @scope (.theme-minimal) {
+  .help-parent {
+    max-width: 75cqw;
+    max-height: 75cqh;
+    overflow-x: auto;
+    overflow-y: auto;
+  }
+}
+
+@scope (.theme-minimal) {
   .help-parent {}
 }
 

--- a/src/ui/panels/helppanel.css
+++ b/src/ui/panels/helppanel.css
@@ -10,7 +10,7 @@
   max-width: 600px;
 }
 
-@scope (.pwafs) {
+@scope (.theme-minimal) {
   .help-parent {}
 }
 

--- a/src/ui/panels/helppanel.css
+++ b/src/ui/panels/helppanel.css
@@ -10,19 +10,6 @@
   max-width: 600px;
 }
 
-@scope (.theme-minimal) {
-  .help-parent {
-    max-width: 75cqw;
-    max-height: 75cqh;
-    overflow-x: auto;
-    overflow-y: auto;
-  }
-}
-
-@scope (.theme-minimal) {
-  .help-parent {}
-}
-
 .help-paper {
   position: relative;
   background-color: #f0f0f0;
@@ -72,4 +59,18 @@
   margin: 10px;
   padding: 5px;
   color: #00FF00;
+}
+
+@scope (.theme-minimal) {
+  .help-section {
+    max-width: 70vw;
+    max-height: 80vh;
+    overflow: auto;
+  }
+
+  .help-parent {
+    width: 100%;
+    height: 100%;
+    max-width: unset;
+  }
 }

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -19,7 +19,7 @@ const HelpPanel = React.memo((props: HelpPanelProps) => {
   const helpText = (props.helptext.length > 1 && props.helptext !== "<Default>") ? props.helptext : defaultHelpText
   const isDarkMode = handleGetTheme() == UI_THEME.DARK
   return (
-    <Flyout icon={faNoteSticky} minWidth={2160} position="top-right">
+    <Flyout icon={faNoteSticky} position="top-right">
       <div className="help-parent"
         style={{
           width: props.narrow ? "" : 500, height:

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { handleGetDarkMode } from "../main2worker"
 import "./helppanel.css"
 import { defaultHelpText } from "./defaulthelptext"
+import Flyout from "../flyout"
+import { faNoteSticky } from "@fortawesome/free-solid-svg-icons"
 
 type HelpPanelProps = {
   narrow: boolean,
@@ -15,16 +17,20 @@ const HelpPanel = React.memo((props: HelpPanelProps) => {
   const height = window.innerHeight ? window.innerHeight - 170 : (window.outerHeight - 170)
   const helpText = (props.helptext.length > 1 && props.helptext !== "<Default>") ? props.helptext : defaultHelpText
   return (
-    <div className="help-parent"
-      style={{width: props.narrow ? "" : 500, height:
-        props.narrow ? "" : height,
-        overflow: (props.narrow ? "visible" : "auto")}}>
-      <div className={handleGetDarkMode() ? "" : "help-paper"}>
-        <pre className={"help-text " + (handleGetDarkMode() ? "help-text-dark" : "help-text-light")}
-          dangerouslySetInnerHTML={{ __html: helpText }}>
-        </pre>
+    <Flyout icon={faNoteSticky} width="auto" position="top-right">
+      <div className="help-parent"
+        style={{
+          width: props.narrow ? "" : 500, height:
+            props.narrow ? "" : height,
+          overflow: (props.narrow ? "visible" : "auto")
+        }}>
+        <div className={handleGetDarkMode() ? "" : "help-paper"}>
+          <pre className={"help-text " + (handleGetDarkMode() ? "help-text-dark" : "help-text-light")}
+            dangerouslySetInnerHTML={{ __html: helpText }}>
+          </pre>
+        </div>
       </div>
-    </div>
+    </Flyout>
   )
 }, (prevProps, nextProps) => {
   return prevProps.helptext === nextProps.helptext

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { handleGetTheme } from "../main2worker"
 import "./helppanel.css"
 import { defaultHelpText } from "./defaulthelptext"
@@ -15,21 +15,30 @@ type HelpPanelProps = {
 // It was re-rendering on every machine state update, which was ridiculous.
 // Now it only re-renders when the help text changes.
 const HelpPanel = React.memo((props: HelpPanelProps) => {
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
   const height = window.innerHeight ? window.innerHeight - 170 : (window.outerHeight - 170)
   const helpText = (props.helptext.length > 1 && props.helptext !== "<Default>") ? props.helptext : defaultHelpText
   const isDarkMode = handleGetTheme() == UI_THEME.DARK
+  const isMinimalTheme = handleGetTheme() == UI_THEME.MINIMAL
+
   return (
-    <Flyout icon={faNoteSticky} position="top-right">
-      <div className="help-parent"
-        style={{
-          width: props.narrow ? "" : 500, height:
-            props.narrow ? "" : height,
-          overflow: (props.narrow ? "visible" : "auto")
-        }}>
-        <div className={isDarkMode ? "" : "help-paper"}>
-          <pre className={"help-text " + (isDarkMode ? "help-text-dark" : "help-text-light")}
-            dangerouslySetInnerHTML={{ __html: helpText }}>
-          </pre>
+    <Flyout
+      icon={faNoteSticky}
+      isOpen={() => { return isFlyoutOpen }}
+      onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
+      position="top-right">
+      <div className="help-section">
+        <div className="help-parent"
+          style={{
+            width: props.narrow || isMinimalTheme ? "" : 500, height:
+              props.narrow || isMinimalTheme ? "" : height,
+            overflow: (props.narrow ? "visible" : "auto")
+          }}>
+          <div className={isDarkMode ? "" : "help-paper"}>
+            <pre className={"help-text " + (isDarkMode ? "help-text-dark" : "help-text-light")}
+              dangerouslySetInnerHTML={{ __html: helpText }}>
+            </pre>
+          </div>
         </div>
       </div>
     </Flyout>

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -1,9 +1,10 @@
 import React from "react"
-import { handleGetDarkMode } from "../main2worker"
+import { handleGetTheme } from "../main2worker"
 import "./helppanel.css"
 import { defaultHelpText } from "./defaulthelptext"
 import Flyout from "../flyout"
 import { faNoteSticky } from "@fortawesome/free-solid-svg-icons"
+import { UI_THEME } from "../../common/utility"
 
 type HelpPanelProps = {
   narrow: boolean,
@@ -16,16 +17,17 @@ type HelpPanelProps = {
 const HelpPanel = React.memo((props: HelpPanelProps) => {
   const height = window.innerHeight ? window.innerHeight - 170 : (window.outerHeight - 170)
   const helpText = (props.helptext.length > 1 && props.helptext !== "<Default>") ? props.helptext : defaultHelpText
+  const isDarkMode = handleGetTheme() == UI_THEME.DARK
   return (
-    <Flyout icon={faNoteSticky} minWidth={4096} position="top-right">
+    <Flyout icon={faNoteSticky} minWidth={2160} position="top-right">
       <div className="help-parent"
         style={{
           width: props.narrow ? "" : 500, height:
             props.narrow ? "" : height,
           overflow: (props.narrow ? "visible" : "auto")
         }}>
-        <div className={handleGetDarkMode() ? "" : "help-paper"}>
-          <pre className={"help-text " + (handleGetDarkMode() ? "help-text-dark" : "help-text-light")}
+        <div className={isDarkMode ? "" : "help-paper"}>
+          <pre className={"help-text " + (isDarkMode ? "help-text-dark" : "help-text-light")}
             dangerouslySetInnerHTML={{ __html: helpText }}>
           </pre>
         </div>

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -17,7 +17,7 @@ const HelpPanel = React.memo((props: HelpPanelProps) => {
   const height = window.innerHeight ? window.innerHeight - 170 : (window.outerHeight - 170)
   const helpText = (props.helptext.length > 1 && props.helptext !== "<Default>") ? props.helptext : defaultHelpText
   return (
-    <Flyout icon={faNoteSticky} width="auto" position="top-right">
+    <Flyout icon={faNoteSticky} minWidth={4096} position="top-right">
       <div className="help-parent"
         style={{
           width: props.narrow ? "" : 500, height:

--- a/src/ui/panels/memorytable.tsx
+++ b/src/ui/panels/memorytable.tsx
@@ -1,7 +1,8 @@
 import { useRef } from "react"
-import { hiresLineToAddress, toHex } from "../../common/utility"
+import { hiresLineToAddress, toHex, UI_THEME } from "../../common/utility"
 import { useGlobalContext } from "../globalcontext"
 import { nColsHgrMagnifier, nRowsHgrMagnifier } from "../graphics"
+import { handleGetTheme } from "../main2worker"
 
 type MemoryTableProps = {
   memory: Uint8Array
@@ -308,11 +309,11 @@ const MemoryTable = (props: MemoryTableProps) => {
   }
 
   const applyHighlightAnimation = (element: HTMLElement) => {
-    const isDarkMode = document.body.classList.contains("dark-mode")
+    const isDarkMode = handleGetTheme() == UI_THEME.DARK
     const animationName = isDarkMode ? "highlight-anim-dark" : "highlight-anim"
     element.style.animation = `${animationName} 1s 0.1s`
   }
-  
+
   // This scrolling code is used by the higher-level MemoryDump component to
   // scroll to a specific row when the address field is changed.
   if (props.scrollRow >= 0) {

--- a/src/ui/tours/tourmain.tsx
+++ b/src/ui/tours/tourmain.tsx
@@ -28,6 +28,10 @@ export const tourMain: Step[] = [
     content: "You can save and restore the complete state of the emulator using these buttons.",
   },
   {
+    target: "#tour-theme-button",
+    content: "Click there to change the emulator UI theme."
+  },
+  {
     target: "body",
     placement: "center",
     content: "You have reached the end of the tour. Click on the globe " +

--- a/src/ui/tours/tourmain.tsx
+++ b/src/ui/tours/tourmain.tsx
@@ -29,7 +29,7 @@ export const tourMain: Step[] = [
   },
   {
     target: "#tour-theme-button",
-    content: "Click there to change the emulator UI theme."
+    content: "Click here to change the emulator UI theme."
   },
   {
     target: "body",

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -2,7 +2,7 @@
 import { Buffer } from "buffer"
 import { passMachineState, passRequestThumbnail, passSoftSwitchDescriptions } from "./worker2main"
 import { s6502, setState6502, reset6502, setCycleCount, setPC, getStackString, getStackDump, setStackDump } from "./instructions"
-import { COLOR_MODE, MAX_SNAPSHOTS, RUN_MODE, RamWorksMemoryStart, TEST_DEBUG } from "../common/utility"
+import { COLOR_MODE, MAX_SNAPSHOTS, RUN_MODE, RamWorksMemoryStart, TEST_DEBUG, UI_THEME } from "../common/utility"
 import { getDriveSaveState, restoreDriveSaveState, resetDrive, doPauseDrive, getHardDriveState } from "./devices/drivestate"
 // import { slot_omni } from "./roms/slot_omni_cx00"
 import { SWITCHES, overrideSoftSwitch, resetSoftSwitches,
@@ -590,7 +590,7 @@ const updateExternalMachineState = () => {
     showScanlines: false,
     cout: memGet(0x0039) << 8 | memGet(0x0038),
     cpuSpeed: cpuSpeed,
-    darkMode: false,  // ignored by main thread
+    theme: UI_THEME.CLASSIC,  // ignored by main thread
     disassembly: doGetDisassembly(),
     extraRamSize: 64 * (RamWorksMaxBank + 1),
     helpText: "",  // ignored by main thread

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import react from "@vitejs/plugin-react-swc"
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
     port: 6502,
   },
   build: {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/99287ae1-18a4-4957-989c-48441fd0fb9a)
![image](https://github.com/user-attachments/assets/b1f7c3c0-6031-47b8-bf6c-beeed8ef630b)
![image](https://github.com/user-attachments/assets/c5f163b5-7161-46d1-b6b2-6fbe0986ab46)

**Changes Made:**
- Replaced "Dark Mode" control button with "Themes" dropdown
- Created three themes: Classic, Dark, and Minimal
- Created Minimal theme which moves all existing UI to flyout panels
- Updated canvas resize logic to center canvas in Minimal theme or right-align it to the debug flyout
- Moved ImageWriter to `diskinterface.tsx` to include in the Minimal theme drives flyout
- Added new "Themes" tour step to Main tour
- Created new flyout component which can be wrapped an existing UI to turn it into a flyout
- Added query string param `themes` to enable theme switching via URL
- Added code to convert existing `Dark Mode` setting to the new Dark theme for backwards compatibility

**Tests Performed:**
- Tested all themes on multiple devices and OSes: Windows PC, Mac, iPad, iPhone
- Verified new features of `Minimal` theme work as expected

**Issues Resolved:**
- Implemented issue #118 