### PR TITLE
Feature: Disk bookmarks

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -310,5 +310,6 @@ type DiskCollectionItem = {
   imageUrl: string,
   diskUrl?: string,
   detailsUrl?: string,
-  diskImage?: diskImage
+  diskImage?: diskImage,
+  bookmarkId?: string
 }

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -305,6 +305,7 @@ type DisassemblyProps = {
 }
 
 type DiskCollectionItem = {
+  type: DISK_COLLECTION_ITEM_TYPE,
   title: string,
   lastUpdated: Date,
   imageUrl: string,

--- a/src/common/diskbookmarks.ts
+++ b/src/common/diskbookmarks.ts
@@ -1,0 +1,64 @@
+const storageKeyPrefix = "dbm-"
+
+export type DiskBookmark = {
+  title: string,
+  screenshotUrl: URL,
+  diskUrl: URL
+}
+
+export class DiskBookmarks {
+  private bookmarks: Map<string, DiskBookmark>
+
+  public constructor() {
+    this.bookmarks = new Map<string, DiskBookmark>()
+    Object.keys(localStorage).forEach((storageKey) => {
+      if (storageKey.startsWith(storageKeyPrefix)) {
+        const storageValue = localStorage.getItem(storageKey)
+
+        if (storageValue) {
+          const bookmark = JSON.parse(storageValue)
+          this.bookmarks.set(storageKey.substring(storageKeyPrefix.length), bookmark)
+        } else {
+          localStorage.removeItem(storageKey)
+        }
+      }
+    })
+  }
+
+  *[Symbol.iterator](): Generator<DiskBookmark> {
+    for (const item of this.bookmarks.values()) {
+      yield item;
+    }
+  }
+
+  public contains(id: string): boolean {
+    let found = false
+
+   Array.from(this.bookmarks.keys()).forEach(key => {
+      if (key == id) {
+        found = true
+        return
+      }
+    })
+
+    return found
+  }
+
+  public add(id: string, bookmark: DiskBookmark) {
+    try {
+      localStorage.setItem(storageKeyPrefix + id, JSON.stringify(bookmark))
+      this.bookmarks.set(id, bookmark)
+    } catch (error) {
+      console.warn(error)
+    }
+  }
+
+  public remove(id: string) {
+    try {
+      this.bookmarks.delete(id)
+      localStorage.removeItem(storageKeyPrefix + id)
+    } catch (error) {
+      console.warn(error)
+    }
+  }
+}

--- a/src/common/diskbookmarks.ts
+++ b/src/common/diskbookmarks.ts
@@ -1,6 +1,9 @@
+import { DISK_COLLECTION_ITEM_TYPE } from "../ui/panels/diskcollectionpanel"
+
 const storageKeyPrefix = "dbm-"
 
 export type DiskBookmark = {
+  type: DISK_COLLECTION_ITEM_TYPE,
   id: string,
   title: string,
   screenshotUrl: URL,

--- a/src/common/diskbookmarks.ts
+++ b/src/common/diskbookmarks.ts
@@ -1,9 +1,12 @@
 const storageKeyPrefix = "dbm-"
 
 export type DiskBookmark = {
+  id: string,
   title: string,
   screenshotUrl: URL,
-  diskUrl: URL
+  diskUrl: URL,
+  detailsUrl: URL,
+  lastUpdated: Date
 }
 
 export class DiskBookmarks {
@@ -32,31 +35,22 @@ export class DiskBookmarks {
   }
 
   public contains(id: string): boolean {
-    let found = false
-
-   Array.from(this.bookmarks.keys()).forEach(key => {
-      if (key == id) {
-        found = true
-        return
-      }
-    })
-
-    return found
+    return this.bookmarks.has(id)
   }
 
-  public add(id: string, bookmark: DiskBookmark) {
+  public add(bookmark: DiskBookmark) {
     try {
-      localStorage.setItem(storageKeyPrefix + id, JSON.stringify(bookmark))
-      this.bookmarks.set(id, bookmark)
+      localStorage.setItem(storageKeyPrefix + bookmark.id, JSON.stringify(bookmark))
+      this.bookmarks.set(bookmark.id, bookmark)
     } catch (error) {
       console.warn(error)
     }
   }
 
-  public remove(id: string) {
+  public remove(bookmarkId: string) {
     try {
-      this.bookmarks.delete(id)
-      localStorage.removeItem(storageKeyPrefix + id)
+      this.bookmarks.delete(bookmarkId)
+      localStorage.removeItem(storageKeyPrefix + bookmarkId)
     } catch (error) {
       console.warn(error)
     }

--- a/src/common/diskbookmarks.ts
+++ b/src/common/diskbookmarks.ts
@@ -38,7 +38,17 @@ export class DiskBookmarks {
     return this.bookmarks.has(id)
   }
 
-  public add(bookmark: DiskBookmark) {
+  public get(id: string): DiskBookmark | undefined {
+    for (const bookmark of this.bookmarks.values()) {
+      if (bookmark.id == id) {
+        return bookmark
+      }
+    }
+
+    return undefined
+  }
+
+  public set(bookmark: DiskBookmark) {
     try {
       localStorage.setItem(storageKeyPrefix + bookmark.id, JSON.stringify(bookmark))
       this.bookmarks.set(bookmark.id, bookmark)

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -1,4 +1,5 @@
 import { KeyboardEvent } from "react"
+import { iconData, iconKey, iconName } from "../ui/img/iconfunctions"
 
 export const TEST_DEBUG = false
 export const TEST_GRAPHICS = false
@@ -447,4 +448,42 @@ export const handleSetTheme = (theme: UI_THEME) => {
 
 export const isFileSystemApiSupported = () => {
   return "showOpenFilePicker" in self && "showSaveFilePicker" in self
+}
+
+export const internetArchiveUrlProtocol = "a2ia://"
+
+export const generateUrlFromInternetArchiveId = (identifier: string): URL => {
+  return new URL(internetArchiveUrlProtocol + identifier)
+}
+
+export const getDiskImageUrlFromIdentifier = async (identifier: string) => {
+  let newDiskImageUrl: URL | undefined
+  const detailsUrl = `https://archive.org/details/${identifier}?output=json`
+  const favicon: { [key: string]: string } = {}
+  favicon[iconKey()] = iconData()
+  
+  await fetch(iconName() + detailsUrl, { headers: favicon })
+    .then(async response => {
+      if (response.ok) {
+        const json = await response.json()
+        if (json.metadata && json.metadata.emulator_ext && json.files) {
+          const emulatorExt = json.metadata.emulator_ext.toString().toLowerCase()
+
+          Object.keys(json.files).forEach((file) => {
+            if (file.toLowerCase().endsWith(emulatorExt)) {
+              newDiskImageUrl = new URL(`https://archive.org/download/${identifier}${file}`)
+              return
+            }
+          })
+        } else {
+          console.warn(`${detailsUrl}: disk image not found`)
+          return undefined
+        }
+      } else {
+        console.warn(`${detailsUrl}: ${response.statusText}`)
+        return undefined
+      }
+    })
+
+  return newDiskImageUrl
 }

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -462,6 +462,7 @@ export const getDiskImageUrlFromIdentifier = async (identifier: string) => {
   const favicon: { [key: string]: string } = {}
   favicon[iconKey()] = iconData()
   
+  showGlobalProgressModal(true)
   await fetch(iconName() + detailsUrl, { headers: favicon })
     .then(async response => {
       if (response.ok) {
@@ -484,6 +485,13 @@ export const getDiskImageUrlFromIdentifier = async (identifier: string) => {
         return undefined
       }
     })
+    .finally(() => {
+      showGlobalProgressModal(false)
+    })
 
   return newDiskImageUrl
+}
+
+export const showGlobalProgressModal = (show: boolean = true) => {
+  document.body.style.setProperty("--global-progress-visibility", show ? "visible" : "hidden")
 }

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -340,7 +340,7 @@ body.dark-mode .centered-title {
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
-  z-index: 9998;
+  z-index: 9997;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -381,4 +381,26 @@ body.dark-mode .divider {
 .noselect {
   cursor: default;
   user-select: none;
+}
+
+.global-progress-modal-overlay {
+  visibility: var(--global-progress-visibility, hidden);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.75);
+  z-index: 9998;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.global-progress-spinner {
+  width: 25%;
+  height: 25%;
+  color: white;
+  animation: rotate .5s linear 3;
+  -webkit-animation: rotate 2s linear infinite;
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,6 +4,8 @@ import DisplayApple2 from "./display"
 import { GlobalContext } from "./globalcontext"
 import { handleGetTheme } from "./main2worker"
 import { UI_THEME } from "../common/utility"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faRotate } from "@fortawesome/free-solid-svg-icons"
 
 const App = () => {
   const [updateHgr, setUpdateHgr] = useState(false)
@@ -33,6 +35,9 @@ const App = () => {
         setUpdateBreakpoint: setUpdateBreakpoint,
       }}>
       <DisplayApple2 />
+      <div className="global-progress-modal-overlay">
+        <FontAwesomeIcon icon={faRotate} className="global-progress-spinner"/>
+      </div>
     </GlobalContext.Provider>
   )
 }

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { CLOUD_SYNC, crc32, DISK_CONVERSION_SUFFIXES, FILE_SUFFIXES, isFileSystemApiSupported, RUN_MODE, uint32toBytes } from "../../common/utility"
+import { CLOUD_SYNC, crc32, DISK_CONVERSION_SUFFIXES, FILE_SUFFIXES, isFileSystemApiSupported, RUN_MODE, showGlobalProgressModal, uint32toBytes } from "../../common/utility"
 import { imageList } from "./assets"
 import {
   handleSetDiskData, handleGetDriveProps,
@@ -130,6 +130,8 @@ const DiskDrive = (props: DiskDriveProps) => {
   }, [dprops.filename, dprops.cloudData])
 
   const loadDiskFromCloud = async (newCloudDrive: CloudProvider) => {
+    showGlobalProgressModal(true)
+    
     const result = await newCloudDrive.download(FILE_SUFFIXES)
 
     if (result) {
@@ -137,6 +139,8 @@ const DiskDrive = (props: DiskDriveProps) => {
       const buffer = await new Response(blob).arrayBuffer()
       handleSetDiskOrFileFromBuffer(dprops.index, buffer, cloudData.fileName, cloudData, null)
     }
+
+    showGlobalProgressModal(false)
   }
 
   const saveDiskToCloud = async (cloudProvider: CloudProvider) => {

--- a/src/ui/devices/diskinterface.tsx
+++ b/src/ui/devices/diskinterface.tsx
@@ -2,7 +2,7 @@ import "./diskinterface.css"
 import DiskDrive from "./diskdrive"
 import { DiskImageChooser } from "./diskimagechooser"
 import Flyout from "../flyout"
-import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons"
+import { faHdd } from "@fortawesome/free-solid-svg-icons"
 import ImageWriter from "./imagewriter"
 import { useState } from "react"
 import { UI_THEME } from "../../common/utility"
@@ -18,8 +18,8 @@ const DiskInterface = (props: DisplayProps) => {
 
   return (
     <Flyout
-      icon={faFloppyDisk}
-      title="disk drives"
+      icon={faHdd}
+      title="disk drives and devices"
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       position="bottom-left">

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -159,6 +159,7 @@ export const handleSetDiskFromURL = async (url: string,
       const bookmark = diskBookmarks.get(identifier)
       if (bookmark) {
         diskBookmarks.set({
+          type: bookmark.type,
           id: bookmark.id,
           title: bookmark.title,
           screenshotUrl: bookmark.screenshotUrl,

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -158,15 +158,8 @@ export const handleSetDiskFromURL = async (url: string,
       const diskBookmarks = new DiskBookmarks()
       const bookmark = diskBookmarks.get(identifier)
       if (bookmark) {
-        diskBookmarks.set({
-          type: bookmark.type,
-          id: bookmark.id,
-          title: bookmark.title,
-          screenshotUrl: bookmark.screenshotUrl,
-          diskUrl: resolvedUrl,
-          detailsUrl: bookmark.detailsUrl,
-          lastUpdated: bookmark.lastUpdated
-        })
+        bookmark.diskUrl = resolvedUrl
+        diskBookmarks.set(bookmark)
       }
     }
   }

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -1,5 +1,5 @@
 import { DiskBookmarks } from "../../common/diskbookmarks"
-import { FILE_SUFFIXES, MAX_DRIVES, RUN_MODE, getDiskImageUrlFromIdentifier, internetArchiveUrlProtocol, isHardDriveImage, replaceSuffix } from "../../common/utility"
+import { FILE_SUFFIXES, MAX_DRIVES, RUN_MODE, getDiskImageUrlFromIdentifier, internetArchiveUrlProtocol, isHardDriveImage, replaceSuffix, showGlobalProgressModal } from "../../common/utility"
 import { iconKey, iconData, iconName } from "../img/iconfunctions"
 import { handleGetRunMode, passPasteText, passSetBinaryBlock, passSetDriveNewData, passSetDriveProps, passSetRunMode } from "../main2worker"
 import { getBlobFromDiskData } from "./diskdrive"
@@ -172,11 +172,14 @@ export const handleSetDiskFromURL = async (url: string,
     // Ask CT6502 for why we need to use this favicon header
     const favicon: { [key: string]: string } = {}
     favicon[iconKey()] = iconData()
+
+    showGlobalProgressModal(true)
     const response = await fetch(iconName() + url, { headers: favicon })
     if (!response.ok) {
       console.error(`HTTP error: status ${response.status}`)
       return
     }
+    showGlobalProgressModal(false)
 
     const blob = await response.blob()
 

--- a/src/ui/devices/onedriveclouddrive.ts
+++ b/src/ui/devices/onedriveclouddrive.ts
@@ -1,4 +1,4 @@
-import { CLOUD_SYNC, showGlobalProgressModal } from "../../common/utility"
+import { CLOUD_SYNC } from "../../common/utility"
 
 export const DEFAULT_SYNC_INTERVAL = 1 * 60 * 1000
 
@@ -25,7 +25,6 @@ export class OneDriveCloudDrive implements CloudProvider {
       }
 
       const downloadUrl = file["@content.downloadUrl"]
-      console.log(`HTTP GET: ${downloadUrl}`)
       const response = await fetch(downloadUrl)
       if (response.ok) {
         cloudData.syncStatus = CLOUD_SYNC.ACTIVE
@@ -68,7 +67,6 @@ export class OneDriveCloudDrive implements CloudProvider {
     let success = false
 
     console.log(`fetch: POST ${sessionUrl}`)
-    showGlobalProgressModal(true)
     await fetch(sessionUrl, {
       method: "POST",
       mode: "cors",
@@ -98,7 +96,6 @@ export class OneDriveCloudDrive implements CloudProvider {
       cloudData.syncStatus = CLOUD_SYNC.FAILED
     })
     .finally(() => {
-      showGlobalProgressModal(false)
       cloudData.lastSyncTime = Date.now()
     })
 

--- a/src/ui/devices/onedriveclouddrive.ts
+++ b/src/ui/devices/onedriveclouddrive.ts
@@ -1,4 +1,4 @@
-import { CLOUD_SYNC } from "../../common/utility"
+import { CLOUD_SYNC, showGlobalProgressModal } from "../../common/utility"
 
 export const DEFAULT_SYNC_INTERVAL = 1 * 60 * 1000
 
@@ -68,6 +68,7 @@ export class OneDriveCloudDrive implements CloudProvider {
     let success = false
 
     console.log(`fetch: POST ${sessionUrl}`)
+    showGlobalProgressModal(true)
     await fetch(sessionUrl, {
       method: "POST",
       mode: "cors",
@@ -97,6 +98,7 @@ export class OneDriveCloudDrive implements CloudProvider {
       cloudData.syncStatus = CLOUD_SYNC.FAILED
     })
     .finally(() => {
+      showGlobalProgressModal(false)
       cloudData.lastSyncTime = Date.now()
     })
 

--- a/src/ui/internetarchivedialog.css
+++ b/src/ui/internetarchivedialog.css
@@ -154,7 +154,6 @@
 
 .iad-result-bookmark {
   position: relative;
-  height: 1.75em;
   top: 21px;
   right: 4px;
   text-align: right;
@@ -162,7 +161,6 @@
 }
 
 .iad-result-bookmark-icon {
-  height: 100%;
   color: yellow;
 }
 

--- a/src/ui/internetarchivedialog.css
+++ b/src/ui/internetarchivedialog.css
@@ -152,9 +152,23 @@
   font-size: 12pt;
 }
 
+.iad-result-bookmark {
+  position: relative;
+  height: 1.75em;
+  top: 21px;
+  right: 4px;
+  text-align: right;
+  cursor: pointer;
+}
+
+.iad-result-bookmark-icon {
+  height: 100%;
+  color: yellow;
+}
+
 .iad-result-tile {
   display: grid;
-  grid-template-rows: max(128px) 24pt 14pt;
+  grid-template-rows: 0px max(128px) 24pt 14pt;
   background-color: #ffffff;
   border: 1px #dddddd solid;
   border-radius: 4px;

--- a/src/ui/internetarchivedialog.tsx
+++ b/src/ui/internetarchivedialog.tsx
@@ -186,6 +186,7 @@ const InternetArchiveResult = (props: InternetDialogResultProps) => {
       title="Click to load disk image">
       <div className="iad-result-bookmark">
         <FontAwesomeIcon
+          size="2x"
           className="iad-result-bookmark-icon"
           onClick={bookmarked ? handleBookmarkRemoveClicked : handleBookmarkAddClicked}
           title={`Click to ${bookmarked ? "remove" : "add"} disk bookmark`}

--- a/src/ui/internetarchivedialog.tsx
+++ b/src/ui/internetarchivedialog.tsx
@@ -148,28 +148,32 @@ const InternetArchiveResult = (props: InternetDialogResultProps) => {
   }
 
   const handleStatsClick = () => {
-    window.open(`https://archive.org/details/${props.identifier}`, "_blank")
+    window.open(detailsUrl.toString(), "_blank")
     return false
   }
 
-  const handleBookmarkAddClicked = (title: string, screenshotUrl: URL) => async () => {
+  const handleBookmarkAddClicked = async () => {
     const newDiskImageUrl = await getDiskImageUrl()
 
     if (newDiskImageUrl) {
-      props.diskBookmarks.add(bookmarkId, {
-        title: title,
+      props.diskBookmarks.add({
+        id: bookmarkId,
+        title: props.title,
         screenshotUrl: screenshotUrl,
-        diskUrl: newDiskImageUrl
+        diskUrl: newDiskImageUrl,
+        detailsUrl: detailsUrl,
+        lastUpdated: new Date()
       })
       setBookmarked(true)
     }
   }
 
-  const handleBookmarkRemoveClicked = (bookmarkId: string) => () => {
+  const handleBookmarkRemoveClicked = () => {
     props.diskBookmarks.remove(bookmarkId)
     setBookmarked(false)
   }
 
+  const detailsUrl = new URL(`https://archive.org/details/${props.identifier}`)
   const screenshotUrl = new URL(`https://archive.org/services/img/${props.identifier}`)
   const bookmarkId = `ia-${props.identifier}`
 
@@ -183,7 +187,7 @@ const InternetArchiveResult = (props: InternetDialogResultProps) => {
       <div className="iad-result-bookmark">
         <FontAwesomeIcon
           className="iad-result-bookmark-icon"
-          onClick={bookmarked ? handleBookmarkRemoveClicked(bookmarkId) : handleBookmarkAddClicked(props.title, screenshotUrl)}
+          onClick={bookmarked ? handleBookmarkRemoveClicked : handleBookmarkAddClicked}
           title={`Click to ${bookmarked ? "remove" : "add"} disk bookmark`}
           icon={bookmarked ? faStarSolid : faStarOutline} />
       </div>

--- a/src/ui/internetarchivedialog.tsx
+++ b/src/ui/internetarchivedialog.tsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faStar as faStarOutline } from "@fortawesome/free-regular-svg-icons"
 import { faStar as faStarSolid } from "@fortawesome/free-solid-svg-icons"
 import { generateUrlFromInternetArchiveId } from "../common/utility"
+import { DISK_COLLECTION_ITEM_TYPE } from "./panels/diskcollectionpanel"
 
 const queryMaxRows = 25
 const queryFormat = "https://archive.org/advancedsearch.php?" + [
@@ -109,6 +110,7 @@ const InternetArchiveResult = (props: InternetDialogResultProps) => {
 
   const handleBookmarkAddClicked = async () => {
     props.diskBookmarks.set({
+      type: DISK_COLLECTION_ITEM_TYPE.INTERNET_ARCHIVE,
       id: props.identifier,
       title: props.title,
       screenshotUrl: screenshotUrl,
@@ -251,6 +253,7 @@ const InternetArchiveDialog = (props: InternetArchiveDialogProps) => {
     const queryUrl = formatString(queryFormat, newQuery || "*", newCollection.id, pageNumber.toString())
 
     setCursorBusy(true)
+
     fetch(queryUrl)
       .then(async response => {
         if (response.ok) {

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -45,9 +45,11 @@
   display: grid;
   align-items: center;
   width: 100%;
+  font-size: 0.825em;
   height: 3.5cqh;
   text-align: center;
   vertical-align: middle;
+  overflow: hidden;
 }
 
 .dcp-item-updated {
@@ -92,13 +94,13 @@
 .dcp-item-help {
   position: absolute;
   cursor: help;
-  left: 4px;
+  left: 2px;
   bottom: 7px;
 }
 
 .dcp-item-help-icon {
   position: relative;
-  top: 10px;
+  top: 14px;
   color: black;
   z-index: 1;
 }
@@ -107,22 +109,22 @@
   position: relative;
   width: 12px;
   height: 12px;
-  left: 18%;
-  bottom: 4px;
+  left: 3px;
+  bottom: 0px;
   background-color: white;
   z-index: 0;
 }
 
 .dcp-item-new {
   position: absolute;
-  right: 4px;
-  bottom: 7px;
+  right: 2px;
+  bottom: 4px;
 }
 
 .dcp-item-new-icon {
   position: relative;
-  top: 10px;
-  color: black;
+  top: 11px;
+  color: green;
   z-index: 1;
 }
 
@@ -136,13 +138,39 @@
   z-index: 0;
 }
 
+.dcp-item-bookmark {
+  position: absolute;
+  right: 2px;
+  bottom: 8px;
+  cursor: pointer;
+}
+
+.dcp-item-bookmark-icon {
+  position: relative;
+  color: yellow;
+  z-index: 1;
+}
+
+.dcp-item-archive {
+  position: absolute;
+  right: 2px;
+  bottom: 0px;
+}
+
+.dcp-item-archive-icon {
+  position: relative;
+  top: 13px;
+  color: gray;
+  z-index: 1;
+}
+
 @media (min-width: 1290px) {
   .disk-collection-panel {
     grid-template-columns: repeat(auto-fill, minmax(192px, 1fr));
   }
 
   .dcp-item-title {
-    font-size: 1.25em;
+    font-size: 1.125em;
     line-height: 1.25;
   }
 
@@ -153,6 +181,6 @@
 
 @media (min-height: 900px) {
   .disk-collection-panel {
-    max-height: 75vh;
+    max-height: 79vh;
   }
 }

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -136,25 +136,50 @@
   z-index: 1;
 }
 
-.dcp-item-archive {
+.dcp-item-a2ts {
   position: absolute;
-  right: 6px;
+  left: 6px;
   bottom: 6px;
 }
 
-.dcp-item-archive-icon {
+.dcp-item-a2ts-icon {
   position: relative;
   top: 11px;
   color: gainsboro;
   z-index: 1;
 }
 
-.dcp-item-archive-icon-bg {
+.dcp-item-a2ts-icon-bg {
   position: relative;
   width: 12px;
   height: 14px;
   left: 12%;
   bottom: 6px;
+  background-color: black;
+  z-index: 0;
+}
+
+.dcp-item-ia {
+  position: absolute;
+  width: 14%;
+  height: 10%;
+  left: 4px;
+  bottom: 28px;
+}
+
+.dcp-item-ia-icon {
+  position: relative;
+  top: 11px;
+  color: gainsboro;
+  z-index: 1;
+}
+
+.dcp-item-ia-icon-bg {
+  position: relative;
+  width: 58%;
+  height: 80%;
+  left: 12%;
+  bottom: 48%;
   background-color: black;
   z-index: 0;
 }

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -98,8 +98,8 @@
 
 .dcp-item-new {
   position: absolute;
-  left: 4%;
-  bottom: 6%;
+  left: 7px;
+  bottom: 10px;
 }
 
 .dcp-item-new-icon {
@@ -138,8 +138,8 @@
 
 .dcp-item-archive {
   position: absolute;
-  right: 4%;
-  bottom: 4%;
+  right: 6px;
+  bottom: 6px;
 }
 
 .dcp-item-archive-icon {

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -38,7 +38,7 @@
   font-weight: bold;
   line-height: 0.85;
   color: white;
-  pointer-events: none;
+  cursor: pointer;
 }
 
 .dcp-item-title {
@@ -52,30 +52,33 @@
   overflow: hidden;
 }
 
+.dcp-item-title:hover {
+  text-decoration: underline;
+}
+
 .dcp-item-updated {
   position: absolute;
   width: 36%;
-  top: 20%;
-  left: 7%;
+  top: 18%;
+  left: 6%;
   text-align: center;
   font-size: 0.25em;
   color: black;
+  pointer-events: none;
 }
 
 .dcp-item-disk {
   width: 100%;
   height: auto;
-  cursor: pointer;
   padding: 0px;
   margin: 0px;
 }
 
 .dcp-item-image-box {
   position: absolute;
-  width: 75%;
-  height: 50%;
-  left: 11%;
-  top: 37%;
+  width: 96%;
+  height: 64%;
+  top: 30%;
   cursor: pointer;
 }
 
@@ -83,15 +86,19 @@
   object-fit: fill;
   width: 100%;
   height: 100%;
-  border-radius: 8px;
-  border: 2px solid transparent;
+  border-radius: 4px;
+  border: 3px solid white;
+}
+
+.dcp-item-image:hover {
+  opacity: 100%;
 }
 
 .dcp-item-help {
   position: absolute;
   cursor: help;
-  left: 2px;
-  bottom: 4px;
+  left: 1px;
+  bottom: 5px;
 }
 
 .dcp-item-help-icon {
@@ -113,8 +120,8 @@
 
 .dcp-item-new {
   position: absolute;
-  right: 2px;
-  bottom: 4px;
+  left: 4%;
+  bottom: 6%;
 }
 
 .dcp-item-new-icon {
@@ -129,35 +136,49 @@
   width: 12px;
   height: 12px;
   left: 18%;
-  bottom: 4px;
+  bottom: 6px;
   background-color: white;
   z-index: 0;
 }
 
 .dcp-item-bookmark {
   position: absolute;
-  right: 2px;
-  bottom: 8px;
+  right: 8px;
+  width: 21%;
+  height: 21%;
+  bottom: 45%;
   cursor: pointer;
 }
 
 .dcp-item-bookmark-icon {
   position: relative;
+  width: 100%;
+  height: 100%;
   color: yellow;
   z-index: 1;
 }
 
 .dcp-item-archive {
   position: absolute;
-  right: 2px;
-  bottom: 0px;
+  right: 4%;
+  bottom: 3%;
 }
 
 .dcp-item-archive-icon {
   position: relative;
-  top: 13px;
-  color: gray;
+  top: 11px;
+  color: gainsboro;
   z-index: 1;
+}
+
+.dcp-item-archive-icon-bg {
+  position: relative;
+  width: 12px;
+  height: 14px;
+  left: 12%;
+  bottom: 6px;
+  background-color: black;
+  z-index: 0;
 }
 
 @media (min-width: 1290px) {
@@ -177,6 +198,6 @@
 
 @media (min-height: 900px) {
   .disk-collection-panel {
-    max-height: 79vh;
+    max-height: 75vh;
   }
 }

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -50,6 +50,7 @@
   vertical-align: middle;
   overflow: hidden;
   color: white;
+  cursor: default;
 }
 
 .dcp-item-title-link {
@@ -138,7 +139,7 @@
 .dcp-item-archive {
   position: absolute;
   right: 4%;
-  bottom: 3%;
+  bottom: 4%;
 }
 
 .dcp-item-archive-icon {

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -38,7 +38,6 @@
   font-weight: bold;
   line-height: 0.85;
   color: white;
-  cursor: pointer;
 }
 
 .dcp-item-title {
@@ -50,17 +49,19 @@
   text-align: center;
   vertical-align: middle;
   overflow: hidden;
+  color: white;
 }
 
-.dcp-item-title:hover {
+.dcp-item-title-link {
   text-decoration: underline;
+  cursor: pointer;
 }
 
 .dcp-item-updated {
   position: absolute;
   width: 36%;
   top: 18%;
-  left: 6%;
+  left: 5%;
   text-align: center;
   font-size: 0.25em;
   color: black;
@@ -94,30 +95,6 @@
   opacity: 100%;
 }
 
-.dcp-item-help {
-  position: absolute;
-  cursor: help;
-  left: 1px;
-  bottom: 5px;
-}
-
-.dcp-item-help-icon {
-  position: relative;
-  top: 14px;
-  color: black;
-  z-index: 1;
-}
-
-.dcp-item-help-icon-bg {
-  position: relative;
-  width: 12px;
-  height: 12px;
-  left: 3px;
-  bottom: 0px;
-  background-color: white;
-  z-index: 0;
-}
-
 .dcp-item-new {
   position: absolute;
   left: 4%;
@@ -127,7 +104,7 @@
 .dcp-item-new-icon {
   position: relative;
   top: 11px;
-  color: green;
+  color: gainsboro;
   z-index: 1;
 }
 
@@ -137,15 +114,15 @@
   height: 12px;
   left: 18%;
   bottom: 6px;
-  background-color: white;
+  background-color: black;
   z-index: 0;
 }
 
 .dcp-item-bookmark {
   position: absolute;
   right: 8px;
-  width: 21%;
-  height: 21%;
+  width: 20%;
+  height: 20%;
   bottom: 45%;
   cursor: pointer;
 }

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import "./diskcollectionpanel.css"
 import Flyout from "../flyout"
-import { faClock, faFloppyDisk, faStar } from "@fortawesome/free-solid-svg-icons"
+import { faCircleExclamation, faFloppyDisk, faStar } from "@fortawesome/free-solid-svg-icons"
 import { handleSetDiskFromFile, handleSetDiskFromURL } from "../devices/driveprops"
 import { diskImages } from "../devices/diskimages"
 import { replaceSuffix } from "../../common/utility"
@@ -165,7 +165,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
             <img className="dcp-item-disk" src="/floppy.png" />
             {!diskCollectionItem.bookmarkId && !diskCollectionItem.diskImage &&
               <div className="dcp-item-new" title="Disk is a new release">
-                <FontAwesomeIcon icon={faClock} size="lg" className="dcp-item-new-icon" onClick={(event) => event.stopPropagation()} />
+                <FontAwesomeIcon icon={faCircleExclamation} size="lg" className="dcp-item-new-icon" onClick={(event) => event.stopPropagation()} />
                 <div className="dcp-item-new-icon-bg">&nbsp;</div>
               </div>}
             {diskCollectionItem.bookmarkId &&

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -43,7 +43,7 @@ const newReleases: DiskCollectionItem[] = [
 
 const minDate = new Date(0)
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
-  year: 'numeric',
+  year: '2-digit',
   month: 'numeric',
   day: 'numeric'
 });
@@ -150,22 +150,22 @@ const DiskCollectionPanel = (props: DisplayProps) => {
       position="top-center">
       <div className="disk-collection-panel">
         {diskCollection.sort(sortByLastUpdatedAsc).map((diskCollectionItem, index) => (
-          <div key={`dcp-item-${index}`} className="dcp-item" title={`Click to insert disk "${diskCollectionItem.title}"`} onClick={handleItemClick(index)}>
+          <div key={`dcp-item-${index}`} className="dcp-item">
             <div className="dcp-item-title-box">
               <div className="dcp-item-title">{diskCollectionItem.title}</div>
             </div>
             {diskCollectionItem.lastUpdated > minDate && <div className="dcp-item-updated">{dateFormatter.format(diskCollectionItem.lastUpdated)}</div>}
-            <div className="dcp-item-image-box">
+            <div className="dcp-item-image-box" title={`Click to insert disk "${diskCollectionItem.title}"`} onClick={handleItemClick(index)}>
               <img className="dcp-item-image" src={diskCollectionItem.imageUrl} />
             </div>
             <img className="dcp-item-disk" src="/floppy.png" />
-            {diskCollectionItem.detailsUrl &&
+            {/* {diskCollectionItem.detailsUrl &&
               <div className="dcp-item-help"
                 title={`Click to show details for "${diskCollectionItem.title}"`}
                 onClick={handleHelpClick(index)}>
-                <FontAwesomeIcon icon={faQuestionCircle} size="lg" className="dcp-item-help-icon" />
+                <FontAwesomeIcon icon={faQuestionCircle} size="xl" className="dcp-item-help-icon" />
                 <div className="dcp-item-help-icon-bg">&nbsp;</div>
-              </div>}
+              </div>} */}
             {!diskCollectionItem.bookmarkId && !diskCollectionItem.diskImage &&
               <div className="dcp-item-new" title="Disk is a new release">
                 <FontAwesomeIcon icon={faClock} size="lg" className="dcp-item-new-icon" onClick={(event) => event.stopPropagation()} />
@@ -174,12 +174,12 @@ const DiskCollectionPanel = (props: DisplayProps) => {
             {diskCollectionItem.bookmarkId &&
               <div
                 className="dcp-item-bookmark" title="Click to remove bookmark" onClick={handleBookmarkClick(index)}>
-                <FontAwesomeIcon icon={faStar} size="lg" className="dcp-item-bookmark-icon" />
+                <FontAwesomeIcon icon={faStar} className="dcp-item-bookmark-icon" />
               </div>}
             {diskCollectionItem.diskImage &&
               <div className="dcp-item-archive" title="Disk is part of the Apple2TS archive">
-                <FontAwesomeIcon icon={faArchive} size="lg" className="dcp-item-archive-icon" onClick={(event) => event.stopPropagation()} />
-                <div className="dcp-item-new-archive-bg">&nbsp;</div>
+                <FontAwesomeIcon icon={faFloppyDisk} size="lg" className="dcp-item-archive-icon" onClick={(event) => event.stopPropagation()} />
+                <div className="dcp-item-archive-icon-bg">&nbsp;</div>
               </div>}
           </div>
         ))}

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -152,20 +152,19 @@ const DiskCollectionPanel = (props: DisplayProps) => {
         {diskCollection.sort(sortByLastUpdatedAsc).map((diskCollectionItem, index) => (
           <div key={`dcp-item-${index}`} className="dcp-item">
             <div className="dcp-item-title-box">
-              <div className="dcp-item-title">{diskCollectionItem.title}</div>
+              <div
+                className={`dcp-item-title ${diskCollectionItem.detailsUrl ? "dcp-item-title-link" : ""}`}
+                title={diskCollectionItem.detailsUrl ? `Click to show details for "${diskCollectionItem.title}"` : diskCollectionItem.title}
+                onClick={diskCollectionItem.detailsUrl ? handleHelpClick(index) : () => {}}>{diskCollectionItem.title}</div>
             </div>
             {diskCollectionItem.lastUpdated > minDate && <div className="dcp-item-updated">{dateFormatter.format(diskCollectionItem.lastUpdated)}</div>}
-            <div className="dcp-item-image-box" title={`Click to insert disk "${diskCollectionItem.title}"`} onClick={handleItemClick(index)}>
+            <div
+              className="dcp-item-image-box"
+              title={`Click to insert disk "${diskCollectionItem.title}"`}
+              onClick={handleItemClick(index)}>
               <img className="dcp-item-image" src={diskCollectionItem.imageUrl} />
             </div>
             <img className="dcp-item-disk" src="/floppy.png" />
-            {/* {diskCollectionItem.detailsUrl &&
-              <div className="dcp-item-help"
-                title={`Click to show details for "${diskCollectionItem.title}"`}
-                onClick={handleHelpClick(index)}>
-                <FontAwesomeIcon icon={faQuestionCircle} size="xl" className="dcp-item-help-icon" />
-                <div className="dcp-item-help-icon-bg">&nbsp;</div>
-              </div>} */}
             {!diskCollectionItem.bookmarkId && !diskCollectionItem.diskImage &&
               <div className="dcp-item-new" title="Disk is a new release">
                 <FontAwesomeIcon icon={faClock} size="lg" className="dcp-item-new-icon" onClick={(event) => event.stopPropagation()} />

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import "./diskcollectionpanel.css"
 import Flyout from "../flyout"
-import { faArchive, faExclamationCircle, faQuestionCircle } from "@fortawesome/free-solid-svg-icons"
+import { faExclamationCircle, faFloppyDisk, faQuestionCircle } from "@fortawesome/free-solid-svg-icons"
 import { handleSetDiskFromFile, handleSetDiskFromURL } from "../devices/driveprops"
 import { diskImages } from "../devices/diskimages"
 import { replaceSuffix } from "../../common/utility"
@@ -110,7 +110,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
 
   return (
     <Flyout
-      icon={faArchive}
+      icon={faFloppyDisk}
       buttonId="tour-disk-images"
       title="disk collection"
       isOpen={() => { return isFlyoutOpen }}

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -7,10 +7,18 @@ import { diskImages } from "../devices/diskimages"
 import { replaceSuffix } from "../../common/utility"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { DiskBookmarks } from "../../common/diskbookmarks"
+import { svgInternetArchiveLogo } from "../img/icon_internetarchive"
+
+export enum DISK_COLLECTION_ITEM_TYPE {
+  A2TS_ARCHIVE,
+  INTERNET_ARCHIVE,
+  NEW_RELEASE
+}
 
 // $TODO: Read this disk collection data from a hosted JSON file
 const newReleases: DiskCollectionItem[] = [
   {
+    type: DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE,
     title: "Glider for Apple II",
     lastUpdated: new Date("3/16/2025"),
     imageUrl: "https://www.colino.net/wordpress/wp-content/uploads/glider-splash.png",
@@ -18,6 +26,7 @@ const newReleases: DiskCollectionItem[] = [
     detailsUrl: "https://www.colino.net/wordpress/glider-for-apple-ii/"
   },
   {
+    type: DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE,
     title: "Million Perfect Tiles",
     lastUpdated: new Date("12/30/2024"),
     imageUrl: "https://ia800300.us.archive.org/16/items/MillionPerfectTiles/00playable_screenshot.png",
@@ -26,6 +35,7 @@ const newReleases: DiskCollectionItem[] = [
   },
   // $TODO: Figure out why the DSK fails to load
   // {
+  //   type: DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE,
   //   title: "Encounter Adventure",
   //   lastUpdated: new Date("11/11/2024"),
   //   imageUrl: "https://www.brutaldeluxe.fr/products/apple2/encounter/title.jpg",
@@ -33,6 +43,7 @@ const newReleases: DiskCollectionItem[] = [
   //   detailsUrl: "https://www.brutaldeluxe.fr/products/apple2/encounter/"
   // }
   {
+    type: DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE,
     title: "Undead Demo",
     lastUpdated: new Date("9/10/2024"),
     imageUrl: "https://www.callapple.org/wp-content/uploads/2024/09/Undead_Demo.png",
@@ -109,6 +120,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
     // Load built-in disk images
     diskImages.forEach((diskImage) => {
       newDiskCollection.push({
+        type: DISK_COLLECTION_ITEM_TYPE.A2TS_ARCHIVE,
         title: diskImage.title,
         lastUpdated: minDate,
         imageUrl: `${"/disks/" + replaceSuffix(diskImage.file, "png")}`,
@@ -120,6 +132,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
     // Load favorites
     for (const diskBookmark of diskBookmarks) {
       newDiskCollection.push({
+        type: diskBookmark.type,
         title: diskBookmark.title,
         lastUpdated: new Date(diskBookmark.lastUpdated),
         diskUrl: diskBookmark.diskUrl?.toString(),
@@ -163,20 +176,30 @@ const DiskCollectionPanel = (props: DisplayProps) => {
               <img className="dcp-item-image" src={diskCollectionItem.imageUrl} />
             </div>
             <img className="dcp-item-disk" src="/floppy.png" />
-            {!diskCollectionItem.bookmarkId && !diskCollectionItem.diskImage &&
+            {diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE &&
               <div className="dcp-item-new" title="Disk is a new release">
                 <FontAwesomeIcon icon={faCircleExclamation} size="lg" className="dcp-item-new-icon" onClick={(event) => event.stopPropagation()} />
                 <div className="dcp-item-new-icon-bg">&nbsp;</div>
+              </div>}
+            {diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.A2TS_ARCHIVE &&
+              <div className="dcp-item-a2ts" title="Disk is part of the Apple2TS collection">
+                <FontAwesomeIcon icon={faFloppyDisk} size="lg" className="dcp-item-a2ts-icon" onClick={(event) => event.stopPropagation()} />
+                <div className="dcp-item-a2ts-icon-bg">&nbsp;</div>
+              </div>}
+            {diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.INTERNET_ARCHIVE &&
+              <div className="dcp-item-ia" title="Disk is part of the Internet Archive">
+                {/* <FontAwesomeIcon icon={faFloppyDisk} size="lg" className="dcp-item-ia-icon" onClick={(event) => event.stopPropagation()} /> */}
+                <svg
+                  className="dcp-item-ia-icon"
+                  onClick={(event) => event.stopPropagation()}
+                  fill="#ffffff"
+                  viewBox="0 0 55 55">{svgInternetArchiveLogo}</svg>
+                <div className="dcp-item-ia-icon-bg">&nbsp;</div>
               </div>}
             {diskCollectionItem.bookmarkId &&
               <div
                 className="dcp-item-bookmark" title="Click to remove bookmark" onClick={handleBookmarkClick(index)}>
                 <FontAwesomeIcon icon={faStar} className="dcp-item-bookmark-icon" />
-              </div>}
-            {diskCollectionItem.diskImage &&
-              <div className="dcp-item-archive" title="Disk is part of the Apple2TS archive">
-                <FontAwesomeIcon icon={faFloppyDisk} size="lg" className="dcp-item-archive-icon" onClick={(event) => event.stopPropagation()} />
-                <div className="dcp-item-archive-icon-bg">&nbsp;</div>
               </div>}
           </div>
         ))}

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import "./diskcollectionpanel.css"
 import Flyout from "../flyout"
-import { faCircleExclamation, faFloppyDisk, faStar } from "@fortawesome/free-solid-svg-icons"
+import { faClock, faFloppyDisk, faStar } from "@fortawesome/free-solid-svg-icons"
 import { handleSetDiskFromFile, handleSetDiskFromURL } from "../devices/driveprops"
 import { diskImages } from "../devices/diskimages"
 import { replaceSuffix } from "../../common/utility"
@@ -178,7 +178,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
             <img className="dcp-item-disk" src="/floppy.png" />
             {diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE &&
               <div className="dcp-item-new" title="Disk is a new release">
-                <FontAwesomeIcon icon={faCircleExclamation} size="lg" className="dcp-item-new-icon" onClick={(event) => event.stopPropagation()} />
+                <FontAwesomeIcon icon={faClock} size="lg" className="dcp-item-new-icon" onClick={(event) => event.stopPropagation()} />
                 <div className="dcp-item-new-icon-bg">&nbsp;</div>
               </div>}
             {diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.A2TS_ARCHIVE &&
@@ -188,7 +188,6 @@ const DiskCollectionPanel = (props: DisplayProps) => {
               </div>}
             {diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.INTERNET_ARCHIVE &&
               <div className="dcp-item-ia" title="Disk is part of the Internet Archive">
-                {/* <FontAwesomeIcon icon={faFloppyDisk} size="lg" className="dcp-item-ia-icon" onClick={(event) => event.stopPropagation()} /> */}
                 <svg
                   className="dcp-item-ia-icon"
                   onClick={(event) => event.stopPropagation()}

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import "./diskcollectionpanel.css"
 import Flyout from "../flyout"
-import { faArchive, faClock, faFloppyDisk, faQuestionCircle, faStar } from "@fortawesome/free-solid-svg-icons"
+import { faClock, faFloppyDisk, faStar } from "@fortawesome/free-solid-svg-icons"
 import { handleSetDiskFromFile, handleSetDiskFromURL } from "../devices/driveprops"
 import { diskImages } from "../devices/diskimages"
 import { replaceSuffix } from "../../common/utility"
@@ -94,8 +94,6 @@ const DiskCollectionPanel = (props: DisplayProps) => {
     if (diskCollectionItem.bookmarkId) {
       diskBookmarks.remove(diskCollectionItem.bookmarkId)
       setDiskBookmarks(new DiskBookmarks())
-      // diskCollection.splice(itemIndex, 1)
-      // setDiskCollection(diskCollection)
     }
 
     event.stopPropagation();
@@ -124,7 +122,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
       newDiskCollection.push({
         title: diskBookmark.title,
         lastUpdated: new Date(diskBookmark.lastUpdated),
-        diskUrl: diskBookmark.diskUrl.toString(),
+        diskUrl: diskBookmark.diskUrl?.toString(),
         imageUrl: diskBookmark.screenshotUrl.toString(),
         detailsUrl: diskBookmark.detailsUrl.toString(),
         bookmarkId: diskBookmark.id
@@ -155,7 +153,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
               <div
                 className={`dcp-item-title ${diskCollectionItem.detailsUrl ? "dcp-item-title-link" : ""}`}
                 title={diskCollectionItem.detailsUrl ? `Click to show details for "${diskCollectionItem.title}"` : diskCollectionItem.title}
-                onClick={diskCollectionItem.detailsUrl ? handleHelpClick(index) : () => {}}>{diskCollectionItem.title}</div>
+                onClick={diskCollectionItem.detailsUrl ? handleHelpClick(index) : () => { }}>{diskCollectionItem.title}</div>
             </div>
             {diskCollectionItem.lastUpdated > minDate && <div className="dcp-item-updated">{dateFormatter.format(diskCollectionItem.lastUpdated)}</div>}
             <div


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/84dbf14d-ae6d-4821-ae96-4005c90686d2)

![image](https://github.com/user-attachments/assets/ac6679f8-c8b2-4cf7-a471-330912087713)

![image](https://github.com/user-attachments/assets/95675524-673e-4bc8-9e58-e86b403c604f)

**Changes made:**
- Added ability to add/remove bookmarked disks from Internet Archive search results
- Added bookmarked disks to the disk collection panel
- Added ability to remove bookmarked disks from the disk collection panel
- Created a global progress modal and enabled it for all long-running operations (HTTP fetch)
- Improved disk collection panel items to indicate the disk source (Internet Archive, new releases, A2TS collection)
- Created `DiskBookmarks` class which loads/saves disk bookmarks to/from local storage
- Updated `handleSetDiskFromURL()` to resolve custom app protocol URLs (`a2ia://`) to enable deferred download of Internet Archive disk images

**Tests performed:**
- Verified disk bookmarks can be toggled on the Internet Archive search results screen
- Verified disk bookmarks saved in local storage and persist across page reloads and browser sessions
- Verified disk bookmarks appear in and can be removed from the disk collection panel
- Verified on multiple platforms (PC, Mac, iPhone, iPad) and OSes (Windows, MacOS, iOS)
- Verified on multiple browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a