### PR TITLE
Minimal theme discoverability improvements

### DIFF
--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -6,16 +6,27 @@ import DebugButtons from "./debugbuttons"
 import FullScreenButton from "./fullscreenbutton"
 import KeyboardButtons from "./keyboardbuttons"
 import { useState } from "react"
+import { getPreferenceFirstRunMinimal, setPreferenceFirstRunMinimal } from "../localstorage"
 
 const ControlPanel = (props: DisplayProps) => {
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
+  const showHighlight = getPreferenceFirstRunMinimal()
+
+  const handleFlyoutClick = () => {
+    if (showHighlight) {
+      setPreferenceFirstRunMinimal(false)
+    }
+
+    setIsFlyoutOpen(!isFlyoutOpen)
+  }
 
   return (
     <Flyout
       icon={faWrench}
-      title="settings panel"
+      title="settings"
+      hightlight={showHighlight}
       isOpen={() => { return isFlyoutOpen }}
-      onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
+      onClick={handleFlyoutClick}
       position="top-left">
       <span className="flex-column">
         <span className="flex-row wrap" id="tour-controlbuttons">

--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -13,6 +13,7 @@ const ControlPanel = (props: DisplayProps) => {
   return (
     <Flyout
       icon={faWrench}
+      title="settings panel"
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="top-left">

--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -15,6 +15,7 @@ const DiskInterface = (props: DisplayProps) => {
   return (
     <Flyout
       icon={faFloppyDisk}
+      title="disk drive panel"
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="bottom-left">

--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -15,7 +15,7 @@ const DiskInterface = (props: DisplayProps) => {
   return (
     <Flyout
       icon={faFloppyDisk}
-      title="disk drive panel"
+      title="disk drives"
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="bottom-left">

--- a/src/ui/flyout.minimal.css
+++ b/src/ui/flyout.minimal.css
@@ -2,6 +2,21 @@
   display: none;
 }
 
+.flyout-button-highlight {
+  animation: fadeInOut 3s infinite;
+}
+
+@keyframes fadeInOut {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
 .flyout {
   position: fixed;
   background-color: #aba7a2;

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -9,6 +9,7 @@ const Flyout = (props: {
   buttonId?: string,
   position: string,
   title: string,
+  hightlight?: boolean,
   isOpen: () => boolean | undefined,
   onClick: () => void | undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,7 +40,7 @@ const Flyout = (props: {
 
   return (
     <div
-      className={`flyout ${className}`}
+      className={`flyout ${className} ${props.hightlight && !isFlyoutOpen ? "flyout-button-highlight" : ""}`}
       style={{
         left: isMinimalTheme && isLeftPosition ? (!isFlyoutOpen || !isTouchDevice ? "14px" : "48px") : "",
         width: isMinimalTheme && !isFlyoutOpen ? "max(8vw, 72px)" : "auto",
@@ -49,7 +50,7 @@ const Flyout = (props: {
       <div
         id={props.buttonId ?? ""}
         className="flyout-button"
-        title={!isTouchDevice ? `Click to ${isFlyoutOpen ? "hide" : "show"} the ${props.title}` : ""}
+        title={!isTouchDevice ? `Click to ${isFlyoutOpen ? "hide" : "show"} ${props.title}` : ""}
         onClick={() => {
           if (props.onClick) {
             props.onClick()

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -8,6 +8,7 @@ const Flyout = (props: {
   icon: IconDefinition,
   buttonId?: string,
   position: string,
+  title: string,
   isOpen: () => boolean | undefined,
   onClick: () => void | undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,6 +49,7 @@ const Flyout = (props: {
       <div
         id={props.buttonId ?? ""}
         className="flyout-button"
+        title={!isTouchDevice ? `Click to ${isFlyoutOpen ? "hide" : "show"} the ${props.title}` : ""}
         onClick={() => {
           if (props.onClick) {
             props.onClick()

--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -92,6 +92,15 @@ export const setPreferenceHotReload = (mode = false) => {
   passHotReload(mode)
 }
 
+export const setPreferenceFirstRunMinimal = (mode = true) => {
+  if (mode === true) {
+    localStorage.removeItem("firstRunMinimal")
+  } else {
+    localStorage.setItem("firstRunMinimal", JSON.stringify(mode))
+  }
+  // UI-only setting, pass along not necessary
+}
+
 export const loadPreferences = () => {
   const capsLock = localStorage.getItem("capsLock")
   if (capsLock) {
@@ -210,5 +219,19 @@ export const resetPreferences = () => {
   setPreferenceHotReload()
 
   localStorage.removeItem("binaryRunAddress")
+}
+
+export const getPreferenceFirstRunMinimal = () => {
+  let value: boolean = true
+
+  const item = localStorage.getItem("firstRunMinimal")
+  if (item) {
+    try {
+      value = JSON.parse(item)
+    } catch {
+    }
+  }
+
+  return value
 }
 

--- a/src/ui/panels/debugsection.tsx
+++ b/src/ui/panels/debugsection.tsx
@@ -23,6 +23,7 @@ const DebugSection = (props: {updateDisplay: UpdateDisplay}) => {
     <Flyout
       icon={faBug}
       position="bottom-right"
+      title="debug panel"
       isOpen={handleGetIsDebugging}
       onClick={() => {
         setPreferenceDebugMode(!handleGetIsDebugging())

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -28,6 +28,7 @@ const HelpPanel = React.memo((props: HelpPanelProps) => {
   return (
     <Flyout
       icon={faNoteSticky}
+      title="help panel"
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="top-right">


### PR DESCRIPTION
![minimal](https://github.com/user-attachments/assets/c3effc2f-bb5c-4713-9b95-eb6230391851)

Changes made:
- Updated Minimal theme to highlight settings flyout button on first run
- Added tooltips to all Minimal theme flyouts

Tests performed:
- Verified setting flyout button is only highlighted until the user click it once
- Verified all themes work as expected in multiple browsers (Chrome, Edge, Firefox, Safari, and Opera)
- Verified all themes work as expected on multiple OSses (Windows, MacOS, iOS) and devices (PC, Mac, iPhone, iPad)

Issues resolved:
- n/a