### PR TITLE
Fix: Issue 181 - Software picker window behavior (Android)

### DIFF
--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -54,8 +54,6 @@ const DiskCollectionPanel = (props: DisplayProps) => {
   const [activeTab, setActiveTab] = useState<number>(0)
   const [hasNewRelease, setHasNewRelease] = useState<boolean>(false)
 
-  let longPressTimer: number
-
   if (getTheme() == UI_THEME.MINIMAL) {
     import("./diskcollectionpanel.minimal.css")
   }

--- a/src/ui/panels/diskcollectionpanel.tsx
+++ b/src/ui/panels/diskcollectionpanel.tsx
@@ -116,20 +116,6 @@ const DiskCollectionPanel = (props: DisplayProps) => {
     return false
   }
 
-  const handleItemTouchStart = (diskCollectionItem: DiskCollectionItem) => (event: React.TouchEvent<HTMLElement>) => {
-    longPressTimer = window.setTimeout(() => {
-      setPopupItem(diskCollectionItem)
-      setPopupLocation([event.touches[0].clientX, event.touches[0].clientY])
-      event.stopPropagation()
-      event.preventDefault()
-      return false
-    }, 1000)
-  }
-
-  const handleItemTouchCancel = () => {
-    clearTimeout(longPressTimer)
-  }
-
   const handleBookmarkClick = (diskCollectionItem: DiskCollectionItem) => (event: React.MouseEvent<HTMLElement>) => {
     if (diskCollectionItem.bookmarkId) {
       diskBookmarks.remove(diskCollectionItem.bookmarkId)
@@ -202,7 +188,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
       highlight={hasNewRelease}
       position="bottom-right">
       <div className="flex-row dcp-tab-row"
-        onClick={(e) => {if (e.target === e.currentTarget) e.stopPropagation()}}>
+        onClick={(e) => { if (e.target === e.currentTarget) e.stopPropagation() }}>
         {tabs.map((tab, i) => (
           <div
             key={`tab-${i}`}
@@ -214,7 +200,7 @@ const DiskCollectionPanel = (props: DisplayProps) => {
         ))}
       </div>
       <div className="disk-collection-panel"
-        onClick={(e) => {if (e.target === e.currentTarget) e.stopPropagation()}}>
+        onClick={(e) => { if (e.target === e.currentTarget) e.stopPropagation() }}>
         {tabs[activeTab].disks.map((diskCollectionItem, index) => (
           <div key={`dcp-item-${index}`} className="dcp-item">
             <div className="dcp-item-title-box">
@@ -228,9 +214,6 @@ const DiskCollectionPanel = (props: DisplayProps) => {
               className="dcp-item-image-box"
               title={`Click to load disk "${diskCollectionItem.title}"`}
               onClick={handleItemClick(diskCollectionItem, 0)}
-              onTouchStart={handleItemTouchStart(diskCollectionItem)}
-              onTouchEnd={handleItemTouchCancel}
-              onTouchCancel={handleItemTouchCancel}
               onContextMenu={handleItemRightClick(diskCollectionItem)}
             >
               <img className="dcp-item-image" src={diskCollectionItem.imageUrl?.toString()} />


### PR DESCRIPTION
<img width="323" height="699" alt="image" src="https://github.com/user-attachments/assets/adb8304f-d383-496b-ae92-34dfdefe08d6" />

**Changes made:**
- Removed touch handling for disk context menu

**Tests performed:**
- Positive case: Verified long press does not activate disk context menu on touch devices
- Negative case: Verified right-click activates disk context menu on non-touch devices
- Verified disk collection panel works as expected
- Verififed on multiple devices (Mac, PC, iPhone, iPad) and browsers (Chrome, Edge, Safari, Firefox)

**Issues resolved:**
- #181 