### PR TITLE
Set VBL at the start of doAdvance6502 instead of the end

### DIFF
--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -617,14 +617,15 @@ const doAdvance6502 = () => {
     const cycles = processInstruction()
     if (cycles < 0) break
     cycleTotal += cycles
-    if ((cycleTotal % 17030) >= 12480) {
+    if (cycleTotal < 4550) {
       // Return "low" for 70 scan lines out of 262 (70 * 65 cycles = 4550)
       if (!SWITCHES.VBL.isSet) {
         startVBL()
       }
+    } else {
+      endVBL()
     }
     if (cycleTotal >= cpuCyclesPerRefresh) {
-      endVBL()
       break
     }
   }


### PR DESCRIPTION
This fixes the flickering described in #161 .
I'm not sure why both aren't functionally equivalent. 
I suppose the HGR bytes in $2000-$3FFF are converted to canvas data at the end of an doAdvance6502 call, and if that's the case and we do VBL at the end of that doAdvance6502, the "beam" would be early by 4550 cycles.

The ideal thing would be to push HGR bytes to the canvas from doAdvance6502, getting one video byte every 65 cycles, but that complicates things a lot.