### PR TITLE
fix: preserve large-disk state during time-travel restore

### DIFF
--- a/src/worker/devices/drivestate.ts
+++ b/src/worker/devices/drivestate.ts
@@ -43,6 +43,7 @@ const initializeDriveState = () => {
 
 const driveState: DriveState[] = []
 const driveData: Array<Uint8Array> = []
+const largeDiskSnapshotThreshold = 32_000_000
 
 initializeDriveState()
 
@@ -112,8 +113,9 @@ export const passDriveData = () => {
 export const getDriveSaveState = (full: boolean): DriveSaveState => {
   const data: string[] = new Array(driveState.length).fill("")
   for (let i=0; i < driveState.length; i++) {
-    // Always save small disk images (< 32Mb), or if a full save was requested
-    if (full || driveData[i].length < 32000000) {
+    // Time-travel snapshots include media below the threshold;
+    // portable save states include all media.
+    if (full || driveData[i].length < largeDiskSnapshotThreshold) {
       data[i] = Buffer.from(driveData[i]).toString("base64")
     }
   }
@@ -130,6 +132,8 @@ export const getDriveSaveState = (full: boolean): DriveSaveState => {
 }
 
 export const restoreDriveSaveState = (newState: DriveSaveState) => {
+  const previousDriveState = driveState.map((state) => ({...state}))
+  const previousDriveData = [...driveData]
   passDriveSound(DRIVE.MOTOR_OFF)
   currentDrive = newState.currentDrive
   // If this is an old save state, we may need to adjust the current drive.
@@ -141,9 +145,15 @@ export const restoreDriveSaveState = (newState: DriveSaveState) => {
   for (let i=0; i < newState.driveState.length; i++) {
     // Make sure our drive had data.
     if (Object.keys(newState.driveState[i]).length > 0) {
-      driveState[dindex] = { ...newState.driveState[i] } as DriveState
       if (newState.driveData[i] !== "") {
+        driveState[dindex] = { ...newState.driveState[i] } as DriveState
         driveData[dindex] = new Uint8Array(Buffer.from(newState.driveData[i], "base64"))
+      } else if (previousDriveData[dindex].length >= largeDiskSnapshotThreshold) {
+        // Time-travel snapshots intentionally exclude large-disk data. Retain
+        // both the current data and its metadata; the historical metadata
+        // describes disk data that was not restored.
+        driveState[dindex] = previousDriveState[dindex]
+        driveData[dindex] = previousDriveData[dindex]
       }
     }
     // See if we had a second hard drive in our save state or not.
@@ -216,4 +226,3 @@ export const doSetEmuDriveProps = (props: DriveProps) => {
   driveState[index].writableFileHandle = props.writableFileHandle
   passDriveData()
 }
-

--- a/src/worker/devices/drivestate_save.test.ts
+++ b/src/worker/devices/drivestate_save.test.ts
@@ -1,0 +1,122 @@
+import { Buffer } from "buffer"
+import { doSetEmuDriveNewData, getDriveSaveState, getHardDriveData, getHardDriveState,
+  restoreDriveSaveState } from "./drivestate"
+import { doGetSaveState, doRestoreSaveState } from "../save_restore"
+import { setIsTesting } from "../worker2main"
+
+const largeDiskSize = 32_000_000
+
+const emptyDriveSaveState = (): DriveSaveState => ({
+  currentDrive: 2,
+  driveState: [{}, {}, {}, {}],
+  driveData: ["", "", "", ""]
+})
+
+const mountHardDrive = (diskData: Uint8Array, filename = "large-disk.hdv") => {
+  const props: DriveProps = {
+    index: 0,
+    hardDrive: true,
+    drive: 1,
+    filename,
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData,
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0
+  }
+  doSetEmuDriveNewData(props)
+}
+
+beforeAll(() => setIsTesting())
+beforeEach(() => restoreDriveSaveState(emptyDriveSaveState()))
+afterEach(() => jest.restoreAllMocks())
+
+test("a time-travel snapshot omits large-disk data without losing the disk on restore", () => {
+  const diskData = new Uint8Array(largeDiskSize)
+  diskData[0] = 0xA5
+  diskData[largeDiskSize - 1] = 0x5A
+  mountHardDrive(diskData)
+  const bufferFrom = jest.spyOn(Buffer, "from")
+
+  const state = doGetSaveState(false)
+  expect(state.driveState.driveData[0]).toBe("")
+  expect(bufferFrom.mock.calls.some(([value]) => value === diskData)).toBe(false)
+
+  doRestoreSaveState(state)
+  const [restoredData,, restoredLength] = getHardDriveData(1)
+  expect(restoredLength).toBe(largeDiskSize)
+  expect(restoredData[0]).toBe(0xA5)
+  expect(restoredData[largeDiskSize - 1]).toBe(0x5A)
+})
+
+test("restoring a time-travel snapshot preserves current large-disk data and metadata", () => {
+  const diskData = new Uint8Array(largeDiskSize)
+  diskData[0] = 0xA5
+  mountHardDrive(diskData)
+  const state = doGetSaveState(false)
+
+  diskData[0] = 0x5A
+  const currentDriveState = getHardDriveState(1)
+  currentDriveState.diskHasChanges = true
+  currentDriveState.lastAppleWriteTime = 123
+  doRestoreSaveState(state)
+
+  const [restoredData] = getHardDriveData(1)
+  expect(restoredData[0]).toBe(0x5A)
+  expect(getHardDriveState(1).diskHasChanges).toBe(true)
+  expect(getHardDriveState(1).lastAppleWriteTime).toBe(123)
+})
+
+test("a portable save state includes large-disk data", () => {
+  const diskData = new Uint8Array(largeDiskSize)
+  mountHardDrive(diskData)
+
+  const state = getDriveSaveState(true)
+  expect(state.driveData[0]).toHaveLength(4 * Math.ceil(largeDiskSize / 3))
+})
+
+test("a time-travel snapshot includes disk data below the size threshold", () => {
+  const diskSize = largeDiskSize - 1
+  const diskData = new Uint8Array(diskSize)
+  mountHardDrive(diskData)
+
+  const state = getDriveSaveState(false)
+  expect(state.driveData[0]).toHaveLength(4 * Math.ceil(diskSize / 3))
+})
+
+test("restoring a time-travel snapshot preserves a replacement large disk", () => {
+  const firstDisk = new Uint8Array(largeDiskSize)
+  firstDisk[0] = 0xA5
+  mountHardDrive(firstDisk, "first.hdv")
+  const firstState = getDriveSaveState(false)
+
+  const secondDisk = new Uint8Array(largeDiskSize)
+  secondDisk[0] = 0x5A
+  mountHardDrive(secondDisk, "second.hdv")
+  restoreDriveSaveState(firstState)
+
+  const [restoredData,, restoredLength] = getHardDriveData(1)
+  expect(restoredLength).toBe(largeDiskSize)
+  expect(restoredData[0]).toBe(0x5A)
+  expect(getHardDriveState(1).filename).toBe("second.hdv")
+})
+
+test("restoring a time-travel snapshot replaces current small-disk data with snapshot data", () => {
+  const firstDisk = new Uint8Array(16_384)
+  firstDisk[0] = 0xA5
+  mountHardDrive(firstDisk, "small.hdv")
+  const firstState = getDriveSaveState(false)
+
+  const replacementDisk = new Uint8Array(16_384)
+  replacementDisk[0] = 0x5A
+  mountHardDrive(replacementDisk, "small.hdv")
+  restoreDriveSaveState(firstState)
+
+  const [restoredData,, restoredLength] = getHardDriveData(1)
+  expect(restoredLength).toBe(16_384)
+  expect(restoredData[0]).toBe(0xA5)
+})


### PR DESCRIPTION
## Summary

- Preserve the currently mounted large disk when restoring a time-travel snapshot that omitted its disk data.
- Keep the current disk data and metadata together instead of applying historical metadata to data that was not restored.
- Add regression tests for large-disk snapshot omission and restoration, portable saves, the size threshold, replacement media, and small-disk restoration.

Large-disk snapshot storage and rewind support remain separate optimization work tracked in #269.

## Testing

- `npm test -- src/worker/devices/drivestate_save.test.ts`
- `npm test`
- `npm run lint`
- `npm run build`
