### PR TITLE
Fix: Scanlines not always positioned correctly

### DIFF
--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -406,52 +406,54 @@ const Apple2Canvas = (props: DisplayProps) => {
   }
 
   const handleCanvasResize = (canvas: HTMLCanvasElement) => {
-    if (!canvas) return "0"
+    // Give React some time to deal resize events
+    window.setTimeout(() => {
+      const width = canvas.offsetWidth
+      const height = canvas.offsetHeight
 
-    const width = canvas.offsetWidth
-    const height = canvas.offsetHeight
+      const scanlinesWidth = width - 2 * width * xmargin
+      const scanlinesHeight = height - 2 * height * ymargin
 
-    const scanlinesWidth = width - 2 * width * xmargin
-    const scanlinesHeight = height - 2 * height * ymargin
+      let scanlinesLeft = canvas.offsetLeft + width * xmargin
+      let scanlinesTop = canvas.offsetTop + height * ymargin
 
-    let scanlinesLeft = canvas.offsetLeft + width * xmargin
-    let scanlinesTop = canvas.offsetTop + height * ymargin
+      if (document.fullscreenElement !== myCanvas?.current?.parentElement) {
+        let marginLeft = canvas.offsetLeft + width * xmargin
+        let marginTop = canvas.offsetTop + height * ymargin
 
-    if (document.fullscreenElement !== myCanvas?.current?.parentElement) {
-      if (getTheme() == UI_THEME.MINIMAL) {
-        scanlinesLeft = (window.innerWidth - scanlinesWidth) / 2
-        scanlinesTop = ((window.innerHeight - scanlinesHeight) / 2) - 32
+        if (getTheme() == UI_THEME.MINIMAL) {
+          marginLeft = (window.innerWidth - scanlinesWidth) / 2
+          marginTop = ((window.innerHeight - scanlinesHeight) / 2)
 
-        if (handleGetIsDebugging()) {
-          const debugSection = document.getElementsByClassName("flyout-bottom-right")[0] as HTMLElement
-          if (debugSection) {
-            scanlinesLeft = Math.max(Math.min(scanlinesLeft, (debugSection.offsetLeft - scanlinesWidth) / 2), 0)
+          if (handleGetIsDebugging()) {
+            const debugSection = document.getElementsByClassName("flyout-bottom-right")[0] as HTMLElement
+            if (debugSection) {
+              marginLeft = Math.max(Math.min(marginLeft, (debugSection.offsetLeft - scanlinesWidth) / 2), 0)
+            }
           }
+
+          canvas.style.marginLeft = `${marginLeft - width * xmargin}px`
+          canvas.style.marginTop = `${Math.max(marginTop - height * ymargin - 160, 32)}px`
+        } else {
+          canvas.style.marginLeft = "0px"
+          canvas.style.marginTop = "0px"
         }
-
-        canvas.style.marginLeft = `${scanlinesLeft - width * xmargin}px`
-        canvas.style.marginTop = `${Math.max(scanlinesTop - height * ymargin - 160, 40)}px`
       } else {
-        canvas.style.marginLeft = "0"
-        canvas.style.marginTop = "0"
+        const marginLeft = Math.max((window.innerWidth - width) / 2, 0)
+        const marginTop = Math.max((window.innerHeight - height) / 2, 0)
+
+        canvas.style.marginLeft = `${marginLeft}px`
+        canvas.style.marginTop = `${marginTop}px`
+
+        scanlinesLeft = marginLeft + width * xmargin
+        scanlinesTop = marginTop + height * ymargin
       }
-    } else {
-      const marginLeft = Math.max((window.innerWidth - width) / 2, 0)
-      const marginTop = Math.max((window.innerHeight - height) / 2, 0)
 
-      canvas.style.marginLeft = `${marginLeft}px`
-      canvas.style.marginTop = `${marginTop}px`
-
-      scanlinesLeft = marginLeft + width * xmargin
-      scanlinesTop = marginTop + height * ymargin
-    }
-
-    document.body.style.setProperty("--scanlines-left", `${scanlinesLeft}px`)
-    document.body.style.setProperty("--scanlines-top", `${scanlinesTop}px`)
-    document.body.style.setProperty("--scanlines-width", `${scanlinesWidth}px`)
-    document.body.style.setProperty("--scanlines-height", `${scanlinesHeight}px`)
-
-    return canvas.style.marginLeft
+      document.body.style.setProperty("--scanlines-left", `${scanlinesLeft}px`)
+      document.body.style.setProperty("--scanlines-top", `${scanlinesTop}px`)
+      document.body.style.setProperty("--scanlines-width", `${scanlinesWidth}px`)
+      document.body.style.setProperty("--scanlines-height", `${scanlinesHeight}px`)
+    }, 200)
   }
 
   // We should probably be using a useEffect here, but when I tried that,

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -406,6 +406,8 @@ const Apple2Canvas = (props: DisplayProps) => {
   }
 
   const handleCanvasResize = (canvas: HTMLCanvasElement) => {
+    if (!canvas) return "0px"
+
     // Give React some time to deal resize events
     window.setTimeout(() => {
       const width = canvas.offsetWidth
@@ -454,6 +456,8 @@ const Apple2Canvas = (props: DisplayProps) => {
       document.body.style.setProperty("--scanlines-width", `${scanlinesWidth}px`)
       document.body.style.setProperty("--scanlines-height", `${scanlinesHeight}px`)
     }, 200)
+
+    return canvas.style.marginLeft
   }
 
   // We should probably be using a useEffect here, but when I tried that,


### PR DESCRIPTION
### NOTE: Red border is for testing purposes only and will not be included in the committed changes.

Chrome (PC):
![image](https://github.com/user-attachments/assets/03a468f4-b1e8-46d3-8a19-b38ca0438515)

Firefox (PC):
![image](https://github.com/user-attachments/assets/8b48341c-6f6f-4840-a0a7-1a5e63cecd85)

Safari (iPhone):
![image](https://github.com/user-attachments/assets/d66e2219-6276-4075-92fa-a6852d9b7ffd)

Safari (iPad):
![IMG_0378](https://github.com/user-attachments/assets/c736fa3f-99fd-4251-bc50-374e7c53fa51)

**Changes made:**
- Added setTimeout to handleCanvasResize to give React time to handle reize events correctly

**Tests performed:**
- Verified scanlines appear in correct position after page load/resize events
- Verified scanlines appear as expected in all UI themes
- Verified behavior on multiple devices (Windows, iPhone, iPad) and browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a