### PR TITLE
Minor UI tweaks for drive menu and Minimal theme

### DIFF
--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -406,7 +406,7 @@ const Apple2Canvas = (props: DisplayProps) => {
     if (document.fullscreenElement !== myCanvas?.current?.parentElement) {
       if (handleGetTheme() == UI_THEME.MINIMAL) {
         scanlinesLeft = (window.innerWidth - scanlinesWidth) / 2
-        scanlinesTop = ((window.innerHeight - scanlinesHeight) / 2) - 50
+        scanlinesTop = ((window.innerHeight - scanlinesHeight) / 2) - 10
 
         if (handleGetIsDebugging()) {
           const debugSection = document.getElementsByClassName("flyout-bottom-right")[0] as HTMLElement

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -286,14 +286,32 @@ const DiskDrive = (props: DiskDriveProps) => {
     }
 
     if (menuIndex >= 0 && menuIndex < driveMenuItems.length) {
-      const menuHeight = driveMenuItems[menuIndex].length * 24
+      const [menuWidth, menuHeight] = estimatePopupDimensions(menuIndex)
+      const x = Math.min(event.clientX, window.innerWidth - menuWidth)
       const y = Math.min(event.clientY, window.innerHeight - menuHeight)
 
-      setPosition({ x: event.clientX, y: y })
+      setPosition({ x: x, y: y })
       setMenuOpen(menuIndex)
     } else {
       // $TODO: Add error handling
     }
+  }
+
+  const estimatePopupDimensions = (menuIndex: number) => {
+    let w = 0
+    let h = 0
+
+    driveMenuItems[menuIndex].forEach((menuItem) => {
+      if (menuItem.label == "-") {
+        w = Math.max(w, 9)
+        h += 16
+      } else {
+        w = Math.max(w, menuItem.label.length * 9)
+        h += 28
+      }
+    })
+
+    return [w, h]
   }
 
   const handleMenuClose = (menuChoice = -1) => {

--- a/src/ui/internetarchivedialog.tsx
+++ b/src/ui/internetarchivedialog.tsx
@@ -136,7 +136,7 @@ const InternetArchiveResult = (props: InternetDialogResultProps) => {
   return (
     <div
       className={`iad-result-tile ${props.lastResult ? "iad-result-last" : ""}`}
-      title="Press to load disk image">
+      title="Click to load disk image">
       <img className="iad-result-image" src={`https://archive.org/services/img/${props.identifier}`} onClick={handleTileClick}></img>
       <div className="iad-result-title" title={props.title}>
         {props.title}
@@ -146,7 +146,7 @@ const InternetArchiveResult = (props: InternetDialogResultProps) => {
           ? `by ${props.creator}`
           : ""}
       </div>
-      <div className="iad-stats" title="Press to view details" onClick={handleStatsClick}>
+      <div className="iad-stats" title="Click to view details" onClick={handleStatsClick}>
         <div className="iad-stats-row">
           <svg className="iad-stats-icon" style={{
             gridRow: "1/3",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7f19ba47-09a4-4886-831a-3e8197fe044a)

![image](https://github.com/user-attachments/assets/cdb758d5-8465-4626-a3f1-e426f5014dce)

![image](https://github.com/user-attachments/assets/1ac7b7df-a517-4cb8-b27f-8669e75262bb)

![image](https://github.com/user-attachments/assets/27efa986-07c9-4aae-a725-106ecc4af40f)

![image](https://github.com/user-attachments/assets/5404901e-1fa9-4a0c-8d36-7c4441f0ee24)

![image](https://github.com/user-attachments/assets/7114cc94-7d5a-47e0-81b2-0636b9472b10)

**Changes made:**
- Added estimatePopupDimensions() to DiskDrive to approximate popup window dimensions
- Minor text changes in IA search results
- Moved canvas down a few pixels in Minimal theme to avoid clipping on iPad

**Tests performed:**
- Verified disk drive menu is fully visible on all devices with no clipping or wraparound
- Verified canvas is no longer clipped at the top with Minimal theme on iPad
- Verified all themes work as expected on multiple browsers (Chrome, Edge, Safari, Firefox), OSes (Windows, Mac, iOS), and devices (PC, Mac, iPhone, iPad)

**Issues resolved:**
n/a