### PR TITLE
Updated DiskInterface to only wrap on narrow screen in Minimal mode

### DIFF
--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -4,13 +4,17 @@ import { DiskImageChooser } from "./diskimagechooser"
 import Flyout from "../flyout"
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons"
 import ImageWriter from "./imagewriter"
-import { handleGetTheme } from "../main2worker"
-import { UI_THEME } from "../../common/utility"
 import { useState } from "react"
+import { UI_THEME } from "../../common/utility"
+import { handleGetTheme } from "../main2worker"
 
 const DiskInterface = (props: DisplayProps) => {
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(true)
+
   const isMinimalTheme = handleGetTheme() == UI_THEME.MINIMAL
+  const height = window.innerHeight ? window.innerHeight : (window.outerHeight - 120)
+  const width = window.innerWidth ? window.innerWidth : (window.outerWidth - 20)
+  const isScreenNarrow = width < height
 
   return (
     <Flyout
@@ -19,21 +23,21 @@ const DiskInterface = (props: DisplayProps) => {
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="bottom-left">
-      <div className={`${isMinimalTheme ? "flex-column" : "flex-row"} wrap`}>
+      <div className={`${isMinimalTheme && isScreenNarrow ? "flex-column" : "flex-row"} wrap`}>
         <span className="flex-row wrap">
           {!isMinimalTheme && <DiskImageChooser {...props} />}
           <DiskDrive key={0} index={0} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
           <DiskDrive key={1} index={1} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
-          {isMinimalTheme && <ImageWriter />}
+          {(isMinimalTheme && isScreenNarrow) && <ImageWriter />}
         </span>
         <span className="flex-row wrap">
           <DiskDrive key={2} index={2} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
           <DiskDrive key={3} index={3} renderCount={props.renderCount}
             setShowFileOpenDialog={props.setShowFileOpenDialog} />
-          {!isMinimalTheme && <ImageWriter />}
+          {(!isMinimalTheme || !isScreenNarrow) && <ImageWriter />}
         </span>
       </div>
     </Flyout>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ae93e7bf-e86f-47d1-a796-782a6be5a261)

![image](https://github.com/user-attachments/assets/30e94d39-b8f7-4823-a9ef-c09e3a4699f9)

**Changes made:**
- Updated `DiskInterface` to enable/disble column wrap for disk drives based on screen width with the Minimal theme

**Tests performed:**
- Verified the disk drives flyout only wraps on narrow screens with the Minimal theme
- Verfieid all flyouts works as expected on multiple devices and OSes

**Issues resolved:**
n/a