### PR TITLE
Fix for bug 136

### DIFF
--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -34,7 +34,6 @@ const DisplayApple2 = () => {
   const [closedAppleKeyMode, setClosedAppleKeyMode] = useState(0)
   const [showFileOpenDialog, setShowFileOpenDialog] = useState({ show: false, index: 0 })
   const [worker, setWorker] = useState<Worker | null>(null)
-  const handleInputParamsResult = handleInputParams()
 
   // We need to create our worker here so it has access to our properties
   // such as cpu speed and help text. Otherwise, if the emulator changed
@@ -85,7 +84,8 @@ const DisplayApple2 = () => {
     // preloadAssets()
     passSpeedMode(0)
     loadPreferences()
-    handleFragment(updateDisplay, handleInputParamsResult.hasBasicProgram)
+    const hasBasicProgram = handleInputParams()
+    handleFragment(updateDisplay, hasBasicProgram)
     //    window.addEventListener('beforeunload', (event) => {
     // Cancel the event as stated by the standard.
     //      event.preventDefault();

--- a/src/ui/inputparams.ts
+++ b/src/ui/inputparams.ts
@@ -4,23 +4,13 @@ import { COLOR_MODE, UI_THEME } from "../common/utility"
 import { useGlobalContext } from "./globalcontext"
 import { passCapsLock, passSetDebug, passSpeedMode, passColorMode, passSetRamWorks, passTheme, passPasteText, passShowScanlines } from "./main2worker"
 
-export type HandleInputParamsResult = {
-  hasBasicProgram: boolean
-  experiments: string[]
-}
-
-export const handleInputParams = (): HandleInputParamsResult => {
+export const handleInputParams = () => {
   // Most parameters are case insensitive. The only exception is the BASIC
   // parameter, where we want to preserve the case of the program.
   const params = new URLSearchParams(window.location.search.toLowerCase())
   const porig = new URLSearchParams(window.location.search)
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { setRunTour } = useGlobalContext()
-
-  const result: HandleInputParamsResult = {
-    hasBasicProgram: false,
-    experiments: []
-  }
 
   if (params.get("capslock") === "off") {
     passCapsLock(false)
@@ -94,16 +84,11 @@ export const handleInputParams = (): HandleInputParamsResult => {
     setRunTour(tour)
   }
 
-  const experiments = params.get("exp")
-  if (experiments) {
-    // Experiments go here
-  }
-
   const run = params.get("run")
   const doRun = !(run === "0" || run === "false")
   // Use the original case of the BASIC program.
   const basic = porig.get("basic") || porig.get("BASIC")
-  result.hasBasicProgram = basic !== null
+   const hasBasicProgram = basic !== null
   if (basic) {
     const trimmed = basic.trim()
     const hasLineNumbers = /^[0-9]/.test(trimmed) || /[\n\r][0-9]/.test(trimmed)
@@ -112,7 +97,7 @@ export const handleInputParams = (): HandleInputParamsResult => {
     setTimeout(() => { passPasteText(basic + cmd) }, 1500)
   }
 
-  return result
+  return hasBasicProgram
 }
 
 // Examples:
@@ -135,7 +120,7 @@ export const handleFragment = async (updateDisplay: UpdateDisplay, hasBasicProgr
     handleSetDiskFromURL(url, updateDisplay)
   } else if (hasBasicProgram) {
     // If we had a BASIC program in the URL, and we didn't have a floppy,
-    // then boot our default blank ProDOS disk.
+    // then boot our default blank ProDOS disk.`
     handleSetDiskFromURL("blank.po", updateDisplay)
   }
 }

--- a/src/ui/inputparams.ts
+++ b/src/ui/inputparams.ts
@@ -120,7 +120,7 @@ export const handleFragment = async (updateDisplay: UpdateDisplay, hasBasicProgr
     handleSetDiskFromURL(url, updateDisplay)
   } else if (hasBasicProgram) {
     // If we had a BASIC program in the URL, and we didn't have a floppy,
-    // then boot our default blank ProDOS disk.`
+    // then boot our default blank ProDOS disk.
     handleSetDiskFromURL("blank.po", updateDisplay)
   }
 }

--- a/src/worker/devices/keyboard.ts
+++ b/src/worker/devices/keyboard.ts
@@ -21,7 +21,7 @@ export const clearKeyStrobe = () => {
 // even if $C010 (the keyboard strobe) isn't being called properly.
 // This was a problem for certain games such as Firebug or Wolfenstein,
 // which only clear the $C010 strobe if it is a valid game key.
-// 1900 ms was heuristically chosen, as that's about how long it takes
+// 3800 ms was heuristically chosen, as that's about how long it takes
 // Applesoft BASIC to process a huge line of code.
 // TODO: We could use two buffers - one for keypress (with a short delay)
 // and another for pasted text, with a longer delay to give Applesoft BASIC
@@ -32,7 +32,7 @@ let tPrevPop = 1000000000
 export const popKey = () => {
   // See note above about this time cutoff before dropping buffer text.
   const t = performance.now()
-  if (keyBuffer !== "" && (memGetC000(0xC000) < 128 || (t - tPrevPop) > 1900)) {
+  if (keyBuffer !== "" && (memGetC000(0xC000) < 128 || (t - tPrevPop) > 3800)) {
     tPrevPop = t
     const key = keyBuffer.charCodeAt(0)
     keyPress(key)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/787f8e31-22fd-40dc-863a-55f46d968592)
![image](https://github.com/user-attachments/assets/31bc9748-5d18-4843-954f-53cfb69b676a)

Changes made:
- Rolled back defunct experiment support which caused BASIC code to run in an infinite loop
- Doubled keyboard buffer delay to avoid swallowing the R in RUN when processing complex BASIC code

Tests performed:
- Verified BASIC code in URL attached to bug worked as expected (see screenshots)
- Verified BASIC code no longer runs in an infinite loop
- Verified first R in RUN is not swallowed when running complex BASIC code

Issues resolved:
- Resolve bug #136 