### PR TITLE
fix(i18n): correct locale identity and language matching

### DIFF
--- a/README-I18N.md
+++ b/README-I18N.md
@@ -22,7 +22,7 @@
 - ✅ 西班牙文語言包 (`languages/es.ts`) - 350+ 翻譯項目
 - ✅ 法文語言包 (`languages/fr.ts`) - 350+ 翻譯項目
 - ✅ 義大利文語言包 (`languages/it.ts`) - 350+ 翻譯項目
-- ✅ 葡萄牙文語言包 (`languages/pt.ts`) - 350+ 翻譯項目
+- ✅ 巴西葡萄牙文語言包 (`languages/pt-BR.ts`) - 350+ 翻譯項目
 - ✅ 日文語言包 (`languages/ja.ts`) - 350+ 翻譯項目
 - ✅ 韓文語言包 (`languages/ko.ts`) - 350+ 翻譯項目
 - ✅ 荷蘭文語言包 (`languages/nl.ts`) - 350+ 翻譯項目
@@ -68,7 +68,7 @@
 | Español | `es` | 100% | 西班牙文完整翻譯 |
 | Français | `fr` | 100% | 法文完整翻譯 |
 | Italiano | `it` | 100% | 義大利文完整翻譯 |
-| Português | `pt` | 100% | 葡萄牙文完整翻譯 |
+| Português (Brasil) | `pt-BR` | 100% | 巴西葡萄牙文完整翻譯 |
 | 日本語 | `ja` | 100% | 日文完整翻譯 |
 | 한국어 | `ko` | 100% | 韓文完整翻譯 |
 | Nederlands | `nl` | 100% | 荷蘭文完整翻譯 |
@@ -90,7 +90,7 @@ src/
 │       ├── es.ts            # 西班牙文語言包
 │       ├── fr.ts            # 法文語言包
 │       ├── it.ts            # 義大利文語言包
-│       ├── pt.ts            # 葡萄牙文語言包
+│       ├── pt-BR.ts         # 巴西葡萄牙文語言包
 │       ├── ja.ts            # 日文語言包
 │       ├── ko.ts            # 韓文語言包
 │       ├── nl.ts            # 荷蘭文語言包
@@ -467,4 +467,3 @@ handleSetDiskData(...)  // 載入新磁碟
 - **翻譯引擎與模組更新**：
   - 更新 `src/i18n/i18n_master.cjs` 字典矩陣，加入 `Trace Settings`, `Variable` 與 `Value` 等核心語句翻譯。
   - 將所有上游變更中之硬編碼字串全數變數化（使用 React Hooks），並使用 Master 腳本自動生成包含 13 種語言之擴充套件檔，並成功替換前端元件。
-

--- a/src/i18n/i18n_master.cjs
+++ b/src/i18n/i18n_master.cjs
@@ -14,11 +14,11 @@ const path = require('path');
 
 const LANG_DIR = path.join(__dirname, 'languages');
 const SOURCE_FILE = path.join(LANG_DIR, 'en.ts');
-const LANGUAGES = ['zh-TW', 'zh-CN', 'es', 'de', 'fr', 'it', 'pt', 'ja', 'ko', 'nl', 'sv', 'ru'];
+const LANGUAGES = ['zh-TW', 'zh-CN', 'es', 'de', 'fr', 'it', 'pt-BR', 'ja', 'ko', 'nl', 'sv', 'ru'];
 
 const EXPORT_NAMES = {
   'zh-TW': 'zhTW', 'zh-CN': 'zhCN', 'es': 'es', 'de': 'de', 'fr': 'fr',
-  'it': 'it', 'pt': 'pt', 'ja': 'ja', 'ko': 'ko', 'nl': 'nl', 'sv': 'sv', 'ru': 'ru'
+  'it': 'it', 'pt-BR': 'ptBR', 'ja': 'ja', 'ko': 'ko', 'nl': 'nl', 'sv': 'sv', 'ru': 'ru'
 };
 
 // Technical Dictionary for common Apple II / UI terms
