### PR TITLE
Fix: Handled case where port is default/null when generating OneDrive auth redirect URL

### DIFF
--- a/src/ui/devices/disk/onedriveclouddrive.ts
+++ b/src/ui/devices/disk/onedriveclouddrive.ts
@@ -14,7 +14,8 @@ export class OneDriveCloudDrive implements CloudProvider {
 
   requestAuthToken(callback: (authToken: string) => void) {
     const baseUrl = new URL(window.location.href)
-    const redirectUri = `${baseUrl.protocol}//${baseUrl.hostname}:${baseUrl.port}?cloudProvider=OneDrive`
+    const port = baseUrl.port != "" ? `:${baseUrl.port}` : ""
+    const redirectUri = `${baseUrl.protocol}//${baseUrl.hostname}${port}?cloudProvider=OneDrive`
 
     window.open(`${authUrl}${redirectUri}`, "_blank")
     const interval = window.setInterval(async () => {


### PR DESCRIPTION
- Avoid appending ":" with no port in prod scenarios