### PR TITLE
Added Kontrabant and Encounter Adventure to new releases

### DIFF
--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -420,7 +420,7 @@ const Apple2Canvas = (props: DisplayProps) => {
     if (document.fullscreenElement !== myCanvas?.current?.parentElement) {
       if (getTheme() == UI_THEME.MINIMAL) {
         scanlinesLeft = (window.innerWidth - scanlinesWidth) / 2
-        scanlinesTop = ((window.innerHeight - scanlinesHeight) / 2) - 10
+        scanlinesTop = ((window.innerHeight - scanlinesHeight) / 2) - 32
 
         if (handleGetIsDebugging()) {
           const debugSection = document.getElementsByClassName("flyout-bottom-right")[0] as HTMLElement

--- a/src/ui/devices/disk/newreleases.ts
+++ b/src/ui/devices/disk/newreleases.ts
@@ -15,15 +15,14 @@ export const newReleases: DiskCollectionItem[] = [
     diskUrl: new URL("https://archive.org/download/MillionPerfectTiles/00playable.po"),
     detailsUrl: new URL("https://archive.org/details/MillionPerfectTiles")
   },
-  // $TODO: Figure out why the DSK fails to load
-  // {
-  //   type: =1,
-  //   title: "Encounter Adventure",
-  //   lastUpdated: new Date("11/11/2024"),
-  //   imageUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/encounter/title.jpg"),
-  //   diskUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/encounter/encounteradventure.dsk"),
-  //   detailsUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/encounter/")
-  // }
+  {
+    type: -1,
+    title: "Encounter Adventure",
+    lastUpdated: new Date("11/11/2024"),
+    imageUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/encounter/title.jpg"),
+    diskUrl: new URL("https://github.com/antoinevignau/source/raw/refs/heads/main/encounter/encounteradventure.dsk"),
+    detailsUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/encounter/")
+  },
   {
     type: -1,
     title: "Undead Demo",
@@ -37,7 +36,7 @@ export const newReleases: DiskCollectionItem[] = [
     title: "Kontrabant",
     lastUpdated: new Date("4/10/2025"),
     imageUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/kontrabant/Kontrabant%20Box.jpg"),
-    diskUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/kontrabant/kontra_en.dsk"),
+    diskUrl: new URL("https://github.com/antoinevignau/source/raw/refs/heads/main/kontrabant/kontra_en.dsk"),
     detailsUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/kontrabant/")
   }
 ]

--- a/src/ui/devices/disk/newreleases.ts
+++ b/src/ui/devices/disk/newreleases.ts
@@ -12,7 +12,7 @@ export const newReleases: DiskCollectionItem[] = [
     title: "Million Perfect Tiles",
     lastUpdated: new Date("12/30/2024"),
     imageUrl: new URL("https://ia800300.us.archive.org/16/items/MillionPerfectTiles/00playable_screenshot.png"),
-    diskUrl: new URL("https://archive.org/download/MillionPerfectTiles/Million.Perfect.Tiles.v1.1.po"),
+    diskUrl: new URL("https://archive.org/download/MillionPerfectTiles/00playable.po"),
     detailsUrl: new URL("https://archive.org/details/MillionPerfectTiles")
   },
   // $TODO: Figure out why the DSK fails to load
@@ -31,5 +31,13 @@ export const newReleases: DiskCollectionItem[] = [
     imageUrl: new URL("https://www.callapple.org/wp-content/uploads/2024/09/Undead_Demo.png"),
     diskUrl: new URL("https://www.callapple.org/wp-content/uploads/2024/09/UNDEAD_DEMO.po_.zip"),
     detailsUrl: new URL("https://www.kickstarter.com/projects/8-bit-shack/undead-a-new-apple-role-player-game?utm_source=a2central")
+  },
+  {
+    type: -1,
+    title: "Kontrabant",
+    lastUpdated: new Date("4/10/2025"),
+    imageUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/kontrabant/Kontrabant%20Box.jpg"),
+    diskUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/kontrabant/kontra_en.dsk"),
+    detailsUrl: new URL("https://www.brutaldeluxe.fr/products/apple2/kontrabant/")
   }
 ]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e24bbfa3-1e06-4661-958b-552b0d0152b6)

**Changes made:**
- Added Kontrabant and Encounter Adventure to new releases
- Fixed scanlines top alignment bug
-  
**Tests performed:**
- Verified Kontrabant and Encounter Adventure both appear in the new releases tab
- Verified new releases tab is highlighted as expected in Mininal theme
- Verified scanlines render in the correct position
- Verified on multiple devices (PC, Mac, iPhone, iPad) and browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a