### PR TITLE
Fix: Progress modal not dismissed when loading disks from Google Drive

### DIFF
--- a/src/common/diskbookmarks.ts
+++ b/src/common/diskbookmarks.ts
@@ -33,7 +33,7 @@ export class DiskBookmarks {
 
   *[Symbol.iterator](): Generator<DiskBookmark> {
     for (const item of this.bookmarks.values()) {
-      yield item;
+      yield item
     }
   }
 

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -130,17 +130,12 @@ const DiskDrive = (props: DiskDriveProps) => {
   }, [dprops.filename, dprops.cloudData])
 
   const loadDiskFromCloud = async (newCloudDrive: CloudProvider) => {
-    showGlobalProgressModal(true)
-    
     const result = await newCloudDrive.download(FILE_SUFFIXES)
-
     if (result) {
       const [blob, cloudData] = result
       const buffer = await new Response(blob).arrayBuffer()
       handleSetDiskOrFileFromBuffer(dprops.index, buffer, cloudData.fileName, cloudData, null)
     }
-
-    showGlobalProgressModal(false)
   }
 
   const saveDiskToCloud = async (cloudProvider: CloudProvider) => {
@@ -158,24 +153,24 @@ const DiskDrive = (props: DiskDriveProps) => {
 
   const prepWritableFile = async (index: number, writableFileHandle: FileSystemFileHandle) => {
     const timer = setInterval(async (index: number) => {
-    const dprops = handleGetDriveProps(index)
+      const dprops = handleGetDriveProps(index)
 
-    if (handleGetHotReload()) {
-      const file = await writableFileHandle.getFile()
-      if (dprops.lastLocalWriteTime > 0 && file.lastModified > dprops.lastLocalWriteTime) {
-        handleSetDiskOrFileFromBuffer(index, await file.arrayBuffer(), file.name, null, writableFileHandle)
-        passSetRunMode(RUN_MODE.NEED_BOOT)
-        return
+      if (handleGetHotReload()) {
+        const file = await writableFileHandle.getFile()
+        if (dprops.lastLocalWriteTime > 0 && file.lastModified > dprops.lastLocalWriteTime) {
+          handleSetDiskOrFileFromBuffer(index, await file.arrayBuffer(), file.name, null, writableFileHandle)
+          passSetRunMode(RUN_MODE.NEED_BOOT)
+          return
+        }
       }
-    }
 
-    if (dprops.diskHasChanges && !dprops.motorRunning) {
-      if (await handleSaveWritableFile(index)) {
-        dprops.diskHasChanges = false
-        dprops.lastLocalWriteTime = Date.now()
-        passSetDriveProps(dprops)
+      if (dprops.diskHasChanges && !dprops.motorRunning) {
+        if (await handleSaveWritableFile(index)) {
+          dprops.diskHasChanges = false
+          dprops.lastLocalWriteTime = Date.now()
+          passSetDriveProps(dprops)
+        }
       }
-    }
     }, 3 * 1000, index)
     return () => clearInterval(timer)
   }

--- a/src/ui/devices/diskdrive.tsx
+++ b/src/ui/devices/diskdrive.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { CLOUD_SYNC, crc32, DISK_CONVERSION_SUFFIXES, FILE_SUFFIXES, isFileSystemApiSupported, RUN_MODE, showGlobalProgressModal, uint32toBytes } from "../../common/utility"
+import { CLOUD_SYNC, crc32, DISK_CONVERSION_SUFFIXES, FILE_SUFFIXES, isFileSystemApiSupported, RUN_MODE, uint32toBytes } from "../../common/utility"
 import { imageList } from "./assets"
 import {
   handleSetDiskData, handleGetDriveProps,

--- a/src/ui/devices/driveprops.ts
+++ b/src/ui/devices/driveprops.ts
@@ -184,8 +184,8 @@ export const handleSetDiskFromURL = async (url: string,
     const blob = await response.blob()
 
     if (url.toLowerCase().endsWith(".zip")) {
-      const unzipper = new fflate.Unzip();
-      unzipper.register(fflate.UnzipInflate);
+      const unzipper = new fflate.Unzip()
+      unzipper.register(fflate.UnzipInflate)
 
       unzipper.onfile = file => {
         const fileExtension = file.name.substring(file.name.lastIndexOf(".")).toLocaleLowerCase()

--- a/src/ui/devices/googledrive.ts
+++ b/src/ui/devices/googledrive.ts
@@ -1,4 +1,4 @@
-import { CLOUD_SYNC } from "../../common/utility"
+import { CLOUD_SYNC, showGlobalProgressModal } from "../../common/utility"
 
 // const MAX_UPLOAD_BYTES = 4 * 1024 * 1024 // 4 MB
 export const DEFAULT_SYNC_INTERVAL = 1 * 60 * 1000
@@ -120,12 +120,17 @@ export class GoogleDrive implements CloudProvider {
         apiEndpoint: "",
         parentID: result.parentID,
       }
+      
+      showGlobalProgressModal(true)
 
       const url = `https://www.googleapis.com/drive/v3/files/${result.fileId}?alt=media`
       const response = await fetch(url, {
         headers: {
           "Authorization": `Bearer ${g_accessToken}`
         }
+      })
+      .finally(() => {
+        showGlobalProgressModal(false)
       })
       if (response.ok) {
         console.log(`File download success: ${result.fileName}`)

--- a/src/ui/devices/onedriveclouddrive.ts
+++ b/src/ui/devices/onedriveclouddrive.ts
@@ -1,4 +1,4 @@
-import { CLOUD_SYNC } from "../../common/utility"
+import { CLOUD_SYNC, showGlobalProgressModal } from "../../common/utility"
 
 export const DEFAULT_SYNC_INTERVAL = 1 * 60 * 1000
 
@@ -24,8 +24,13 @@ export class OneDriveCloudDrive implements CloudProvider {
         parentID: "",
       }
 
+      showGlobalProgressModal(true)
+
       const downloadUrl = file["@content.downloadUrl"]
       const response = await fetch(downloadUrl)
+      .finally(() => {
+        showGlobalProgressModal(false)
+      })
       if (response.ok) {
         cloudData.syncStatus = CLOUD_SYNC.ACTIVE
         const blob = await response.blob()

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -57,14 +57,14 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: '2-digit',
   month: 'numeric',
   day: 'numeric'
-});
+})
 
 const sortByLastUpdatedAsc = (a: DiskCollectionItem, b: DiskCollectionItem): number => {
   if (a.lastUpdated && b.lastUpdated) {
     const aTime = a.lastUpdated
     const bTime = b.lastUpdated
-    if (aTime > bTime) return -1;
-    if (aTime < bTime) return 1;
+    if (aTime > bTime) return -1
+    if (aTime < bTime) return 1
   }
 
   if (a.title && b.title) {
@@ -81,8 +81,9 @@ const DiskCollectionPanel = (props: DisplayProps) => {
 
   const handleHelpClick = (itemIndex: number) => (event: React.MouseEvent<HTMLElement>) => {
     const diskCollectionItem = diskCollection[itemIndex]
-    event.stopPropagation();
-    window.open(diskCollectionItem.detailsUrl, "_blank"); return false;
+    event.stopPropagation()
+    window.open(diskCollectionItem.detailsUrl, "_blank")
+    return false
   }
 
   const handleItemClick = (itemIndex: number) => () => {
@@ -107,7 +108,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
       setDiskBookmarks(new DiskBookmarks())
     }
 
-    event.stopPropagation();
+    event.stopPropagation()
   }
 
   useEffect(() => {


### PR DESCRIPTION
**Changes made:**
- Moved show progress to after cloud drive pickers are displayed
- Removed semicolons added in previous PR

**Tests performed:**
- Verified load disk from cloud drives works as expected
- Verified scenarios on multiple platforms (Windows, Mac, iPhone, iPad) and browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a