### PR TITLE
Feature: Tabs for the disk collection panel

### DIFF
--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -101,6 +101,15 @@ export const setPreferenceFirstRunMinimal = (mode = true) => {
   // UI-only setting, pass along not necessary
 }
 
+export const setPreferenceNewReleasesChecked = (lastChecked = -1) => {
+  if (lastChecked == -1) {
+    localStorage.removeItem("newReleasesChecked")
+  } else {
+    localStorage.setItem("newReleasesChecked", JSON.stringify(lastChecked))
+  }
+  // UI-only setting, pass along not necessary
+}
+
 export const setPreferenceTouchJoystickMode = (mode: TOUCH_JOYSTICK_MODE = "off") => {
   if (mode === "off") {
     localStorage.removeItem("touchJoystickMode")
@@ -272,3 +281,15 @@ export const getPreferenceFirstRunMinimal = () => {
   return value
 }
 
+export const getPreferenceNewReleasesChecked = () => {
+  let value: number = -1
+
+  const item = localStorage.getItem("newReleasesChecked")
+  if (item) {
+    try {
+      value = JSON.parse(item)
+    } catch { /* empty */ }
+  }
+
+  return value
+}

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -40,8 +40,28 @@
   cursor: pointer;
 }
 
+.dcp-tab:hover {
+  background-color: gray;
+}
+
 .dcp-tab-active {
   background-color: gray;
+}
+
+.dcp-tab-highlighted {
+  animation: tabFadeInOut 3s 5;
+}
+
+@keyframes tabFadeInOut {
+
+  0%,
+  100% {
+    background-color: #aba7a2;
+  }
+
+  50% {
+    background-color: gray;
+  }
 }
 
 .dcp-item {

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -1,14 +1,14 @@
 .disk-collection-panel {
   display: grid;
   grid-template-rows: repeat(1fr);
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(156px, 1fr));
   row-gap: 0px;
   column-gap: 0px;
   margin: 0px;
   padding: 0px;
   width: 100%;
   height: auto;
-  max-height: 66vh;
+  max-height: 62vh;
   overflow-y: auto;
   padding-top: 6px;
   padding-bottom: 0px;
@@ -16,6 +16,32 @@
   padding-right: 0px;
   overflow-x: hidden;
   overflow-y: auto;
+}
+
+.dcp-tab-row {
+  display: grid;
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
+  margin-left: -2px;
+  margin-right: -6px;
+  padding: 12px;
+  padding-bottom: 0px;
+  border-bottom: 1px solid black;
+}
+
+.dcp-tab {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-top: 1px solid black;
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+  text-align: center;
+  padding: 4px;
+  cursor: pointer;
+}
+
+.dcp-tab-active {
+  background-color: gray;
 }
 
 .dcp-item {
@@ -101,7 +127,7 @@
 .dcp-item-new {
   position: absolute;
   left: 6px;
-  bottom: 10px;
+  bottom: 8px;
 }
 
 .dcp-item-new-icon {
@@ -141,7 +167,7 @@
 .dcp-item-a2ts {
   position: absolute;
   left: 6px;
-  bottom: 6px;
+  bottom: 4px;
 }
 
 .dcp-item-a2ts-icon {
@@ -166,7 +192,7 @@
   width: 14%;
   height: 10%;
   left: 4px;
-  bottom: 28px;
+  bottom: 26px;
 }
 
 .dcp-item-ia-icon {
@@ -219,6 +245,22 @@
 
 @media (min-height: 900px) {
   .disk-collection-panel {
-    max-height: 75vh;
+    max-height: 70vh;
+  }
+
+  .dcp-item-new {
+    bottom: 12px;
+  }
+
+  .dcp-item-a2ts {
+    bottom: 8px;
+  }
+
+  .dcp-item-ia {
+    position: absolute;
+    width: 14%;
+    height: 10%;
+    left: 4px;
+    bottom: 32px;
   }
 }

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -178,7 +178,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
           <div
             className={`dcp-tab ${i == activeTab ? "dcp-tab-active" : ""}`}
             title={tab.label}
-            onClick={() => {setActiveTab(i)}}>
+            onClick={(event) => {setActiveTab(i); event.stopPropagation() }}>
             <FontAwesomeIcon icon={tab.icon}/>
           </div>
         ))}

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import "./diskcollectionpanel.css"
 import Flyout from "../flyout"
-import { faClock, faCloud, faFloppyDisk, faHardDrive, faStar } from "@fortawesome/free-solid-svg-icons"
+import { faAsterisk, faClock, faCloud, faFloppyDisk, faH, faHardDrive, faHdd, faStar } from "@fortawesome/free-solid-svg-icons"
 import { UI_THEME } from "../../common/utility"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { svgInternetArchiveLogo } from "../img/icon_internetarchive"
@@ -48,6 +48,8 @@ const DiskCollectionPanel = (props: DisplayProps) => {
   const [diskBookmarks, setDiskBookmarks] = useState<DiskBookmarks>(new DiskBookmarks)
   const [popupLocation, setPopupLocation] = useState<[number, number]>()
   const [popupItemIndex, setPopupItemIndex] = useState<number>(-1)
+  const [activeTab, setActiveTab] = useState<number>(0)
+
   let longPressTimer: number
 
   const handleHelpClick = (itemIndex: number) => (event: React.MouseEvent<HTMLElement>) => {
@@ -144,6 +146,24 @@ const DiskCollectionPanel = (props: DisplayProps) => {
     setDiskCollection(newDiskCollection)
   }, [diskBookmarks])
 
+  const tabs = [
+    {
+      icon: faFloppyDisk,
+      label: "Show Apple2TS collection",
+      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.A2TS_ARCHIVE)
+    },
+    {
+      icon: faClock,
+      label: "Show new releases",
+      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE)
+    },
+    {
+      icon: faStar,
+      label: "Show favorites",
+      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.INTERNET_ARCHIVE || x.type == DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE)
+    }
+  ]
+
   return (
     <Flyout
       icon={faFloppyDisk}
@@ -153,8 +173,18 @@ const DiskCollectionPanel = (props: DisplayProps) => {
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       width={`max( ${handleGetTheme() == UI_THEME.MINIMAL ? "55vw" : "75vw"}, 348px )`}
       position="top-center">
+      <div className="dcp-tab-row">
+        {tabs.map((tab, i) => (
+          <div
+            className={`dcp-tab ${i == activeTab ? "dcp-tab-active" : ""}`}
+            title={tab.label}
+            onClick={() => {setActiveTab(i)}}>
+            <FontAwesomeIcon icon={tab.icon}/>
+          </div>
+        ))}
+      </div>
       <div className="disk-collection-panel">
-        {diskCollection.sort(sortByLastUpdatedAsc).map((diskCollectionItem, index) => (
+        {tabs[activeTab].disks.map((diskCollectionItem, index) => (
           <div key={`dcp-item-${index}`} className="dcp-item">
             <div className="dcp-item-title-box">
               <div

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import "./diskcollectionpanel.css"
 import Flyout from "../flyout"
-import { faAsterisk, faClock, faCloud, faFloppyDisk, faH, faHardDrive, faHdd, faStar } from "@fortawesome/free-solid-svg-icons"
+import { faClock, faCloud, faFloppyDisk, faHardDrive, faStar } from "@fortawesome/free-solid-svg-icons"
 import { UI_THEME } from "../../common/utility"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { svgInternetArchiveLogo } from "../img/icon_internetarchive"
@@ -12,6 +12,7 @@ import { handleSetDiskFromCloudData, handleSetDiskFromFile, handleSetDiskFromURL
 import { diskImages } from "../devices/disk/diskimages"
 import { newReleases } from "../devices/disk/newreleases"
 import { DiskBookmarks } from "../devices/disk/diskbookmarks"
+import { getPreferenceNewReleasesChecked, setPreferenceNewReleasesChecked } from "../localstorage"
 
 export enum DISK_COLLECTION_ITEM_TYPE {
   A2TS_ARCHIVE,
@@ -49,8 +50,30 @@ const DiskCollectionPanel = (props: DisplayProps) => {
   const [popupLocation, setPopupLocation] = useState<[number, number]>()
   const [popupItemIndex, setPopupItemIndex] = useState<number>(-1)
   const [activeTab, setActiveTab] = useState<number>(0)
+  const [hasNewRelease, setHasNewRelease] = useState<boolean>(false)
 
   let longPressTimer: number
+
+  const tabs = [
+    {
+      icon: faFloppyDisk,
+      label: "Show Apple2TS collection",
+      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.A2TS_ARCHIVE),
+      isHighlighted: false
+    },
+    {
+      icon: faClock,
+      label: "Show new releases",
+      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE),
+      isHighlighted: hasNewRelease
+    },
+    {
+      icon: faStar,
+      label: "Show favorites",
+      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.INTERNET_ARCHIVE || x.type == DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE),
+      isHighlighted: false
+    }
+  ]
 
   const handleHelpClick = (itemIndex: number) => (event: React.MouseEvent<HTMLElement>) => {
     const diskCollectionItem = diskCollection[itemIndex]
@@ -110,12 +133,24 @@ const DiskCollectionPanel = (props: DisplayProps) => {
     event.stopPropagation()
   }
 
+  const handleTabClick = (tabIndex: number) => (event: React.MouseEvent<HTMLElement>) => {
+    setHasNewRelease(false)
+    setPreferenceNewReleasesChecked(Date.now())
+
+    const element = event.target as HTMLElement
+    element.classList.remove("dcp-tab-highlighted")
+    setActiveTab(tabIndex)
+
+    event.stopPropagation()
+  }
+
   useEffect(() => {
     setDiskBookmarks(new DiskBookmarks())
   }, [isFlyoutOpen])
 
   useEffect(() => {
     const newDiskCollection: DiskCollectionItem[] = []
+    const newReleasesChecked = new Date(getPreferenceNewReleasesChecked())
 
     // Load built-in disk images
     diskImages.forEach((diskImage) => {
@@ -141,28 +176,14 @@ const DiskCollectionPanel = (props: DisplayProps) => {
     newReleases.forEach((newRelease) => {
       newRelease.type = DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE
       newDiskCollection.push(newRelease)
+
+      if (newRelease.lastUpdated >= newReleasesChecked) {
+        setHasNewRelease(true)
+      }
     })
 
     setDiskCollection(newDiskCollection)
   }, [diskBookmarks])
-
-  const tabs = [
-    {
-      icon: faFloppyDisk,
-      label: "Show Apple2TS collection",
-      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.A2TS_ARCHIVE)
-    },
-    {
-      icon: faClock,
-      label: "Show new releases",
-      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.NEW_RELEASE)
-    },
-    {
-      icon: faStar,
-      label: "Show favorites",
-      disks: diskCollection.sort(sortByLastUpdatedAsc).filter(x => x.type == DISK_COLLECTION_ITEM_TYPE.INTERNET_ARCHIVE || x.type == DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE)
-    }
-  ]
 
   return (
     <Flyout
@@ -172,14 +193,16 @@ const DiskCollectionPanel = (props: DisplayProps) => {
       isOpen={() => { return isFlyoutOpen }}
       onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
       width={`max( ${handleGetTheme() == UI_THEME.MINIMAL ? "55vw" : "75vw"}, 348px )`}
+      highlight={hasNewRelease}
       position="top-center">
       <div className="dcp-tab-row">
         {tabs.map((tab, i) => (
           <div
-            className={`dcp-tab ${i == activeTab ? "dcp-tab-active" : ""}`}
+            key={`tab-${i}`}
+            className={`dcp-tab ${i == activeTab ? " dcp-tab-active" : ""} ${tab.isHighlighted ? " dcp-tab-highlighted" : ""}`}
             title={tab.label}
-            onClick={(event) => {setActiveTab(i); event.stopPropagation() }}>
-            <FontAwesomeIcon icon={tab.icon}/>
+            onClick={handleTabClick(i)}>
+            <FontAwesomeIcon icon={tab.icon} size="lg"/>
           </div>
         ))}
       </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4f2fd228-7d34-44f9-8065-b3b8377d8097)

![image](https://github.com/user-attachments/assets/d29a0208-a7b4-4b7a-9849-844cf9a18ae2)

![image](https://github.com/user-attachments/assets/7386ddde-f8f7-432e-bf0c-d01ded77363c)

**Changes made:**
- Added tabs to the disk collection panel for the three disk types (built-in collection, new releases, and favorites)
- Added tab highlight for new releases
- Added local storage to persist last date when new releases were checked
- Minor UI tweaks for disk collection type icon placement

**Tests performed:**
- Verified tabs in disk collection panel filter disks by type
- Verified new release tab is highlighted only when last checked date is less than the newest release date
- Verified on multiple devices (PC, Mac, iPhone. iPad) and browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a