### PR TITLE
Support for zipped disk images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@googleworkspace/drive-picker-element": "^0.3.4",
         "buffer": "^6.0.3",
+        "fflate": "^0.8.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-joyride": "^2.9.3"
@@ -4673,6 +4674,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@googleworkspace/drive-picker-element": "^0.3.4",
     "buffer": "^6.0.3",
+    "fflate": "^0.8.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-joyride": "^2.9.3"

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -44,7 +44,7 @@ const Flyout = (props: {
     if (props.position.indexOf("left") >= 0) {
       left = !isFlyoutOpen || !isTouchDevice ? "14px" : "48px"
     } else if (props.position.indexOf("center") >= 0) {
-      left = `calc( -0.5vw + ${window.outerWidth / 2}px - ${isFlyoutOpen ? props.width ?? "auto" : flyoutButtonWidth} / 2)`
+      left = `calc( -0.625vw + ${window.outerWidth / 2}px - ${isFlyoutOpen ? props.width ?? "auto" : flyoutButtonWidth} / 2)`
     }
   }
 

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -70,30 +70,26 @@
 
 .dcp-item-image-box {
   position: absolute;
-  display: inline;
-  width: 100%;
-  height: auto;
-  left: -0.25%;
-  top: 34%;
-  padding: 0px;
-  margin: 0px;
-  text-align: center;
+  width: 75%;
+  height: 50%;
+  left: 11%;
+  top: 37%;
   cursor: pointer;
 }
 
 .dcp-item-image {
-  width: 75%;
-  height: auto;
-  bottom: 1%;
+  object-fit: fill;
+  width: 100%;
+  height: 100%;
   border-radius: 8px;
-  border: 2px solid white;
+  border: 2px solid transparent;
 }
 
 .dcp-item-help {
   position: absolute;
   cursor: help;
   left: 4px;
-  bottom: 7px;
+  bottom: 4px;
 }
 
 .dcp-item-help-icon {
@@ -116,7 +112,7 @@
 .dcp-item-new {
   position: absolute;
   right: 4px;
-  bottom: 7px;
+  bottom: 4px;
 }
 
 .dcp-item-new-icon {

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -34,14 +34,13 @@ const newReleases: DiskCollectionItem[] = [
   //   diskUrl: "https://www.brutaldeluxe.fr/products/apple2/encounter/encounteradventure.dsk",
   //   detailsUrl: "https://www.brutaldeluxe.fr/products/apple2/encounter/"
   // }
-  // $TODO: Add support for zipped disk images
-  // {
-  //   title: "Undead Demo",
-  //   lastUpdated: new Date("9/10/2024"),
-  //   imageUrl: "https://www.callapple.org/wp-content/uploads/2024/09/Undead_Demo.png",
-  //   diskUrl: "https://www.callapple.org/wp-content/uploads/2024/09/UNDEAD_DEMO.po_.zip",
-  //   detailsUrl: "https://www.kickstarter.com/projects/8-bit-shack/undead-a-new-apple-role-player-game?utm_source=a2central"
-  // }
+  {
+    title: "Undead Demo",
+    lastUpdated: new Date("9/10/2024"),
+    imageUrl: "https://www.callapple.org/wp-content/uploads/2024/09/Undead_Demo.png",
+    diskUrl: "https://www.callapple.org/wp-content/uploads/2024/09/UNDEAD_DEMO.po_.zip",
+    detailsUrl: "https://www.kickstarter.com/projects/8-bit-shack/undead-a-new-apple-role-player-game?utm_source=a2central"
+  }
 ]
 
 const minDate = new Date(0)
@@ -95,16 +94,14 @@ const DiskCollectionPanel = (props: DisplayProps) => {
 
   const handleItemClick = (itemIndex: number) => () => {
     const diskCollectionItem = diskCollectionItems[itemIndex]
-
     if (diskCollectionItem.diskImage) {
       handleSetDiskFromFile(diskCollectionItem.diskImage, props.updateDisplay)
+    } else if (diskCollectionItem.diskUrl) {
+      handleSetDiskFromURL(diskCollectionItem.diskUrl)
     } else {
-      if (diskCollectionItem.diskUrl) {
-        handleSetDiskFromURL(diskCollectionItem.diskUrl)
-      } else {
-        // $TODO: Add error handling
-      }
+      // $TODO: Add error handling
     }
+
     setIsFlyoutOpen(false)
   }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/34e1eaa4-1a52-459f-85b4-b709a76b1782)
![image](https://github.com/user-attachments/assets/efced7dd-f1b9-4470-8d44-1e3c1b4955ac)

**Changes made:**
- Updated `handleSetDiskFromURL` to support downloading .zip files
- Added Undead Demo to new releases collection
- Updated disk collection image snapshot to stretch to fill
- Added `fflate` package to support file unzip
- Minor tweak to better center disk collection flyout panel

**Tests performed:**
- Verified Undead Demo appears as a new release in the disk collections panel
- Verified Undead Demo unzips and loads in the emulator when clicked
- Verified on multiple platforms (PC, Mac, iPhone, iPad) and OSes (Windows, MacOS, iOS)
- Verified on multiple browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a