### PR TITLE
Minimal theme flyout panel fixes

### DIFF
--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -24,7 +24,7 @@ const ControlPanel = (props: DisplayProps) => {
     <Flyout
       icon={faWrench}
       title="settings"
-      hightlight={showHighlight}
+      highlight={showHighlight}
       isOpen={() => { return isFlyoutOpen }}
       onClick={handleFlyoutClick}
       position="top-left">

--- a/src/ui/flyout.minimal.css
+++ b/src/ui/flyout.minimal.css
@@ -3,10 +3,11 @@
 }
 
 .flyout-button-highlight {
-  animation: fadeInOut 3s infinite;
+  animation: fadeInOut 3s 5;
 }
 
 @keyframes fadeInOut {
+
   0%,
   100% {
     opacity: 0.25;

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -9,7 +9,7 @@ const Flyout = (props: {
   buttonId?: string,
   position: string,
   title: string,
-  hightlight?: boolean,
+  highlight?: boolean,
   isOpen: () => boolean | undefined,
   onClick: () => void | undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +40,7 @@ const Flyout = (props: {
 
   return (
     <div
-      className={`flyout ${className} ${props.hightlight && !isFlyoutOpen ? "flyout-button-highlight" : ""}`}
+      className={`flyout ${className} ${props.highlight && !isFlyoutOpen ? "flyout-button-highlight" : ""}`}
       style={{
         left: isMinimalTheme && isLeftPosition ? (!isFlyoutOpen || !isTouchDevice ? "14px" : "48px") : "",
         width: isMinimalTheme && !isFlyoutOpen ? "max(8vw, 72px)" : "auto",

--- a/src/ui/panels/helppanel.minimal.css
+++ b/src/ui/panels/helppanel.minimal.css
@@ -9,7 +9,7 @@
   width: auto;
   height: auto;
   max-width: min(70vw, 600px);
-  max-height: 75vh;
+  max-height: 70vh;
   overflow-x: hidden !important;
   overflow-y: auto !important;
 }

--- a/src/ui/panels/helppanel.minimal.css
+++ b/src/ui/panels/helppanel.minimal.css
@@ -2,16 +2,22 @@
    In dark mode the help-paper isn't shown, so no need to worry about colors. */
 
 .help-parent {
+  display: flex;
   box-sizing: content-box;
   margin: 0;
   padding: 0;
   height: auto;
   width: auto;
-  max-width: 600px;
+  max-width: 384px;
+  max-height: 75vh;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
 }
 
 .help-paper {
   position: relative;
+  width: 100%;
+  height: 100%;
   background-color: #f0f0f0;
   background-image:
     repeating-linear-gradient(to bottom,

--- a/src/ui/panels/helppanel.minimal.css
+++ b/src/ui/panels/helppanel.minimal.css
@@ -6,9 +6,9 @@
   box-sizing: content-box;
   margin: 0;
   padding: 0;
-  height: auto;
   width: auto;
-  max-width: 384px;
+  height: auto;
+  max-width: min(70vw, 600px);
   max-height: 75vh;
   overflow-x: hidden !important;
   overflow-y: auto !important;
@@ -51,12 +51,12 @@
 }
 
 .help-text-light {
-  margin-left: 40px;
+  margin-left: px;
   margin-top: 0px;
   margin-bottom: 0px;
   padding-top: 10px;
   padding-bottom: 10px;
-  padding-left: 20px;
+  padding-left: 10px;
   border-left: 1px solid #d8e6e1;
   color: var(--text-color);
 }

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useMemo, useState } from "react"
 import { handleGetTheme } from "../main2worker"
 import "./helppanel.css"
 import { defaultHelpText } from "./defaulthelptext"

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -1,21 +1,25 @@
-import React, { useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { handleGetTheme } from "../main2worker"
 import "./helppanel.css"
 import { defaultHelpText } from "./defaulthelptext"
 import Flyout from "../flyout"
 import { faNoteSticky } from "@fortawesome/free-solid-svg-icons"
-import { UI_THEME } from "../../common/utility"
+import { crc32, UI_THEME } from "../../common/utility"
 
 type HelpPanelProps = {
   narrow: boolean,
   helptext: string,
 }
 
+const defaultHelpTextCrc = crc32(new TextEncoder().encode(defaultHelpText))
+
 // Use the React.memo() function to optimize the HelpPanel component.
 // It was re-rendering on every machine state update, which was ridiculous.
 // Now it only re-renders when the help text changes.
 const HelpPanel = React.memo((props: HelpPanelProps) => {
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(window.outerWidth > 384 * 4)
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
+  const [helpTextCrc, setHelpTextCrc] = useState(defaultHelpTextCrc)
+
   const height = window.innerHeight ? window.innerHeight - 170 : (window.outerHeight - 170)
   const helpText = (props.helptext.length > 1 && props.helptext !== "<Default>") ? props.helptext : defaultHelpText
   const isDarkMode = handleGetTheme() == UI_THEME.DARK
@@ -25,10 +29,18 @@ const HelpPanel = React.memo((props: HelpPanelProps) => {
     import("./helppanel.minimal.css")
   }
 
+  const newHelpTextCrc = crc32(new TextEncoder().encode(helpText))
+  const showHighlight = !isFlyoutOpen && newHelpTextCrc != helpTextCrc && newHelpTextCrc != defaultHelpTextCrc
+
+  useMemo(() => {
+    setHelpTextCrc(newHelpTextCrc)
+  }, [isFlyoutOpen])
+
   return (
     <Flyout
       icon={faNoteSticky}
       title="help panel"
+      highlight={showHighlight}
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="top-right">

--- a/src/ui/panels/helppanel.tsx
+++ b/src/ui/panels/helppanel.tsx
@@ -15,7 +15,7 @@ type HelpPanelProps = {
 // It was re-rendering on every machine state update, which was ridiculous.
 // Now it only re-renders when the help text changes.
 const HelpPanel = React.memo((props: HelpPanelProps) => {
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(window.outerWidth > 384 * 4)
   const height = window.innerHeight ? window.innerHeight - 170 : (window.outerHeight - 170)
   const helpText = (props.helptext.length > 1 && props.helptext !== "<Default>") ? props.helptext : defaultHelpText
   const isDarkMode = handleGetTheme() == UI_THEME.DARK


### PR DESCRIPTION
![ezgif-2deda3a57cf308](https://github.com/user-attachments/assets/616aae04-0b8d-4f2c-84e9-1c380b4f1fd1)

![image](https://github.com/user-attachments/assets/4ddf2aa6-8f9c-47c2-a4be-e853b0151b5f)

**Changes made:**
- Added button highlight when help panel text updates and panel is not visible
- Fixed help flyout sizing issues on small screens
- Fixed typo in 'hightlight' property to 'highlight'

**Tests performed:**
- Verified help panel flyout is only highlighted when new, non-default content is set
- Verified help panel flyout works as expected on multiple devices (Windows, Mac, iPhone, iPad)

**Issues resolved:**
n/a