### PR TITLE
fix(i18n): properly replace repeated placeholders in translated strings

### DIFF
--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -5,6 +5,8 @@ describe("translateFromCatalogs", () => {
     debug: {
       tooltip: "English value: {{value}}",
       englishOnly: "English fallback",
+      repeated: "{{value}} then {{value}}",
+      separateValues: "{{first}} then {{second}}",
     },
   }
 
@@ -27,6 +29,18 @@ describe("translateFromCatalogs", () => {
   test("returns the key path when neither catalog contains a key", () => {
     expect(translateFromCatalogs({}, english, "debug.missing"))
       .toBe("debug.missing")
+  })
+
+  test("replaces every occurrence of a template variable", () => {
+    expect(translateFromCatalogs({}, english, "debug.repeated", {value: "$03"}))
+      .toBe("$03 then $03")
+  })
+
+  test("does not interpolate placeholder text inside a replacement value", () => {
+    expect(translateFromCatalogs({}, english, "debug.separateValues", {
+      first: "{{second}}",
+      second: "$03",
+    })).toBe("{{second}} then $03")
   })
 })
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -50,7 +50,7 @@ export const LanguageFlags = Object.fromEntries(
   languageDefinitions.map(({ id, flag }) => [id, flag]),
 ) as Record<Language, string>
 
-const translations = Object.fromEntries(
+export const LanguageCatalogs = Object.fromEntries(
   languageDefinitions.map(({ id, catalog }) => [id, catalog]),
 ) as Record<Language, TranslationCatalog>
 
@@ -76,8 +76,8 @@ export const translateFromCatalogs = (
   let result = lookupTranslation(selectedLanguage, key) ?? lookupTranslation(english, key) ?? key
 
   if (params) {
-    Object.keys(params).forEach(param => {
-      result = result.replace(`{{${param}}}`, params[param])
+    result = result.replace(/{{([^{}]+)}}/g, (token, param: string) => {
+      return Object.prototype.hasOwnProperty.call(params, param) ? params[param] : token
     })
   }
 
@@ -158,7 +158,7 @@ export class I18n {
   }
   
   t(key: string, params?: Record<string, string>): string {
-    return translateFromCatalogs(translations[this.currentLanguage], en, key, params)
+    return translateFromCatalogs(LanguageCatalogs[this.currentLanguage], en, key, params)
   }
 }
 

--- a/src/i18n/translation_placeholders.test.ts
+++ b/src/i18n/translation_placeholders.test.ts
@@ -1,0 +1,53 @@
+import { AllLanguages, LanguageCatalogs } from "./index"
+
+type Catalog = Record<string, unknown>
+
+const catalogs = AllLanguages
+  .filter(locale => locale !== "en")
+  .map(locale => [locale, LanguageCatalogs[locale]] as const)
+
+const flattenStrings = (
+  value: Catalog,
+  prefix = "",
+  result = new Map<string, string>(),
+) => {
+  for (const [key, child] of Object.entries(value)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (typeof child === "string") {
+      result.set(path, child)
+    } else if (child && typeof child === "object") {
+      flattenStrings(child as Catalog, path, result)
+    }
+  }
+  return result
+}
+
+const templateVariables = (value: string) =>
+  [...value.matchAll(/{{([^{}]+)}}/g)]
+    .map(match => match[1])
+    .sort()
+
+describe("translation template variables", () => {
+  const english = flattenStrings(LanguageCatalogs.en)
+
+  test("requires the runtime's exact placeholder spelling", () => {
+    expect(templateVariables("{{ value }}")).not.toEqual(templateVariables("{{value}}"))
+  })
+
+  test.each(catalogs)("%s retains every English template variable", (_locale, catalog) => {
+    const translated = flattenStrings(catalog)
+
+    for (const [key, englishValue] of english) {
+      const translatedValue = translated.get(key)
+      if (translatedValue === undefined) continue
+
+      expect({
+        key,
+        variables: templateVariables(translatedValue),
+      }).toEqual({
+        key,
+        variables: templateVariables(englishValue),
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Some translated strings reuse the same template variable multiple times. `translateFromCatalogs()` replaced only the first occurrence, leaving later placeholders visible.

- Replace every placeholder occurrence in one non-cascading pass.
- Use the authoritative language-catalog registry to audit every shipped translation.
- Require translated strings to preserve the exact placeholder multiset while continuing to allow missing keys to fall back to English.

## Testing

- `npm test -- --runInBand`
- `npm run lint`
- `npm run build`