### PR TITLE
Feature: Added proper paging support to the Internet Archive search via infinite scrollbar

### DIFF
--- a/src/ui/internetarchivedialog.tsx
+++ b/src/ui/internetarchivedialog.tsx
@@ -214,6 +214,7 @@ const InternetArchiveDialog = (props: InternetArchiveDialogProps) => {
 
   const handleClose = () => {
     props.onClose()
+    setQuery("")
     setResults([])
   }
 

--- a/src/ui/internetarchivedialog.tsx
+++ b/src/ui/internetarchivedialog.tsx
@@ -16,7 +16,7 @@ const queryFormat = "https://archive.org/advancedsearch.php?" + [
   "sort[]=downloads+desc",
   "sort[]=stars+desc",
   `rows=${queryMaxRows}`,
-  "page=1",
+  "page={2}",
   "output=json"
 ].join("&")
 
@@ -180,6 +180,7 @@ export interface InternetArchiveDialogProps {
 
 const InternetArchiveDialog = (props: InternetArchiveDialogProps) => {
   const [results, setResults] = useState<InternetDialogResultProps[]>([])
+  const [resultsCount, setResultsCount] = useState<number>(0)
   const [query, setQuery] = useState<string>("")
   const [collection, setCollection] = useState<SoftwareCollection>(softwareCollections[0])
   const [cursorBusy, setCursorBusy] = useState(false)
@@ -211,7 +212,9 @@ const InternetArchiveDialog = (props: InternetArchiveDialogProps) => {
     setCollection(newCollection)
 
     window.setTimeout(() => {
-      const queryUrl = formatString(queryFormat, newQuery || "*", newCollection.id)
+      const pageNumber = (resultsCount - results.length) / queryMaxRows
+      const queryUrl = formatString(queryFormat, newQuery || "*", newCollection.id, pageNumber.toString())
+
       setCursorBusy(true)
       fetch(queryUrl)
         .then(async response => {
@@ -220,6 +223,7 @@ const InternetArchiveDialog = (props: InternetArchiveDialogProps) => {
             if (json) {
               const dialog = document.getElementsByClassName("internet-archive-dialog")[0] as HTMLElement
               setResults(json.response.docs)
+              setResultsCount(json.response.numFound)
               dialog.style.height = "85%"
             }
           } else {
@@ -267,7 +271,7 @@ const InternetArchiveDialog = (props: InternetArchiveDialogProps) => {
                 spellCheck="false"
                 autoFocus
                 style={{ cursor: cursorBusy ? "wait" : "text" }}
-                onChange={(event) => {setQuery(event.target.value)}}
+                onChange={(event) => { setQuery(event.target.value) }}
                 onKeyDown={handleSearchBoxKeyDown} />
               <input className="iad-search-button" type="button" value="GO" onClick={handleSearchButtonClick} />
             </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/927bf158-c565-4140-97c3-f0d6806bd8b3)
![image](https://github.com/user-attachments/assets/bdaa9495-1097-4f71-95fd-e453004e0c8b)

**Changes made:**
- Added support to paging of search results
- Added support for detecting when last result is scrolled into view via `IntersectionObserver`
- Reduced `queryMaxRows` to 25 too many paged queries faster
- Fixed bug where search query was not reset when IA dialog was dismissed 

**Tests performed:**
- Verified multi-page results are loaded dynamically as user scrolls
- Verified all new UI changes on multiple platforms
- Verified search works as expected and selecting collections filters search results
- Verified clicking on the "image" portion of the search result tile downloads the disk image and loads it into the selected disk drive
- Verified clicking on the "stats" portion of the search result tile navigates to the Internet Archive details page in a new browser window
- Tested all changes on multiple devices (PC, Mac, iPad, iPhone) and OSes (Windows, MacOS, iOS)

**Issues resolved:**
- n/a