### PR TITLE
fix(i18n): fall back to English for missing translations

### DIFF
--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -1,0 +1,31 @@
+import { translateFromCatalogs } from "./index"
+
+describe("translateFromCatalogs", () => {
+  const english = {
+    debug: {
+      tooltip: "English value: {{value}}",
+      englishOnly: "English fallback",
+    },
+  }
+
+  test("uses the selected-language translation when it exists", () => {
+    const selectedLanguage = {
+      debug: {
+        tooltip: "Localized value: {{value}}",
+      },
+    }
+
+    expect(translateFromCatalogs(selectedLanguage, english, "debug.tooltip", {value: "$03"}))
+      .toBe("Localized value: $03")
+  })
+
+  test("falls back to English when the selected language lacks a key", () => {
+    expect(translateFromCatalogs({}, english, "debug.englishOnly"))
+      .toBe("English fallback")
+  })
+
+  test("returns the key path when neither catalog contains a key", () => {
+    expect(translateFromCatalogs({}, english, "debug.missing"))
+      .toBe("debug.missing")
+  })
+})

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -48,6 +48,34 @@ const translations = {
   "ru": ru
 }
 
+type TranslationCatalog = Record<string, unknown>
+
+// Look up nested translation keys.
+const lookupTranslation = (catalog: TranslationCatalog, key: string): string | undefined => {
+  let value: unknown = catalog
+  for (const part of key.split(".")) {
+    value = (value as Record<string, unknown>)?.[part]
+  }
+  return typeof value === "string" ? value : undefined
+}
+
+export const translateFromCatalogs = (
+  selectedLanguage: TranslationCatalog,
+  english: TranslationCatalog,
+  key: string,
+  params?: Record<string, string>,
+): string => {
+  let result = lookupTranslation(selectedLanguage, key) ?? lookupTranslation(english, key) ?? key
+
+  if (params) {
+    Object.keys(params).forEach(param => {
+      result = result.replace(`{{${param}}}`, params[param])
+    })
+  }
+
+  return result
+}
+
 class I18n {
   private currentLanguage: Language = "en"
   
@@ -118,24 +146,8 @@ class I18n {
     return this.currentLanguage
   }
   
-  // 支援巢狀屬性的翻譯函數
   t(key: string, params?: Record<string, string>): string {
-    const keys = key.split(".")
-    let value: unknown = translations[this.currentLanguage]
-    
-    for (const k of keys) {
-      value = (value as Record<string, unknown>)?.[k]
-    }
-    
-    let result = (value as string) || key
-
-    if (params) {
-      Object.keys(params).forEach(param => {
-        result = result.replace(`{{${param}}}`, params[param])
-      })
-    }
-    
-    return result
+    return translateFromCatalogs(translations[this.currentLanguage], en, key, params)
   }
 }
 


### PR DESCRIPTION
## Summary

Add English to the translation fallback path.

Before:

    Selected language -> key path

After:

    Selected language -> English -> key path

## Tests

- `npm test -- --runInBand src/i18n/index.test.ts`
- `npm run lint`
- `npm run build`