### PR TITLE
Fixed tab editing in the exPectin panel

### DIFF
--- a/src/ui/panels/debugsection.css
+++ b/src/ui/panels/debugsection.css
@@ -567,7 +567,6 @@ body.dark-mode .icon-text {
   color: white;
   border: 1px solid black;
   border-radius: 10px;
-  tab-size: 2;
 }
 
 .dbg-expectin-button-row {

--- a/src/ui/panels/debugsection.tsx
+++ b/src/ui/panels/debugsection.tsx
@@ -56,8 +56,8 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay }) => {
       const s = elem.selectionStart
       const e = elem.selectionEnd
 
-      elem.value = v.substring(0, s) + "\t" + v.substring(e)
-      elem.selectionStart = elem.selectionEnd = s + 1
+      elem.value = v.substring(0, s) + "  " + v.substring(e)
+      elem.selectionStart = elem.selectionEnd = s + 2
 
       event.preventDefault()
       return false
@@ -130,7 +130,7 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay }) => {
               readOnly={expectinObject?.IsRunning()}
               onChange={handleTextAreaChange}
               onKeyDown={handleTextAreaKeyDown}
-              value={expectinText} />
+              defaultValue={expectinText} />
             <div className="dbg-expectin-button-row">
               <div
                 style={{ gridColumn: expectinError === "" ? "span 1" : "span 2" }}


### PR DESCRIPTION
![Untitled video](https://github.com/user-attachments/assets/d244d79e-9504-4cf0-9d4b-161b54feba89)

**Changes made:**
- Updated `handleTextAreaKeyDown()` in `DebugSection` to insert two spaces when TAB key is pressed
- Updated `DebugSection` to use `DefaultValue` property

**Tests performed:**
- Verified pressing tab in the exPectin panel insert two spaces
- Verified sample exPectin JSON runs as expected
- Verfieid all exPectin commands work as expected
- Verified invalid exPectin JSON displays errors and prevents script from being run
- Verififed on multiple devices (Mac, PC, iPhone, iPad) and browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
n/a