### PR TITLE
Rework Video7 processing.  Add 160x mode

### DIFF
--- a/src/ui/panels/memorymap.tsx
+++ b/src/ui/panels/memorymap.tsx
@@ -162,6 +162,8 @@ const MemoryMap = (props: {updateDisplay: UpdateDisplay}) => {
           func={() => setSoftSwitches([switches.COLUMN80 ? 0xC00C : 0xC00D])} />
         <CheckedBox name="Dbl Hires" checked={switches.DHIRES}
           func={() => setSoftSwitches([switches.DHIRES ? 0xC05F : 0xC05E])} />
+        <CheckedBox name="V7 160x" checked={switches.VIDEO7_160}
+          func={() => setSoftSwitches([switches.VIDEO7_160 ? 0xC078 : 0xC079])} />
         <CheckedBox name="V7 Mono" checked={switches.VIDEO7_MONO}
           func={() => setSoftSwitches([switches.VIDEO7_MONO ? 0xC07A : 0xC07B])} />
         <CheckedBox name="V7 Mixed" checked={switches.VIDEO7_MIXED}

--- a/src/worker/memory.ts
+++ b/src/worker/memory.ts
@@ -599,7 +599,7 @@ export const getHires = () => {
   const doubleRes = SWITCHES.DHIRES.isSet && SWITCHES.COLUMN80.isSet
   const video7foreground = SWITCHES.DHIRES.isSet && !SWITCHES.COLUMN80.isSet && SWITCHES.STORE80.isSet
   const nlines = SWITCHES.MIXED.isSet ? 160 : 192
-  if (doubleRes || SWITCHES.VIDEO7_MONO.isSet || SWITCHES.VIDEO7_MONO.isSet || video7foreground) {
+  if (doubleRes || SWITCHES.VIDEO7_MONO.isSet || SWITCHES.VIDEO7_160.isSet || video7foreground) {
     // Only select second 80-column text page if STORE80 is also OFF
     const pageOffset = (SWITCHES.PAGE2.isSet && !SWITCHES.STORE80.isSet) ? 0x4000 : 0x2000
     const hgrPage = new Uint8Array(80 * nlines)


### PR DESCRIPTION
Rework video7 processing to match the patent in the way it claims to clock in the 80COL value to form the 2-bit flags register to select the video mode.  This simplifies the logic a bit.
Add the 16 color 160x192 nybble mode.  Note that since much of the display code uses 560 width as a baseline, and 160 does not divide evenly into 560, the resulting display uses variable width 4/3 pixel columns.  I didn't find it offensive for now, but perhaps we need to work on a more customizable variable width code path.
Another TODO would be to emulate actual RGB mode which uses the canonical pixel locations to display color (with no fringe) rather than the NTSC artifact color.  
Tested with the Video7 demo disk, A2Desktop, and several programs that use doublehires everything seems to still work as expected. 