### PR TITLE
"Save Disk to Device" feature

### DIFF
--- a/src/ui/devices/diskdrive_menu.tsx
+++ b/src/ui/devices/diskdrive_menu.tsx
@@ -1,4 +1,4 @@
-import { faClock, faCloud, faDownload, faEject, faFolderOpen, faLock, faPause, faSync, IconDefinition } from "@fortawesome/free-solid-svg-icons"
+import { faClock, faCloud, faDownload, faEject, faFloppyDisk, faFolderOpen, faLock, faPause, faSync, IconDefinition } from "@fortawesome/free-solid-svg-icons"
 
 type MenuItem = {
   label: string,
@@ -124,6 +124,52 @@ export const driveMenuItems: Array<Array<MenuItem>> = [
       label: "Load Disk from Google Drive",
       icon: faCloud,
       index: 2
+    }
+  ],
+  [
+    {
+      label: "Write Protect Disk",
+      icon: faLock,
+      index: 3
+    },
+    {
+      label: "-"
+    },
+    {
+      label: "Save Disk to Device",
+      icon: faFloppyDisk,
+      index: 6
+    },
+    {
+      label: "-"
+    },
+    {
+      label: "Download Disk",
+      icon: faDownload,
+      index: 0
+    },
+    {
+      label: "Download and Eject Disk",
+      icon: faDownload,
+      index: 1
+    },
+    {
+      label: "Eject Disk",
+      icon: faEject,
+      index: 2
+    },
+    {
+      label: "-"
+    },
+    {
+      label: "Save Disk to OneDrive",
+      icon: faCloud,
+      index: 4
+    },
+    {
+      label: "Save Disk to Google Drive",
+      icon: faCloud,
+      index: 5
     }
   ]
 ]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/45498ebe-1cc7-4a29-9c33-d8417cd74a97)

**Changes Made:**
- Added new "Save Disk to Device" option to disk drive menu when read-only disk is loaded
- Refactored writable file handle prep code from `showReadWriteFilePicker()` to be shared by new `showSaveFilePicker()` function
- Updated disk drive popup menu to resize dynamically based on the number of menu items to display

**Tests Performed:**
- Verified `Save Disk to Device` menu only appears when read-only disks are loaded (e.g., the baked-in disk image)
- Verified existing read-only disk load scenarios still work
- Verified new read/write disk load scenarios work as expected: user is prompted to pick a local file with a picker, disk image is loaded successfully, and changes to the disks are written to the local drive automatically every three seconds
- Tested all changes on multiple devices (PC, Mac, iPad, iPhone) and OSes (Windows, MacOS, iOS)

**Issues Resolved:**
- n/a