### PR TITLE
Fix: Bookmarks added via the Internet Archive panel were not recognized in the 

### DIFF
--- a/src/ui/controls/popupmenu.tsx
+++ b/src/ui/controls/popupmenu.tsx
@@ -19,15 +19,16 @@ const PopupMenu = (props: PopupMenuProps) => {
     let w = 0
     let h = 0
 
-    props.menuItems[props.menuIndex || 0].forEach((menuItem) => {
+    props.menuItems[props.menuIndex || 0].filter(value => value.isVisible == undefined || value.isVisible()).map((menuItem) => {
       if (menuItem.label == "-") {
         w = Math.max(w, 9)
-        h += 16
+        h += 12
       } else {
         w = Math.max(w, menuItem.label.length * 9)
-        h += 28
+        h += 26
       }
     })
+    h += 22
 
     return {
       left: Math.min(x, window.innerWidth - w),

--- a/src/ui/flyout.tsx
+++ b/src/ui/flyout.tsx
@@ -44,7 +44,7 @@ const Flyout = (props: {
     if (props.position.indexOf("left") >= 0) {
       left = !isFlyoutOpen || !isTouchDevice ? "14px" : "48px"
     } else if (props.position.indexOf("center") >= 0) {
-      left = `calc( -0.625vw + ${window.outerWidth / 2}px - ${isFlyoutOpen ? props.width ?? "auto" : flyoutButtonWidth} / 2)`
+      left = `calc( ${isFlyoutOpen ? "-1.25vw" : "-0.625vw"} + ${window.outerWidth / 2}px - ${isFlyoutOpen ? props.width ?? "auto" : flyoutButtonWidth} / 2)`
     }
   }
 

--- a/src/ui/internetarchivedialog.tsx
+++ b/src/ui/internetarchivedialog.tsx
@@ -125,7 +125,18 @@ const InternetArchiveResult = (props: InternetDialogResultProps) => {
       screenshotUrl: screenshotUrl,
       diskUrl: generateUrlFromInternetArchiveId(props.identifier),
       detailsUrl: detailsUrl,
-      lastUpdated: new Date()
+      lastUpdated: new Date(),
+      cloudData: {
+        providerName: "InternetArchive",
+        syncStatus: CLOUD_SYNC.INACTIVE,
+        syncInterval: -1,
+        lastSyncTime: Number.MAX_VALUE,
+        fileName: "",
+        itemId: props.identifier,
+        apiEndpoint: "",
+        downloadUrl: generateUrlFromInternetArchiveId(props.identifier).toString(),
+        detailsUrl: `https://archive.org/details/${props.identifier}`
+      }
     })
     setBookmarked(true)
   }

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -5,12 +5,13 @@ import { faClock, faCloud, faFloppyDisk, faHardDrive, faStar } from "@fortawesom
 import { handleSetDiskFromCloudData, handleSetDiskFromFile, handleSetDiskFromURL } from "../devices/driveprops"
 import { diskImages } from "../devices/diskimages"
 import { newReleases } from "../devices/newreleases"
-import { replaceSuffix } from "../../common/utility"
+import { replaceSuffix, UI_THEME } from "../../common/utility"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { DiskBookmarks } from "../../common/diskbookmarks"
 import { svgInternetArchiveLogo } from "../img/icon_internetarchive"
 import PopupMenu from "../controls/popupmenu"
 import { DISK_DRIVE_LABELS } from "../devices/diskdrive"
+import { handleGetTheme } from "../main2worker"
 
 export enum DISK_COLLECTION_ITEM_TYPE {
   A2TS_ARCHIVE,
@@ -160,7 +161,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
       title="disk collection"
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
-      width="max( 75vw, 200px )"
+      width={`max( ${handleGetTheme() == UI_THEME.MINIMAL ? "55vw" : "75vw"}, 348px )`}
       position="top-center">
       <div className="disk-collection-panel">
         {diskCollection.sort(sortByLastUpdatedAsc).map((diskCollectionItem, index) => (


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0d44c722-2306-4249-b1d1-333bee973599)
![image](https://github.com/user-attachments/assets/677541da-c564-49a3-8062-5c00bcc82599)
![image](https://github.com/user-attachments/assets/0a134977-5f44-4fc5-be9c-4e21d9ac12d7)
![image](https://github.com/user-attachments/assets/110c6cb7-f481-47a7-8c87-b4bd1c82c94f)
![image](https://github.com/user-attachments/assets/e24b167a-55aa-428a-8ebb-c83336cb723a)

**Changes made:**
- Added IA disk metadata to bookmark cloud data when added via the IA panel
- Ignore hidden menu items when estimating popup menu dimensions
- Minor disk collection panel sizing tweaks

**Tests performed:**
- Verified bookmarks work consistently when added via IA panel and disk drive content menu
- Verified bookmark functionality on multiple devices (PC, Mac, iPhone, iPad) and browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a