### PR TITLE
Read/write disk images and hot reload feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@types/react-dom": "^19.0.2",
         "@types/react-fontawesome": "^1.6.8",
         "@types/w3c-web-serial": "^1.0.7",
-        "@types/wicg-file-system-access": "^2023.10.5",
         "@vitejs/plugin-react-swc": "^3.7.2",
         "eslint": "^9.20.1",
         "eslint-plugin-react": "^7.37.4",
@@ -2612,13 +2611,6 @@
       "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.7.tgz",
       "integrity": "sha512-jzcwm//EZ0Z306L1/O1GXC3GthRd//9eaNB4/Yagm98UjEQViTzDS8bYvL+y+rTk1r9OFt9Yhp5pprUQFzSiiQ==",
       "dev": true
-    },
-    "node_modules/@types/wicg-file-system-access": {
-      "version": "2023.10.5",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2023.10.5.tgz",
-      "integrity": "sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/react-dom": "^19.0.2",
         "@types/react-fontawesome": "^1.6.8",
         "@types/w3c-web-serial": "^1.0.7",
+        "@types/wicg-file-system-access": "^2023.10.5",
         "@vitejs/plugin-react-swc": "^3.7.2",
         "eslint": "^9.20.1",
         "eslint-plugin-react": "^7.37.4",
@@ -2611,6 +2612,13 @@
       "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.7.tgz",
       "integrity": "sha512-jzcwm//EZ0Z306L1/O1GXC3GthRd//9eaNB4/Yagm98UjEQViTzDS8bYvL+y+rTk1r9OFt9Yhp5pprUQFzSiiQ==",
       "dev": true
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2023.10.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2023.10.5.tgz",
+      "integrity": "sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/react-dom": "^19.0.2",
     "@types/react-fontawesome": "^1.6.8",
     "@types/w3c-web-serial": "^1.0.7",
+    "@types/wicg-file-system-access": "^2023.10.5",
     "@vitejs/plugin-react-swc": "^3.7.2",
     "eslint": "^9.20.1",
     "eslint-plugin-react": "^7.37.4",

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -150,7 +150,8 @@ type DriveState = {
   maxHalftrack: number,
   lastWriteTime: number,
   cloudData: CloudData | null,
-  writableFileHandle: FileSystemFileHandle | null
+  writableFileHandle: FileSystemFileHandle | null,
+  lastLocalWriteTime: number
 }
 
 type DriveProps = {
@@ -165,7 +166,8 @@ type DriveProps = {
   diskData: Uint8Array,
   lastWriteTime: number,
   cloudData: CloudData | null,
-  writableFileHandle: FileSystemFileHandle | null
+  writableFileHandle: FileSystemFileHandle | null,
+  lastLocalWriteTime: number
 }
 
 type DriveSaveState = {

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -150,7 +150,8 @@ type DriveState = {
   trackLocation: number,
   maxHalftrack: number,
   lastWriteTime: number,
-  cloudData: CloudData | null
+  cloudData: CloudData | null,
+  writableFileHandle: FileSystemFileHandle | null
 }
 
 type DriveProps = {
@@ -164,7 +165,8 @@ type DriveProps = {
   isWriteProtected: boolean,
   diskData: Uint8Array,
   lastWriteTime: number,
-  cloudData: CloudData | null
+  cloudData: CloudData | null,
+  writableFileHandle: FileSystemFileHandle | null
 }
 
 type DriveSaveState = {

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -110,6 +110,7 @@ type MachineState = {
   textPage: Uint8Array,
   timeTravelThumbnails: Array<TimeTravelThumbnail>,
   useOpenAppleKey: boolean,
+  hotReload: boolean
 }
 
 type CloudData = {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -451,3 +451,7 @@ export const handleSetTheme = (theme: UI_THEME) => {
     document.documentElement.classList.remove("theme-minimal")
   }
 }
+
+export const isFileSystemApiSupported = () => {
+  return "showOpenFilePicker" in self && "showSaveFilePicker" in self
+}

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -7,6 +7,8 @@ export const FLOPPY_DISK_SUFFIXES = ".a2ts,.dsk,.woz,.do,.bin,.a,.bas"
 export const HARD_DRIVE_SUFFIXES = ".2mg,.hdv,.po"
 export const FILE_SUFFIXES = `${FLOPPY_DISK_SUFFIXES},${HARD_DRIVE_SUFFIXES}`
 export const MAX_DRIVES = 4
+export const DISK_CONVERSION_SUFFIXES = new Map<string, string>([
+  [".dsk", ".woz"]]);
 
 // Put memory offset constants here so we can use them in the worker and main thread.
 // We used to have these in the memory.ts file, but when we imported that into

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -7,8 +7,7 @@ export const FLOPPY_DISK_SUFFIXES = ".a2ts,.dsk,.woz,.do,.bin,.a,.bas"
 export const HARD_DRIVE_SUFFIXES = ".2mg,.hdv,.po"
 export const FILE_SUFFIXES = `${FLOPPY_DISK_SUFFIXES},${HARD_DRIVE_SUFFIXES}`
 export const MAX_DRIVES = 4
-export const DISK_CONVERSION_SUFFIXES = new Map<string, string>([
-  [".dsk", ".woz"]]);
+export const DISK_CONVERSION_SUFFIXES = new Map<string, string>([[".dsk", ".woz"]])
 
 // Put memory offset constants here so we can use them in the worker and main thread.
 // We used to have these in the memory.ts file, but when we imported that into

--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -19,7 +19,7 @@ const ControlPanel = (props: DisplayProps) => {
       <span className="flex-column">
         <span className="flex-row wrap" id="tour-controlbuttons">
           <ControlButtons {...props} />
-          <DebugButtons />
+          <DebugButtons {...props} />
           <FullScreenButton />
         </span>
         <ConfigButtons {...props} />

--- a/src/ui/controls/debugbuttons.tsx
+++ b/src/ui/controls/debugbuttons.tsx
@@ -2,13 +2,16 @@ import { RUN_MODE, UI_THEME } from "../../common/utility"
 import {
   passGoBackInTime, passGoForwardInTime,
   handleCanGoBackward, handleCanGoForward, passTimeTravelSnapshot, handleGetIsDebugging, handleGetRunMode,
-  handleGetTheme
+  handleGetTheme,
+  handleGetHotReload
 } from "../main2worker"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
   faBug,
   faBugSlash,
   faCamera,
+  faEye,
+  faEyeSlash,
   faFastBackward,
   faFastForward,
   faLayerGroup,
@@ -17,9 +20,9 @@ import {
 } from "@fortawesome/free-solid-svg-icons"
 import { handleSetCPUState } from "../controller"
 import { handleFileSave } from "../savestate"
-import { setPreferenceDebugMode } from "../localstorage"
+import { setPreferenceDebugMode, setPreferenceHotReload } from "../localstorage"
 
-const DebugButtons = () => {
+const DebugButtons = (props: DisplayProps) => {
   const runMode = handleGetRunMode()
   const notStarted = runMode === RUN_MODE.IDLE || runMode === RUN_MODE.NEED_BOOT
   return <span className="flex-row">
@@ -66,6 +69,14 @@ const DebugButtons = () => {
         onClick={() => setPreferenceDebugMode(!handleGetIsDebugging())}>
         <FontAwesomeIcon icon={handleGetIsDebugging() ? faBug : faBugSlash} />
       </button>}
+    <button className="push-button"
+      title={handleGetHotReload() ? "Hot Reload Enabled" : "Hot Reload Disabled"}
+      onClick={() => {
+        setPreferenceHotReload(!handleGetHotReload())
+        props.updateDisplay()
+      }}>
+      <FontAwesomeIcon icon={handleGetHotReload() ? faEye : faEyeSlash} />
+    </button>
   </span>
 }
 

--- a/src/ui/controls/debugbuttons.tsx
+++ b/src/ui/controls/debugbuttons.tsx
@@ -1,4 +1,4 @@
-import { RUN_MODE, UI_THEME } from "../../common/utility"
+import { isFileSystemApiSupported, RUN_MODE, UI_THEME } from "../../common/utility"
 import {
   passGoBackInTime, passGoForwardInTime,
   handleCanGoBackward, handleCanGoForward, passTimeTravelSnapshot, handleGetIsDebugging, handleGetRunMode,
@@ -69,14 +69,15 @@ const DebugButtons = (props: DisplayProps) => {
         onClick={() => setPreferenceDebugMode(!handleGetIsDebugging())}>
         <FontAwesomeIcon icon={handleGetIsDebugging() ? faBug : faBugSlash} />
       </button>}
-    <button className="push-button"
-      title={handleGetHotReload() ? "Hot Reload Enabled" : "Hot Reload Disabled"}
-      onClick={() => {
-        setPreferenceHotReload(!handleGetHotReload())
-        props.updateDisplay()
-      }}>
-      <FontAwesomeIcon icon={handleGetHotReload() ? faEye : faEyeSlash} />
-    </button>
+    {isFileSystemApiSupported() &&
+      <button className="push-button"
+        title={handleGetHotReload() ? "Hot Reload Enabled" : "Hot Reload Disabled"}
+        onClick={() => {
+          setPreferenceHotReload(!handleGetHotReload())
+          props.updateDisplay()
+        }}>
+        <FontAwesomeIcon icon={handleGetHotReload() ? faEye : faEyeSlash} />
+      </button>}
   </span>
 }
 

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -151,14 +151,12 @@ const DiskDrive = (props: DiskDriveProps) => {
   }
 
   const showReadWriteFilePicker = async (index: number) => {
-    const suffixes = FILE_SUFFIXES.split(",")
     let [writableFileHandle] = await window.showOpenFilePicker({
       types: [
         {
           description: "Disk Images",
           accept: {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            "application/octet-stream": suffixes
+            "application/octet-stream": FILE_SUFFIXES.split(",") as `.${string}`[]
           }
         }
       ],
@@ -181,7 +179,7 @@ const DiskDrive = (props: DiskDriveProps) => {
         types: [
           {
             description: "Disk Image",
-            accept: { "application/octet": [newFileExtension] },
+            accept: { "application/octet": [newFileExtension] as `.${string}`[] },
           },
         ]
       })

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -189,12 +189,13 @@ const DiskDrive = (props: DiskDriveProps) => {
     passSetDriveProps(dprops)
 
     const timer = setInterval(async (index: number) => {
-      let dprops = handleGetDriveProps(index)
+      const dprops = handleGetDriveProps(index)
       if (dprops.diskHasChanges
-        && !dprops.motorRunning
-        && await handleSaveWritableFile(index)) {
-        dprops.diskHasChanges = false
-        passSetDriveProps(dprops)
+        && !dprops.motorRunning) {
+        if (await handleSaveWritableFile(index)) {
+          dprops.diskHasChanges = false
+          passSetDriveProps(dprops)
+        }
       }
     }, 1000, index)
     return () => clearInterval(timer)

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { CLOUD_SYNC, crc32, DISK_CONVERSION_SUFFIXES, FILE_SUFFIXES, RUN_MODE, uint32toBytes } from "../../common/utility"
+import { CLOUD_SYNC, crc32, DISK_CONVERSION_SUFFIXES, FILE_SUFFIXES, isFileSystemApiSupported, RUN_MODE, uint32toBytes } from "../../common/utility"
 import { imageList } from "./assets"
 import {
   handleSetDiskData, handleGetDriveProps,
@@ -235,7 +235,7 @@ const DiskDrive = (props: DiskDriveProps) => {
       if (dprops.filename.length > 0) {
         setMenuOpen(0)
       } else {
-        if ("showOpenFilePicker" in self && "showSaveFilePicker" in self) {
+        if (isFileSystemApiSupported()) {
           setMenuOpen(3)
         } else {
           setMenuOpen(2)

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -170,6 +170,7 @@ const DiskDrive = (props: DiskDriveProps) => {
 
     const file = await writableFileHandle.getFile()
     const fileExtension = file.name.substring(file.name.lastIndexOf("."))
+    let newIndex = index
 
     if (DISK_CONVERSION_SUFFIXES.has(fileExtension)) {
       const newFileExtension = DISK_CONVERSION_SUFFIXES.get(fileExtension)
@@ -183,9 +184,9 @@ const DiskDrive = (props: DiskDriveProps) => {
           },
         ]
       })
-      handleSetDiskOrFileFromBuffer(index, await file.arrayBuffer(), file.name, null, writableFileHandle)
+      newIndex = handleSetDiskOrFileFromBuffer(index, await file.arrayBuffer(), file.name, null, writableFileHandle)
     } else {
-      handleSetDiskOrFileFromBuffer(index, await file.arrayBuffer(), writableFileHandle.name, null, writableFileHandle)
+      newIndex = handleSetDiskOrFileFromBuffer(index, await file.arrayBuffer(), writableFileHandle.name, null, writableFileHandle)
     }
 
     const timer = setInterval(async (index: number) => {
@@ -207,7 +208,7 @@ const DiskDrive = (props: DiskDriveProps) => {
           passSetDriveProps(dprops)
         }
       }
-    }, 3 * 1000, index)
+    }, 3 * 1000, newIndex)
     return () => clearInterval(timer)
   }
 

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -12,7 +12,7 @@ import { GoogleDrive } from "./googledrive"
 import { driveMenuItems } from "./diskdrive_menu"
 import { passSetDriveProps } from "../main2worker"
 
-const getBlobFromDiskData = (diskData: Uint8Array, filename: string) => {
+export const getBlobFromDiskData = (diskData: Uint8Array, filename: string): Blob => {
   // Only WOZ requires a checksum. Other formats should be ready to download.
   if (filename.toLowerCase().endsWith(".woz")) {
     const crc = crc32(diskData, 12)

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -151,12 +151,14 @@ const DiskDrive = (props: DiskDriveProps) => {
   }
 
   const showReadWriteFilePicker = async (index: number) => {
+    const suffixes = FILE_SUFFIXES.split(",")
     let [writableFileHandle] = await window.showOpenFilePicker({
       types: [
         {
           description: "Disk Images",
           accept: {
-            "application/octet-stream": FILE_SUFFIXES.split(",")
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            "application/octet-stream": suffixes
           }
         }
       ],

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -141,6 +141,10 @@ const DiskDrive = (props: DiskDriveProps) => {
     const blob = getBlobFromDiskData(dprops.diskData, driveFileName)
     dprops.cloudData = await cloudProvider.upload(dprops.filename, blob)
     if (dprops.cloudData) {
+      if (dprops.writableFileHandle) {
+        await handleSaveWritableFile(dprops.index)
+        dprops.writableFileHandle = null
+      }
       dprops.diskHasChanges = false
       passSetDriveProps(dprops)
     }
@@ -223,11 +227,7 @@ const DiskDrive = (props: DiskDriveProps) => {
 
     if (!dprops.cloudData || dprops.cloudData.syncStatus == CLOUD_SYNC.INACTIVE) {
       if (dprops.filename.length > 0) {
-        if (dprops.writableFileHandle == null) {
-          setMenuOpen(0)
-        } else {
-          setMenuOpen(4)
-        }
+        setMenuOpen(0)
       } else {
         if ("showOpenFilePicker" in self && "showSaveFilePicker" in self) {
           setMenuOpen(3)

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -44,7 +44,6 @@ const DiskDrive = (props: DiskDriveProps) => {
 
   const [menuOpen, setMenuOpen] = useState<number>(-1)
   const [position, setPosition] = useState<{ x: number, y: number }>({ x: 0, y: 0 })
-  const [diskFileHandle, setDiskFileHandle] = useState<FileSystemFileHandle>()
 
   const resetDrive = (index: number) => {
     handleSetDiskData(index, new Uint8Array(), "", null)
@@ -232,7 +231,7 @@ const DiskDrive = (props: DiskDriveProps) => {
     } else if (menuNumber == 2) {
       switch (menuChoice) {
         case 0:
-          setDiskFileHandle(props.setShowFileOpenDialog(true, props.index))
+          props.setShowFileOpenDialog(true, props.index)
           break
         case 1:
           loadDiskFromCloud(new OneDriveCloudDrive())

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -11,7 +11,7 @@ import { faRotate } from "@fortawesome/free-solid-svg-icons"
 import { OneDriveCloudDrive } from "./onedriveclouddrive"
 import { GoogleDrive } from "./googledrive"
 import { driveMenuItems } from "./diskdrive_menu"
-import { passSetDriveProps, passSetRunMode } from "../main2worker"
+import { handleGetHotReload, passSetDriveProps, passSetRunMode } from "../main2worker"
 
 export const getBlobFromDiskData = (diskData: Uint8Array, filename: string): Blob => {
   // Only WOZ requires a checksum. Other formats should be ready to download.
@@ -191,7 +191,7 @@ const DiskDrive = (props: DiskDriveProps) => {
     const timer = setInterval(async (index: number) => {
       const dprops = handleGetDriveProps(index)
 
-      if (true) {
+      if (handleGetHotReload()) {
         const file = await writableFileHandle.getFile()
         if (dprops.lastLocalWriteTime > 0 && file.lastModified > dprops.lastLocalWriteTime) {
           handleSetDiskOrFileFromBuffer(index, await file.arrayBuffer(), file.name, null, writableFileHandle)

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from "react"
 import { CLOUD_SYNC, crc32, FILE_SUFFIXES, uint32toBytes } from "../../common/utility"
 import { imageList } from "./assets"
-import { handleSetDiskData, handleGetDriveProps,
-  handleSetDiskWriteProtected, handleSetDiskOrFileFromBuffer } from "./driveprops"
+import {
+  handleSetDiskData, handleGetDriveProps,
+  handleSetDiskWriteProtected, handleSetDiskOrFileFromBuffer
+} from "./driveprops"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faRotate } from "@fortawesome/free-solid-svg-icons"
 import { OneDriveCloudDrive } from "./onedriveclouddrive"
@@ -42,7 +44,8 @@ const DiskDrive = (props: DiskDriveProps) => {
 
   const [menuOpen, setMenuOpen] = useState<number>(-1)
   const [position, setPosition] = useState<{ x: number, y: number }>({ x: 0, y: 0 })
-  
+  const [diskFileHandle, setDiskFileHandle] = useState<FileSystemFileHandle>()
+
   const resetDrive = (index: number) => {
     handleSetDiskData(index, new Uint8Array(), "", null)
   }
@@ -82,10 +85,10 @@ const DiskDrive = (props: DiskDriveProps) => {
       }
     }, 1000)
     return () => clearInterval(timer)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dprops.cloudData, dprops.cloudData?.syncStatus, dprops.cloudData?.lastSyncTime,
-    dprops.cloudData?.syncInterval, dprops.isWriteProtected, dprops.motorRunning,
-    dprops.diskHasChanges])
+  dprops.cloudData?.syncInterval, dprops.isWriteProtected, dprops.motorRunning,
+  dprops.diskHasChanges])
 
   const cloudDriveStatusClassName = useMemo(() => {
     if (!dprops.cloudData) return "disk-clouddrive-inactive"
@@ -99,7 +102,7 @@ const DiskDrive = (props: DiskDriveProps) => {
     } else {
       return `disk-clouddrive-${CLOUD_SYNC[syncStatus].toLowerCase()}`
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dprops.cloudData, dprops.cloudData?.syncStatus, dprops.cloudData?.syncInterval])
 
   const diskDriveLabel = useMemo(() => {
@@ -115,14 +118,14 @@ const DiskDrive = (props: DiskDriveProps) => {
   const driveFileName = useMemo(() => {
     // if (dprops.filename == '') {
     // }
-    
+
     if (dprops.cloudData) {
       if (dprops.filename != dprops.cloudData.fileName) {
         dprops.cloudData.fileName = `apple2ts.${dprops.filename}`
       }
     }
     return dprops.filename
-  }, [dprops.filename, dprops.cloudData]) 
+  }, [dprops.filename, dprops.cloudData])
 
   const loadDiskFromCloud = async (newCloudDrive: CloudProvider) => {
     const result = await newCloudDrive.download(FILE_SUFFIXES)
@@ -201,7 +204,7 @@ const DiskDrive = (props: DiskDriveProps) => {
         case 5:
           saveDiskToCloud(new GoogleDrive())
           break
-        }
+      }
     } else if (menuNumber == 1) {
       if (menuChoice == 2) {
         resetDrive(props.index)
@@ -229,7 +232,7 @@ const DiskDrive = (props: DiskDriveProps) => {
     } else if (menuNumber == 2) {
       switch (menuChoice) {
         case 0:
-          props.setShowFileOpenDialog(true, props.index)
+          setDiskFileHandle(props.setShowFileOpenDialog(true, props.index))
           break
         case 1:
           loadDiskFromCloud(new OneDriveCloudDrive())
@@ -262,10 +265,10 @@ const DiskDrive = (props: DiskDriveProps) => {
             id={dprops.index === 2 ? "tour-floppy-disks" : ""}
             title={diskDriveLabel}
             onClick={handleMenuClick} />
-            <FontAwesomeIcon
-              icon={faRotate}
-              className={`fa-fw disk-clouddrive ${cloudDriveStatusClassName}`}>
-            </FontAwesomeIcon>
+          <FontAwesomeIcon
+            icon={faRotate}
+            className={`fa-fw disk-clouddrive ${cloudDriveStatusClassName}`}>
+          </FontAwesomeIcon>
         </span>
       </span>
       <span className={"disk-label" + (dprops.diskHasChanges ? " disk-label-unsaved" : "")}>
@@ -282,18 +285,18 @@ const DiskDrive = (props: DiskDriveProps) => {
             style={{ left: position.x, top: position.y }}>
             {driveMenuItems[menuOpen].map((menuItem, index) => (
               <div key={index}>
-              {menuItem.label == "-"
-              ? <div style={{ borderTop: "1px solid #aaa", margin: "5px 0" }}></div>
-              : <div className="droplist-option"
-                style={{ padding: "5px", paddingLeft: "10px", paddingRight: "10px" }}
-                onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ccc"}
-                onMouseOut={(e) => e.currentTarget.style.backgroundColor = "inherit"}
-                key={menuItem.label} onClick={() => handleMenuClose(menuItem.index)}>
-                {getMenuCheck(menuItem.index || -1)}
-                {menuItem.icon && <FontAwesomeIcon icon={menuItem.icon} style={{width: "24px"}} />}
-                {menuItem.label}</div>}
+                {menuItem.label == "-"
+                  ? <div style={{ borderTop: "1px solid #aaa", margin: "5px 0" }}></div>
+                  : <div className="droplist-option"
+                    style={{ padding: "5px", paddingLeft: "10px", paddingRight: "10px" }}
+                    onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ccc"}
+                    onMouseOut={(e) => e.currentTarget.style.backgroundColor = "inherit"}
+                    key={menuItem.label} onClick={() => handleMenuClose(menuItem.index)}>
+                    {getMenuCheck(menuItem.index || -1)}
+                    {menuItem.icon && <FontAwesomeIcon icon={menuItem.icon} style={{ width: "24px" }} />}
+                    {menuItem.label}</div>}
               </div>
-              ))}
+            ))}
           </div>
         </div>
       }

--- a/src/ui/devices/diskdrive_menu.tsx
+++ b/src/ui/devices/diskdrive_menu.tsx
@@ -1,4 +1,4 @@
-import { faClock, faCloud, faDownload, faEject, faFloppyDisk, faFolderOpen, faLock, faPause, faSync, IconDefinition } from "@fortawesome/free-solid-svg-icons"
+import { faClock, faCloud, faDownload, faEject, faFolderOpen, faLock, faPause, faSync, IconDefinition } from "@fortawesome/free-solid-svg-icons"
 
 type MenuItem = {
   label: string,

--- a/src/ui/devices/diskdrive_menu.tsx
+++ b/src/ui/devices/diskdrive_menu.tsx
@@ -1,4 +1,4 @@
-import { faClock, faCloud, faDownload, faEject, faFolderOpen, faLock, faPause, faSync, IconDefinition } from "@fortawesome/free-solid-svg-icons"
+import { faClock, faCloud, faDownload, faEject, faFloppyDisk, faFolderOpen, faLock, faPause, faSync, IconDefinition } from "@fortawesome/free-solid-svg-icons"
 
 type MenuItem = {
   label: string,
@@ -88,7 +88,7 @@ export const driveMenuItems: Array<Array<MenuItem>> = [
   ],
   [
     {
-      label: "Load Disk from Local Computer",
+      label: "Load Disk from Device (read-only)",
       icon: faFolderOpen,
       index: 0
     },
@@ -103,6 +103,56 @@ export const driveMenuItems: Array<Array<MenuItem>> = [
     {
       label: "Load Disk from Google Drive",
       icon: faCloud,
+      index: 2
+    }
+  ],
+  [
+    {
+      label: "Load Disk from Device (read-only)",
+      icon: faFolderOpen,
+      index: 0
+    },
+    {
+      label: "Load Disk from Device (read/write)",
+      icon: faFloppyDisk,
+      index: 3
+    },
+    {
+      label: "-"
+    },
+    {
+      label: "Load Disk from OneDrive",
+      icon: faCloud,
+      index: 1
+    },
+    {
+      label: "Load Disk from Google Drive",
+      icon: faCloud,
+      index: 2
+    }
+  ],
+  [
+    {
+      label: "Write Protect Disk",
+      icon: faLock,
+      index: 3
+    },
+    {
+      label: "-"
+    },
+    {
+      label: "Download Disk",
+      icon: faDownload,
+      index: 0
+    },
+    {
+      label: "Download and Eject Disk",
+      icon: faDownload,
+      index: 1
+    },
+    {
+      label: "Eject Disk",
+      icon: faEject,
       index: 2
     }
   ]

--- a/src/ui/devices/diskdrive_menu.tsx
+++ b/src/ui/devices/diskdrive_menu.tsx
@@ -108,13 +108,8 @@ export const driveMenuItems: Array<Array<MenuItem>> = [
   ],
   [
     {
-      label: "Load Disk from Device (read-only)",
-      icon: faFolderOpen,
-      index: 0
-    },
-    {
       label: "Load Disk from Device (read/write)",
-      icon: faFloppyDisk,
+      icon: faFolderOpen,
       index: 3
     },
     {
@@ -128,31 +123,6 @@ export const driveMenuItems: Array<Array<MenuItem>> = [
     {
       label: "Load Disk from Google Drive",
       icon: faCloud,
-      index: 2
-    }
-  ],
-  [
-    {
-      label: "Write Protect Disk",
-      icon: faLock,
-      index: 3
-    },
-    {
-      label: "-"
-    },
-    {
-      label: "Download Disk",
-      icon: faDownload,
-      index: 0
-    },
-    {
-      label: "Download and Eject Disk",
-      icon: faDownload,
-      index: 1
-    },
-    {
-      label: "Eject Disk",
-      icon: faEject,
       index: 2
     }
   ]

--- a/src/ui/devices/diskdrive_menu.tsx
+++ b/src/ui/devices/diskdrive_menu.tsx
@@ -88,7 +88,7 @@ export const driveMenuItems: Array<Array<MenuItem>> = [
   ],
   [
     {
-      label: "Load Disk from Device (read-only)",
+      label: "Load Disk from Device (Read-Only)",
       icon: faFolderOpen,
       index: 0
     },
@@ -108,7 +108,7 @@ export const driveMenuItems: Array<Array<MenuItem>> = [
   ],
   [
     {
-      label: "Load Disk from Device (read/write)",
+      label: "Load Disk from Device (Read/Write)",
       icon: faFolderOpen,
       index: 3
     },

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -45,8 +45,10 @@ export const doSetUIDriveProps = (props: DriveProps) => {
   // If our disk is the same but it hasn't changed, keep the existing data.
   if (props.diskData.length === 0) {
     const tmp = driveProps[props.index].diskData
+    const diskHasChanges = driveProps[props.index].diskHasChanges
     driveProps[props.index] = props
     driveProps[props.index].diskData = tmp
+    driveProps[props.index].diskHasChanges = diskHasChanges
   } else {
     driveProps[props.index] = props
   }

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -57,10 +57,11 @@ export const handleGetDriveProps = (index: number) => {
 }
 
 export const handleSetDiskData = (index: number,
-  data: Uint8Array, filename: string, cloudData: CloudData | null) => {
+  data: Uint8Array, filename: string, cloudData: CloudData | null, writableFileHandle: FileSystemFileHandle | null) => {
   driveProps[index].filename = filename
   driveProps[index].diskData = data
   driveProps[index].cloudData = cloudData
+  driveProps[index].writableFileHandle = writableFileHandle
   passSetDriveNewData(driveProps[index])
 }
 
@@ -109,7 +110,7 @@ export const handleSetDiskOrFileFromBuffer = (index: number, buffer: ArrayBuffer
     } else {
       if (index < 2) index = 2
     }
-    handleSetDiskData(index, new Uint8Array(buffer), filename, cloudData)
+    handleSetDiskData(index, new Uint8Array(buffer), filename, cloudData, null)
     if (handleGetRunMode() === RUN_MODE.IDLE) {
       passSetRunMode(RUN_MODE.NEED_BOOT)
     } else {
@@ -151,7 +152,7 @@ export const handleSetDiskFromURL = async (url: string,
 
 const resetAllDiskDrives = () => {
   for (let i=0; i < MAX_DRIVES; i++) {
-    handleSetDiskData(i, new Uint8Array(), "", null)
+    handleSetDiskData(i, new Uint8Array(), "", null, null)
   }
 }
 
@@ -165,7 +166,7 @@ export const handleSetDiskFromFile = async (disk: diskImage,
    return
   }
   resetAllDiskDrives()
-  handleSetDiskData(0, new Uint8Array(data), disk.file, null)
+  handleSetDiskData(0, new Uint8Array(data), disk.file, null, null)
   passSetRunMode(RUN_MODE.NEED_BOOT)
   const helpFile = replaceSuffix(disk.file, "txt")
   try {

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -1,6 +1,7 @@
 import { MAX_DRIVES, RUN_MODE, isHardDriveImage, replaceSuffix } from "../../common/utility"
 import { iconKey, iconData, iconName } from "../img/iconfunctions"
 import { handleGetRunMode, passPasteText, passSetBinaryBlock, passSetDriveNewData, passSetDriveProps, passSetRunMode } from "../main2worker"
+import { getBlobFromDiskData } from "./diskdrive"
 import { diskImages } from "./diskimages"
 
 // Technically, all of these properties should be in the main2worker.ts file,
@@ -195,7 +196,8 @@ export const handleSaveWritableFile = async (index: number, writableFileHandle: 
   if (writableFileHandle) {
     try {
       const writable = await writableFileHandle.createWritable()
-      await writable.write(driveProps[index].diskData)
+      const blob = getBlobFromDiskData(driveProps[index].diskData, driveProps[index].filename)
+      await writable.write(blob)
       await writable.close()
       success = true
     } catch (ex) {
@@ -220,6 +222,3 @@ export const handleSetWritableFileHandle = async (index: number, writableFileHan
 
   return success
 }
-
-// export function handleSetCloudUrl(url: string) {
-// }

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -105,6 +105,8 @@ export const handleSetDiskOrFileFromBuffer = (
   cloudData: CloudData | null,
   writableFileHandle: FileSystemFileHandle | null) => {
   const fname = filename.toLowerCase()
+  let newIndex = index
+
   if (fname.endsWith(".bin")) {
     passSetBinaryBlock(binaryRunAddress, new Uint8Array(buffer), true)
   } else if (fname.endsWith(".bas") || fname.endsWith(".a")) {
@@ -119,17 +121,19 @@ export const handleSetDiskOrFileFromBuffer = (
   } else {
     // Force hard drive images to be in "0" or "1" (slot 7 drive 1 or 2)
     if (isHardDriveImage(fname)) {
-      if (index > 1) index = 0
+      if (index > 1) newIndex = 0
     } else {
-      if (index < 2) index = 2
+      if (index < 2) newIndex = 2
     }
-    handleSetDiskData(index, new Uint8Array(buffer), filename, cloudData, writableFileHandle, Date.now())
+    handleSetDiskData(newIndex, new Uint8Array(buffer), filename, cloudData, writableFileHandle, Date.now())
     if (handleGetRunMode() === RUN_MODE.IDLE) {
       passSetRunMode(RUN_MODE.NEED_BOOT)
     } else {
 //      props.updateDisplay()
     }
   }
+
+  return newIndex
 }
 
 export const handleSetDiskFromURL = async (url: string,

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -195,30 +195,18 @@ export const handleSaveWritableFile = async (index: number, writableFileHandle: 
 
   if (writableFileHandle) {
     try {
+      const dprops = driveProps[index]
+      const blob = getBlobFromDiskData(dprops.diskData, dprops.filename)
       const writable = await writableFileHandle.createWritable()
-      const blob = getBlobFromDiskData(driveProps[index].diskData, driveProps[index].filename)
+
       await writable.write(blob)
       await writable.close()
+      
       success = true
     } catch (ex) {
       console.log(`Error saving writable file: ${ex}`)
     }
   }
-
-  return success
-}
-
-export const handleSetWritableFileHandle = async (index: number, writableFileHandle: FileSystemFileHandle) => {
-  let success = false
-
-  // Force permission check by saving immediately
-  if (await handleSaveWritableFile(index, writableFileHandle)) {
-    driveProps[index].writableFileHandle = writableFileHandle
-    success = true
-  } else {
-    driveProps[index].writableFileHandle = null
-  }
-  passSetDriveProps(driveProps[index])
 
   return success
 }

--- a/src/ui/fileinput.tsx
+++ b/src/ui/fileinput.tsx
@@ -82,7 +82,7 @@ const FileInput = (props: DisplayProps) => {
       if (await handleSetWritableFileHandle(index, writableFileHandle)) {
         const timer = setInterval(async (index: number) => {
           let dprops = handleGetDriveProps(index)
-          if (dprops.diskHasChanges && await handleSaveWritableFile(index)) {
+          if (dprops.diskHasChanges && !dprops.motorRunning && await handleSaveWritableFile(index)) {
             dprops.diskHasChanges = false
             passSetDriveProps(dprops)
           }

--- a/src/ui/fileinput.tsx
+++ b/src/ui/fileinput.tsx
@@ -68,7 +68,7 @@ const FileInput = (props: DisplayProps) => {
         {
           description: "Disk Images",
           accept: {
-            "application/octet-stream": FILE_SUFFIXES.split(",").filter(x => { return x !== ".dsk" })
+            "application/octet-stream": FILE_SUFFIXES.split(",") //.filter(x => { return x !== ".dsk" })
           }
         }
       ],

--- a/src/ui/fileinput.tsx
+++ b/src/ui/fileinput.tsx
@@ -28,7 +28,7 @@ const FileInput = (props: DisplayProps) => {
           setDisplayBinaryDialog(true)
         }
       } else {
-        handleSetDiskOrFileFromBuffer(index, buffer, file.name, null)
+        handleSetDiskOrFileFromBuffer(index, buffer, file.name, null, null)
       }
     }
   }

--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -1,6 +1,6 @@
 import { changeMockingboardMode } from "./devices/mockingboard_audio"
 import { COLOR_MODE, UI_THEME } from "../common/utility"
-import { passCapsLock, passColorMode, passShowScanlines, passTheme, passSetDebug, passSetMachineName, passSetRamWorks, passSpeedMode } from "./main2worker"
+import { passCapsLock, passColorMode, passShowScanlines, passTheme, passSetDebug, passSetMachineName, passSetRamWorks, passSpeedMode, passHotReload } from "./main2worker"
 
 export const setPreferenceCapsLock = (mode = true) => {
   if (mode === true) {
@@ -81,6 +81,15 @@ export const setPreferenceSpeedMode = (mode = 0) => {
     localStorage.setItem("speedMode", JSON.stringify(mode))
   }
   passSpeedMode(mode)
+}
+
+export const setPreferenceHotReload = (mode = false) => {
+  if (mode === false) {
+    localStorage.removeItem("hotReload")
+  } else {
+    localStorage.setItem("hotReload", JSON.stringify(mode))
+  }
+  passHotReload(mode)
 }
 
 export const loadPreferences = () => {
@@ -177,6 +186,15 @@ export const loadPreferences = () => {
       localStorage.removeItem("ramWorks")
     }
   }
+
+  const hotReload = localStorage.getItem("hotReload")
+  if (hotReload) {
+    try {
+      passHotReload(JSON.parse(hotReload))
+    } catch {
+      localStorage.removeItem("hotReload")
+    }
+  }
 }
 
 export const resetPreferences = () => {
@@ -189,6 +207,7 @@ export const resetPreferences = () => {
   setPreferenceMachineName()
   setPreferenceRamWorks()
   setPreferenceDebugMode()
+  setPreferenceHotReload()
 
   localStorage.removeItem("binaryRunAddress")
 }

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -103,6 +103,10 @@ export const passHelpText = (helptext: string) => {
   machineState.helpText = helptext
 }
 
+export const passHotReload = (mode: boolean) => {
+  machineState.hotReload = mode
+}
+
 export const passGoForwardInTime = () => {
   doPostMessage(MSG_MAIN.TIME_TRAVEL_STEP, "FORWARD")
 }
@@ -246,6 +250,7 @@ let machineState: MachineState = {
   textPage: new Uint8Array(1).fill(32),
   timeTravelThumbnails: new Array<TimeTravelThumbnail>(),
   useOpenAppleKey: false,
+  hotReload: false
 }
 
 export const doOnMessage = (e: MessageEvent): {speed: number, helptext: string} | null => {
@@ -264,6 +269,7 @@ export const doOnMessage = (e: MessageEvent): {speed: number, helptext: string} 
       newState.theme = machineState.theme
       newState.helpText = machineState.helpText
       newState.useOpenAppleKey = machineState.useOpenAppleKey
+      newState.hotReload = machineState.hotReload
       machineState = newState
       return {speed: machineState.cpuSpeed, helptext: machineState.helpText}
     }
@@ -493,5 +499,9 @@ export const handleGetMachineName = () => {
 
 export const handleGetSoftSwitchDescriptions = () => {
   return softSwitchDescriptions
+}
+
+export const handleGetHotReload = () => {
+  return machineState.hotReload
 }
 

--- a/src/worker/devices/drivestate.ts
+++ b/src/worker/devices/drivestate.ts
@@ -23,9 +23,10 @@ const initDriveState = (index: number, drive: number, hardDrive: boolean): Drive
     trackNbits: !hardDrive ? Array<number>(80) : Array<number>(),
     trackLocation: 0,
     maxHalftrack: 0,
-    lastWriteTime: -1,
+    lastLocalWriteTime: -1,
     cloudData: null,
-    writableFileHandle: null
+    writableFileHandle: null,
+    lastWriteTime: -1
   }
 }
 
@@ -83,6 +84,7 @@ export const passData = () => {
       isWriteProtected: driveState[i].isWriteProtected,
       diskData: driveState[i].diskHasChanges ? driveData[i] : new Uint8Array(),
       lastWriteTime: driveState[i].lastWriteTime,
+      lastLocalWriteTime: driveState[i].lastLocalWriteTime,
       cloudData: driveState[i].cloudData,
       writableFileHandle: driveState[i].writableFileHandle
     }
@@ -168,6 +170,8 @@ export const doSetEmuDriveNewData = (props: DriveProps, forceIndex: boolean = fa
     driveState[index].filename = ""
   }
   driveState[index].cloudData = props.cloudData
+  driveState[index].writableFileHandle = props.writableFileHandle
+  driveState[index].lastLocalWriteTime = props.lastLocalWriteTime
   passData()
 }
 
@@ -179,6 +183,8 @@ export const doSetEmuDriveProps = (props: DriveProps) => {
   driveState[index].motorRunning = props.motorRunning
   driveState[index].isWriteProtected = props.isWriteProtected
   driveState[index].diskHasChanges = props.diskHasChanges
+  driveState[index].lastWriteTime = props.lastWriteTime
+  driveState[index].lastLocalWriteTime = props.lastLocalWriteTime
   driveState[index].cloudData = props.cloudData
   driveState[index].writableFileHandle = props.writableFileHandle
   passData()

--- a/src/worker/devices/drivestate.ts
+++ b/src/worker/devices/drivestate.ts
@@ -24,7 +24,8 @@ const initDriveState = (index: number, drive: number, hardDrive: boolean): Drive
     trackLocation: 0,
     maxHalftrack: 0,
     lastWriteTime: -1,
-    cloudData: null
+    cloudData: null,
+    writableFileHandle: null
   }
 }
 

--- a/src/worker/devices/drivestate.ts
+++ b/src/worker/devices/drivestate.ts
@@ -82,7 +82,8 @@ export const passData = () => {
       isWriteProtected: driveState[i].isWriteProtected,
       diskData: driveState[i].diskHasChanges ? driveData[i] : new Uint8Array(),
       lastWriteTime: driveState[i].lastWriteTime,
-      cloudData: driveState[i].cloudData
+      cloudData: driveState[i].cloudData,
+      writableFileHandle: driveState[i].writableFileHandle
     }
     passDriveProps(dprops)
   }
@@ -178,6 +179,7 @@ export const doSetEmuDriveProps = (props: DriveProps) => {
   driveState[index].isWriteProtected = props.isWriteProtected
   driveState[index].diskHasChanges = props.diskHasChanges
   driveState[index].cloudData = props.cloudData
+  driveState[index].writableFileHandle = props.writableFileHandle
   passData()
 }
 

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -610,7 +610,8 @@ const updateExternalMachineState = () => {
     stackString: doGetStackString(),
     textPage: getTextPage(),
     timeTravelThumbnails: getTimeTravelThumbnails(),
-    useOpenAppleKey: false,  // ignored by main thread
+    useOpenAppleKey: false,  // ignored by main thread,
+    hotReload: false
   }
   passMachineState(state)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,12 @@
       "webworker"
     ],
     "types": [
-      "@types/wicg-file-system-access",
-      "@types/jest"
+      "@types/gapi.client.drive-v3",
+      "@types/google.accounts",
+      "@types/google.picker",
+      "@types/jest",
+      "@types/w3c-web-serial",
+      "@types/wicg-file-system-access"
     ],
     "allowJs": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
       "esnext",
       "webworker"
     ],
+    "types": [
+      "@types/wicg-file-system-access"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "webworker"
     ],
     "types": [
-      "@types/wicg-file-system-access"
+      "@types/wicg-file-system-access",
+      "@types/jest"
     ],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6aa9b2ff-1773-405d-ba95-648da2194ce2)
![image](https://github.com/user-attachments/assets/255b2e26-b5dd-4b9c-ad66-cf5f70ead225)
![image](https://github.com/user-attachments/assets/d2dc2131-e05c-49a5-9641-147b5533cd19)
![image](https://github.com/user-attachments/assets/b519c393-f2f6-489d-9732-8d8a3e23fe17)
![image](https://github.com/user-attachments/assets/52b5c6b8-fddd-46e7-838c-3e52bb6661e5)
![image](https://github.com/user-attachments/assets/18060ae0-31e2-4379-a9c7-d8dd4a7c0b2f)
![image](https://github.com/user-attachments/assets/d4692fbf-dc2a-4080-a147-5ecaeda78425)

**Changes Made:**
- Added support for read/write disk images on devices/OSes which support the File System API
- Added `DISK_CONVERSION_SUFFIXES` map to handle read/write .dsk images being converted to .woz format by prompting the user to save the converted file (one-time only)
- Added `writableFileHandle` property to `DriveState` which allows read/write operations for disk images
- Added `lastLocalWriteTime` to `DriveProps` to detect when the file on disk has been updated outside the emulator, triggering a hot reload
- Added support for hot reload feature which allows the emulator to "watch" read/write files for changes, restarting the emulator and reloading the new file content automatically
- Added `hotReload` property to `MachineState` which allow users to toggle the hot reload feature as it could pontentially be expensive to reload files to detect changes every three seconds
- Added toggle button to `DebugButtons` to toggle the hot reload feature
- Updated `DiskDrive.saveDiskToCloud()` to force save a read/write file before breaking the linkage since it doesn't make sense to update the disk image in two places (local drive and cloud drive)
- Added `DiskDrive.showReadWriteFilePicker()` method which prompts the user to select a disk image from the local drive, handles .dsk to .woz conversion, and creates an interval which checks for changes to the disk in memory, writing to the local file system when necessary
- Updated the popup menu logic in `DiskDrive` to handle read/write and read-only disk loading scenarios
- Added new menu to `diskdrive_menu` for read/write scenarios and updated the existing menu to reflect the read-only state
- Added `@types/wicg-file-system-access` to `packages.json` and `tsconfig.json` which includes File System API declarations

**Tests Performed:**
- Verified existing read-only disk load scenarios still work
- Verified new read/write disk load scenarios work as expected: user is prompted to pick a local file with a picker, disk image is loaded successfully, and changes to the disks are written to the local drive automatically every three seconds
- Verified read/write .dsk images are converted to .woz format, the user is prompted to save the new file, and all save scenarios work as expcted
- Verified hot reload scenarios works as expected: user picks a read/write disk image, user touches/updates the file externally, the emulator automatically reloads the new disk image and reboots
- Verified the hot reload toggle button works as expected (i.e. hot reload is disable when the button is disabled)
- Tested all changes on multiple devices (PC, Mac, iPad, iPhone) and OSes (Windows, MacOS, iOS)

**Issues Resolved:**
- Implemented feature #46 