@@ -26,45 +26,45 @@ const DICT = {
   "Load Disk": {
     "zh-TW": "載入磁碟", "zh-CN": "加载磁盘", "ja": "ディスクを読み込む", "ko": "디스크 로드",
     "es": "Cargar disco", "de": "Disk laden", "fr": "Charger le disque", "it": "Carica disco",
-    "pt": "Carregar disco", "nl": "Disk laden", "sv": "Ladda disk", "ru": "Загрузить диск"
+    "pt-BR": "Carregar disco", "nl": "Disk laden", "sv": "Ladda disk", "ru": "Загрузить диск"
   },
   "Eject Disk": {
     "zh-TW": "退出磁碟", "zh-CN": "弹出磁盘", "ja": "ディスクを排出", "ko": "디스크 꺼내기",
     "es": "Expulsar disco", "de": "Disk auswerfen", "fr": "Éjecter le disque", "it": "Espelli disco",
-    "pt": "Ejetar disco", "nl": "Disk uitwerpen", "sv": "Mata ut disk", "ru": "Извлечь диск"
+    "pt-BR": "Ejetar disco", "nl": "Disk uitwerpen", "sv": "Mata ut disk", "ru": "Извлечь диск"
   },
   "Save Disk": {
     "zh-TW": "儲存磁碟", "zh-CN": "保存磁盘", "ja": "ディスクを保存", "ko": "디스크 저장",
     "es": "Guardar disco", "de": "Disk speichern", "fr": "Enregistrer le disque", "it": "Salva disco",
-    "pt": "Salvar disco", "nl": "Disk opslaan", "sv": "Spara disk", "ru": "Сохранить диск"
+    "pt-BR": "Salvar disco", "nl": "Disk opslaan", "sv": "Spara disk", "ru": "Сохранить диск"
   },
-  "Main": { "zh-TW": "主要", "zh-CN": "主要", "ja": "メイン", "ko": "메인", "es": "Principal", "de": "Hauptmenü", "fr": "Principal", "it": "Principale", "pt": "Principal", "nl": "Hoofdmenu", "sv": "Huvudmeny", "ru": "Главный" },
-  "Settings": { "zh-TW": "設定", "zh-CN": "设置", "ja": "設定", "ko": "설정", "es": "Ajustes", "de": "Einstellungen", "fr": "Paramètres", "it": "Impostazioni", "pt": "Configurações", "nl": "Instellingen", "sv": "Inställningar", "ru": "Настройки" },
-  "Debug": { "zh-TW": "除錯", "zh-CN": "调试", "ja": "デバッグ", "ko": "디버그", "es": "Depuración", "de": "Debugging", "fr": "Débogage", "it": "Debug", "pt": "Depuração", "nl": "Debuggen", "sv": "Felsökning", "ru": "Отладка" },
+  "Main": { "zh-TW": "主要", "zh-CN": "主要", "ja": "メイン", "ko": "메인", "es": "Principal", "de": "Hauptmenü", "fr": "Principal", "it": "Principale", "pt-BR": "Principal", "nl": "Hoofdmenu", "sv": "Huvudmeny", "ru": "Главный" },
+  "Settings": { "zh-TW": "設定", "zh-CN": "设置", "ja": "設定", "ko": "설정", "es": "Ajustes", "de": "Einstellungen", "fr": "Paramètres", "it": "Impostazioni", "pt-BR": "Configurações", "nl": "Instellingen", "sv": "Inställningar", "ru": "Настройки" },
+  "Debug": { "zh-TW": "除錯", "zh-CN": "调试", "ja": "デバッグ", "ko": "디버그", "es": "Depuración", "de": "Debugging", "fr": "Débogage", "it": "Debug", "pt-BR": "Depuração", "nl": "Debuggen", "sv": "Felsökning", "ru": "Отладка" },
   "New Program": {
     "zh-TW": "新程式", "zh-CN": "新程序", "ja": "新規プログラム", "ko": "새 프로그램",
     "es": "Nuevo programa", "de": "Neues Programm", "fr": "Nouveau programme", "it": "Nuovo programma",
-    "pt": "Novo programa", "nl": "Nieuw programma", "sv": "Nytt program", "ru": "Новая программа"
+    "pt-BR": "Novo programa", "nl": "Nieuw programma", "sv": "Nytt program", "ru": "Новая программа"
   },
   "Help": {
     "zh-TW": "說明", "zh-CN": "帮助", "ja": "ヘルプ", "ko": "도움말",
     "es": "Ayuda", "de": "Hilfe", "fr": "Aide", "it": "Aiuto",
-    "pt": "Ajuda", "nl": "Help", "sv": "Hjälp", "ru": "Помощь"
+    "pt-BR": "Ajuda", "nl": "Help", "sv": "Hjälp", "ru": "Помощь"
   },
   "Debugging": {
     "zh-TW": "除錯", "zh-CN": "调试", "ja": "デバッグ", "ko": "디버깅",
     "es": "Depuración", "de": "Fehlersuche", "fr": "Débogage", "it": "Debug",
-    "pt": "Depuração", "nl": "Foutopsporing", "sv": "Felsökning", "ru": "Отладка"
+    "pt-BR": "Depuração", "nl": "Foutopsporing", "sv": "Felsökning", "ru": "Отладка"
   },
-  "Guided Tour": { "zh-TW": "引導式導覽", "zh-CN": "引导式导览", "ja": "ガイド付きツアー", "ko": "가이드 투어", "es": "Tour Guiado", "de": "Geführte Tour", "fr": "Visite Guidée", "it": "Tour Guidato", "pt": "Tour Guiado", "nl": "Rondleiding", "sv": "Guidad tur", "ru": "Управляемый тур" },
+  "Guided Tour": { "zh-TW": "引導式導覽", "zh-CN": "引导式导览", "ja": "ガイド付きツアー", "ko": "가이드 투어", "es": "Tour Guiado", "de": "Geführte Tour", "fr": "Visite Guidée", "it": "Tour Guidato", "pt-BR": "Tour Guiado", "nl": "Rondleiding", "sv": "Guidad tur", "ru": "Управляемый тур" },
   "Guided Tour: Main": {
-    "zh-TW": "引導式導覽：主要", "zh-CN": "引导式导览：主要", "ja": "ガイド付きツアー：メイン", "ko": "가이드 투어: 메인", "es": "Tour Guiado: Principal", "de": "Geführte Tour: Hauptmenü", "fr": "Visite Guidée : Principal", "it": "Tour Guidato: Principale", "pt": "Tour Guiado: Principal", "nl": "Rondleiding: Hoofdmenu", "sv": "Guidad tur: Huvudmeny", "ru": "Управляемый тур: Главный"
+    "zh-TW": "引導式導覽：主要", "zh-CN": "引导式导览：主要", "ja": "ガイド付きツアー：メイン", "ko": "가이드 투어: 메인", "es": "Tour Guiado: Principal", "de": "Geführte Tour: Hauptmenü", "fr": "Visite Guidée : Principal", "it": "Tour Guidato: Principale", "pt-BR": "Tour Guiado: Principal", "nl": "Rondleiding: Hoofdmenu", "sv": "Guidad tur: Huvudmeny", "ru": "Управляемый тур: Главный"
   },
   "Guided Tour: Settings": {
-    "zh-TW": "引導式導覽：設定", "zh-CN": "引导式导览：设置", "ja": "ガイド付きツアー：設定", "ko": "가이드 투어: 설정", "es": "Tour Guiado: Ajustes", "de": "Geführte Tour: Einstellungen", "fr": "Visite Guidée : Paramètres", "it": "Tour Guidato: Impostazioni", "pt": "Tour Guiado: Configurações", "nl": "Rondleiding: Instellingen", "sv": "Guidad tur: Inställningar", "ru": "Управляемый тур: Настройки"
+    "zh-TW": "引導式導覽：設定", "zh-CN": "引导式导览：设置", "ja": "ガイド付きツアー：設定", "ko": "가이드 투어: 설정", "es": "Tour Guiado: Ajustes", "de": "Geführte Tour: Einstellungen", "fr": "Visite Guidée : Paramètres", "it": "Tour Guidato: Impostazioni", "pt-BR": "Tour Guiado: Configurações", "nl": "Rondleiding: Instellingen", "sv": "Guidad tur: Inställningar", "ru": "Управляемый тур: Настройки"
   },
   "Guided Tour: Debug": {
-    "zh-TW": "引導式導覽：除錯", "zh-CN": "引导式导览：调试", "ja": "ガイド付きツアー：デバッグ", "ko": "가이드 투어: 디버그", "es": "Tour Guiado: Depuración", "de": "Geführte Tour: Debugging", "fr": "Visite Guidée : Débogage", "it": "Tour Guidato: Debug", "pt": "Tour Guiado: Depuração", "nl": "Rondleiding: Debuggen", "sv": "Guidad tur: Felsökning", "ru": "Управляемый тур: Отладка"
+    "zh-TW": "引導式導覽：除錯", "zh-CN": "引导式导览：调试", "ja": "ガイド付きツアー：デバッグ", "ko": "가이드 투어: 디버그", "es": "Tour Guiado: Depuración", "de": "Geführte Tour: Debugging", "fr": "Visite Guidée : Débogage", "it": "Tour Guidato: Debug", "pt-BR": "Tour Guiado: Depuração", "nl": "Rondleiding: Debuggen", "sv": "Guidad tur: Felsökning", "ru": "Управляемый тур: Отладка"
   },
   "Next (Step {step} of {steps})": {
     "zh-TW": "下一步 (第 {step} 步，共 {steps} 步)",
@@ -75,19 +75,19 @@ const DICT = {
     "fr": "Suivant (Étape {step} sur {steps})",
     "de": "Weiter (Schritt {step} von {steps})",
     "it": "Avanti (Passaggio {step} di {steps})",
-    "pt": "Próximo (Passo {step} de {steps})",
+    "pt-BR": "Próximo (Passo {step} de {steps})",
     "nl": "Volgende (Stap {step} van {steps})",
     "sv": "Nästa (Steg {step} av {steps})",
     "ru": "Далее (Шаг {step} из {steps})"
   },
   "Variable": {
-    "zh-TW": "變數", "zh-CN": "变量", "ja": "変数", "ko": "변수", "es": "Variable", "de": "Variable", "fr": "Variable", "it": "Variabile", "pt": "Variável", "nl": "Variabele", "sv": "Variabel", "ru": "Переменная"
+    "zh-TW": "變數", "zh-CN": "变量", "ja": "変数", "ko": "변수", "es": "Variable", "de": "Variable", "fr": "Variable", "it": "Variabile", "pt-BR": "Variável", "nl": "Variabele", "sv": "Variabel", "ru": "Переменная"
   },
   "Value": {
-    "zh-TW": "值", "zh-CN": "值", "ja": "値", "ko": "값", "es": "Valor", "de": "Wert", "fr": "Valeur", "it": "Valore", "pt": "Valor", "nl": "Waarde", "sv": "Värde", "ru": "Значение"
+    "zh-TW": "值", "zh-CN": "值", "ja": "値", "ko": "값", "es": "Valor", "de": "Wert", "fr": "Valeur", "it": "Valore", "pt-BR": "Valor", "nl": "Waarde", "sv": "Värde", "ru": "Значение"
   },
   "Trace Settings": {
-    "zh-TW": "追蹤設定", "zh-CN": "追踪设置", "ja": "トレース設定", "ko": "추적 설정", "es": "Ajustes de traza", "de": "Trace-Einstellungen", "fr": "Paramètres de trace", "it": "Impostazioni di tracciamento", "pt": "Configurações de rastreamento", "nl": "Trace-instellingen", "sv": "Spårningsinställningar", "ru": "Настройки трассировки"
+    "zh-TW": "追蹤設定", "zh-CN": "追踪设置", "ja": "トレース設定", "ko": "추적 설정", "es": "Ajustes de traza", "de": "Trace-Einstellungen", "fr": "Paramètres de trace", "it": "Impostazioni di tracciamento", "pt-BR": "Configurações de rastreamento", "nl": "Trace-instellingen", "sv": "Spårningsinställningar", "ru": "Настройки трассировки"
   }
 };
 

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -1,4 +1,4 @@
-import { translateFromCatalogs } from "./index"
+import { I18n, translateFromCatalogs } from "./index"
 
 describe("translateFromCatalogs", () => {
   const english = {
@@ -27,5 +27,48 @@ describe("translateFromCatalogs", () => {
   test("returns the key path when neither catalog contains a key", () => {
     expect(translateFromCatalogs({}, english, "debug.missing"))
       .toBe("debug.missing")
+  })
+})
+
+const createStorage = (saved: string | null) => {
+  let value = saved
+  return {
+    getItem: jest.fn(() => value),
+    setItem: jest.fn((_key: string, nextValue: string) => {
+      value = nextValue
+    }),
+  }
+}
+
+describe("Portuguese language identity", () => {
+  test("migrates the saved pt preference to pt-BR", () => {
+    const storage = createStorage("pt")
+    const i18n = new I18n(storage, "en-US")
+
+    expect(i18n.getLanguage()).toBe("pt-BR")
+    expect(storage.setItem).toHaveBeenCalledWith("apple2ts-language", "pt-BR")
+  })
+
+  test.each([
+    ["pt-BR", "pt-BR"],
+    ["pt", "pt-BR"],
+    ["pt-PT", "pt-BR"],
+    ["pt-AO", "pt-BR"],
+  ])("detects browser language %s as %s", (browserLanguage, expectedLanguage) => {
+    const i18n = new I18n(createStorage(null), browserLanguage)
+
+    expect(i18n.getLanguage()).toBe(expectedLanguage)
+  })
+
+  test.each([
+    ["es-MX", "es"],
+    ["zh", "zh-TW"],
+    ["zh-Hant-HK", "zh-TW"],
+    ["zh-Hans-SG", "zh-CN"],
+    ["est", "en"],
+  ])("uses exact primary-language matching for %s", (browserLanguage, expectedLanguage) => {
+    const i18n = new I18n(createStorage(null), browserLanguage)
+
+    expect(i18n.getLanguage()).toBe(expectedLanguage)
   })
 })

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,50 +5,58 @@ import { es } from "./languages/es"
 import { de } from "./languages/de"
 import { fr } from "./languages/fr"
 import { it } from "./languages/it"
-import { pt } from "./languages/pt"
+import { ptBR } from "./languages/pt-BR"
 import { ja } from "./languages/ja"
 import { ko } from "./languages/ko"
 import { nl } from "./languages/nl"
 import { sv } from "./languages/sv"
 import { ru } from "./languages/ru"
 
-export type Language = "en" | "zh-TW" | "zh-CN" | "es" | "de" | "fr" | "it" | "pt" | "ja" | "ko" | "nl" | "sv" | "ru"
+export type Language = "en" | "zh-TW" | "zh-CN" | "es" | "de" | "fr" | "it" | "pt-BR" | "ja" | "ko" | "nl" | "sv" | "ru"
 export type TranslationKey = keyof typeof en
 
-// 語言顯示名稱（用原生語言顯示）
-export const LanguageNames: Record<Language, string> = {
-  "en": "English",
-  "zh-TW": "繁體中文",
-  "zh-CN": "简体中文",
-  "es": "Español",
-  "de": "Deutsch",
-  "fr": "Français",
-  "it": "Italiano",
-  "pt": "Português",
-  "ja": "日本語",
-  "ko": "한국어",
-  "nl": "Nederlands",
-  "sv": "Svenska",
-  "ru": "Русский"
-}
-
-const translations = {
-  "en": en,
-  "zh-TW": zhTW,
-  "zh-CN": zhCN,
-  "es": es,
-  "de": de,
-  "fr": fr,
-  "it": it,
-  "pt": pt,
-  "ja": ja,
-  "ko": ko,
-  "nl": nl,
-  "sv": sv,
-  "ru": ru
-}
-
 type TranslationCatalog = Record<string, unknown>
+
+type LanguageDefinition = {
+  id: Language
+  name: string
+  flag: string
+  catalog: TranslationCatalog
+  browserPrimaryLanguage?: string
+}
+
+// Keep each shipped catalog's identity, menu metadata, and browser alias together.
+const languageDefinitions: readonly LanguageDefinition[] = [
+  { id: "en", name: "English", flag: "🇺🇸", catalog: en, browserPrimaryLanguage: "en" },
+  { id: "zh-TW", name: "繁體中文", flag: "🇹🇼", catalog: zhTW },
+  { id: "zh-CN", name: "简体中文", flag: "🇨🇳", catalog: zhCN },
+  { id: "es", name: "Español", flag: "🇪🇸", catalog: es, browserPrimaryLanguage: "es" },
+  { id: "de", name: "Deutsch", flag: "🇩🇪", catalog: de, browserPrimaryLanguage: "de" },
+  { id: "fr", name: "Français", flag: "🇫🇷", catalog: fr, browserPrimaryLanguage: "fr" },
+  { id: "it", name: "Italiano", flag: "🇮🇹", catalog: it, browserPrimaryLanguage: "it" },
+  { id: "pt-BR", name: "Português (Brasil)", flag: "🇧🇷", catalog: ptBR, browserPrimaryLanguage: "pt" },
+  { id: "ja", name: "日本語", flag: "🇯🇵", catalog: ja, browserPrimaryLanguage: "ja" },
+  { id: "ko", name: "한국어", flag: "🇰🇷", catalog: ko, browserPrimaryLanguage: "ko" },
+  { id: "nl", name: "Nederlands", flag: "🇳🇱", catalog: nl, browserPrimaryLanguage: "nl" },
+  { id: "sv", name: "Svenska", flag: "🇸🇪", catalog: sv, browserPrimaryLanguage: "sv" },
+  { id: "ru", name: "Русский", flag: "🇷🇺", catalog: ru, browserPrimaryLanguage: "ru" },
+]
+
+export const AllLanguages = languageDefinitions.map(({ id }) => id)
+export const LanguageNames = Object.fromEntries(
+  languageDefinitions.map(({ id, name }) => [id, name]),
+) as Record<Language, string>
+export const LanguageFlags = Object.fromEntries(
+  languageDefinitions.map(({ id, flag }) => [id, flag]),
+) as Record<Language, string>
+
+const translations = Object.fromEntries(
+  languageDefinitions.map(({ id, catalog }) => [id, catalog]),
+) as Record<Language, TranslationCatalog>
+
+const legacySavedLanguageIds: Readonly<Record<string, Language>> = {
+  pt: "pt-BR",
+}
 
 // Look up nested translation keys.
 const lookupTranslation = (catalog: TranslationCatalog, key: string): string | undefined => {
@@ -76,58 +84,61 @@ export const translateFromCatalogs = (
   return result
 }
 
-class I18n {
+type LanguageStorage = Pick<Storage, "getItem" | "setItem">
+
+export class I18n {
   private currentLanguage: Language = "en"
   
-  constructor() {
-    // 從 localStorage 讀取語言設定
-    const saved = localStorage.getItem("apple2ts-language")
-    if (saved && this.isValidLanguage(saved)) {
-      this.currentLanguage = saved as Language
+  constructor(
+    private readonly storage: LanguageStorage = localStorage,
+    browserLanguage = navigator.language,
+  ) {
+    // Read the saved language setting.
+    const saved = this.storage.getItem("apple2ts-language")
+    const migrated = saved && (legacySavedLanguageIds[saved] ?? saved)
+    if (migrated && this.isValidLanguage(migrated)) {
+      this.currentLanguage = migrated
+      if (migrated !== saved) {
+        this.storage.setItem("apple2ts-language", migrated)
+      }
     } else {
-      // 偵測瀏覽器語言
-      this.currentLanguage = this.detectBrowserLanguage()
+      // Detect the browser language.
+      this.currentLanguage = this.detectBrowserLanguage(browserLanguage)
     }
   }
   
-  private isValidLanguage(lang: string): boolean {
-    return ["en", "zh-TW", "zh-CN", "es", "de", "fr", "it", "pt", "ja", "ko", "nl", "sv", "ru"].includes(lang)
+  private isValidLanguage(lang: string): lang is Language {
+    return languageDefinitions.some(({ id }) => id === lang)
   }
   
-  private detectBrowserLanguage(): Language {
-    const browserLang = navigator.language.toLowerCase()
+  private detectBrowserLanguage(browserLanguage: string): Language {
+    const [primaryLanguage, ...subtags] = browserLanguage.toLowerCase().split("-")
     
-    // 檢測中文變體
-    if (browserLang.includes("zh")) {
-      if (browserLang.includes("tw") || browserLang.includes("hant") || browserLang.includes("mo")) {
-        return "zh-TW"  // 繁體中文（台灣、香港、澳門）
+    // Detect Chinese variants.
+    if (primaryLanguage === "zh") {
+      if (subtags.includes("tw") || subtags.includes("hant") || subtags.includes("mo")) {
+        return "zh-TW"  // Traditional Chinese (Taiwan, Hong Kong, Macau)
       }
-      if (browserLang.includes("cn") || browserLang.includes("hans") || browserLang.includes("sg")) {
-        return "zh-CN"  // 簡體中文（中國大陸、新加坡）
+      if (subtags.includes("cn") || subtags.includes("hans") || subtags.includes("sg")) {
+        return "zh-CN"  // Simplified Chinese (Mainland China, Singapore)
       }
-      return "zh-TW"  // 預設繁體中文
+      return "zh-TW"  // Default to Traditional Chinese.
     }
     
-    // 檢測其他語言
-    if (browserLang.startsWith("es")) return "es"  // 西班牙文
-    if (browserLang.startsWith("de")) return "de"  // 德文
-    if (browserLang.startsWith("fr")) return "fr"  // 法文
-    if (browserLang.startsWith("it")) return "it"  // 義大利文
-    if (browserLang.startsWith("pt")) return "pt"  // 葡萄牙文
-    if (browserLang.startsWith("ja")) return "ja"  // 日文
-    if (browserLang.startsWith("ko")) return "ko"  // 韓文
-    if (browserLang.startsWith("nl")) return "nl"  // 荷蘭文
-    if (browserLang.startsWith("sv")) return "sv"  // 瑞典文
-    if (browserLang.startsWith("ru")) return "ru"  // 俄文
+    // pt intentionally selects pt-BR until a pt-PT catalog exists.
+    const matchingLanguage = languageDefinitions.find(
+      ({ browserPrimaryLanguage }) => browserPrimaryLanguage === primaryLanguage,
+    )
+    if (matchingLanguage) return matchingLanguage.id
     
-    return "en"  // 預設英文
+    return "en"  // Default to English.
   }
   
   private listeners: ((lang: Language) => void)[] = []
 
   setLanguage(lang: Language) {
     this.currentLanguage = lang
-    localStorage.setItem("apple2ts-language", lang)
+    this.storage.setItem("apple2ts-language", lang)
     this.emitChange()
   }
 

--- a/src/i18n/languages/pt-BR.ts
+++ b/src/i18n/languages/pt-BR.ts
@@ -1,4 +1,4 @@
-export const pt = {
+export const ptBR = {
   "controls": {
     "boot": "Iniciar",
     "reset": "Reiniciar",

--- a/src/ui/controls/languageswitch.tsx
+++ b/src/ui/controls/languageswitch.tsx
@@ -1,27 +1,7 @@
 import React, { useState } from "react"
 import { useTranslation } from "../../i18n/useTranslation"
-import { Language, LanguageNames } from "../../i18n"
+import { AllLanguages, LanguageFlags, LanguageNames } from "../../i18n"
 import PopupMenu from "./popupmenu"
-
-// 語言標誌映射（使用 Unicode emoji 或簡寫）
-const LanguageFlags: Record<Language, string> = {
-  "en": "🇺🇸",
-  "zh-TW": "🇹🇼",
-  "zh-CN": "🇨🇳",
-  "es": "🇪🇸",
-  "de": "🇩🇪",
-  "fr": "🇫🇷",
-  "it": "🇮🇹",
-  "pt": "🇵🇹",
-  "ja": "🇯🇵",
-  "ko": "🇰🇷",
-  "nl": "🇳🇱",
-  "sv": "🇸🇪",
-  "ru": "🇷🇺"
-}
-
-// 所有支援的語言列表
-const AllLanguages: Language[] = ["en", "zh-TW", "zh-CN", "es", "de", "fr", "it", "pt", "ja", "ko", "nl", "sv", "ru"]
 
 const LanguageSwitch: React.FC = () => {
   const { language, changeLanguage } = useTranslation()


### PR DESCRIPTION
## Summary

- Rename the ambiguous Portuguese catalog identity from `pt` to `pt-BR`.
- Migrate saved ambiguous Portuguese preferences to Brazilian Portuguese.
- Centralize locale metadata into a single table.
- Improve precision of browser language matching.
- Add tests for saved-language migration and browser-language detection.
- Add test controllability for storage and browser-language values.

## Tests

- `npm test -- --runInBand src/i18n/index.test.ts`
- `npm run lint`
- `npm run build`