### PR TITLE
fix(debugger): honor Break Once across breakpoint types

### DIFF
--- a/src/ui/panels/breakpoints/bpedit_breakpoint.tsx
+++ b/src/ui/panels/breakpoints/bpedit_breakpoint.tsx
@@ -75,37 +75,39 @@ const BPEdit_Breakpoint = (props: {
           placeholder={t("debug.any")}
           width="5em" />
       </div>
-      <div style={{ marginTop: "16px" }}>
-        <EditField name="Hit&nbsp;Count: "
-          value={props.breakpoint.hitcount.toString()}
-          setValue={handleHitCountChange}
-          isNumber={true}
-          placeholder="1"
-          width="5em" />
-        <span className="dialog-title">Expression:</span>
-        <ExpressionControl expr={props.breakpoint.expression1}
-          setExpr={handleExpressionChange1} />
-        <span style={{ marginLeft: "1em", marginRight: "1em" }}>
-          <Droplist
-            monospace={true}
-            disabled={props.breakpoint.expression1.register === ""}
-            value={props.breakpoint.expressionOperator}
-            values={["", "&&", "||"]}
-            setValue={(v: string) => handleExpressionOperatorChange(v as ExpressionOperator)} />
-        </span>
-        <ExpressionControl expr={props.breakpoint.expression2}
-          setExpr={handleExpressionChange2}
-          disabled={props.breakpoint.expression1.register === "" || props.breakpoint.expressionOperator === ""}
-        />
-      </div>
-      <Droplist name="Memory&nbsp;Bank: "
-        value={MEMORY_BANKS[props.breakpoint.memoryBank].name}
-        values={MemoryBankNames}
-        setValue={handleMemoryBankChange}
-        userdata={props.breakpoint.address}
-        isDisabled={isBankDisabledForAddress} />
+      {!props.breakpoint.basic && <div>
+        <div style={{ marginTop: "16px" }}>
+          <EditField name="Hit&nbsp;Count: "
+            value={props.breakpoint.hitcount.toString()}
+            setValue={handleHitCountChange}
+            isNumber={true}
+            placeholder="1"
+            width="5em" />
+          <span className="dialog-title">Expression:</span>
+          <ExpressionControl expr={props.breakpoint.expression1}
+            setExpr={handleExpressionChange1} />
+          <span style={{ marginLeft: "1em", marginRight: "1em" }}>
+            <Droplist
+              monospace={true}
+              disabled={props.breakpoint.expression1.register === ""}
+              value={props.breakpoint.expressionOperator}
+              values={["", "&&", "||"]}
+              setValue={(v: string) => handleExpressionOperatorChange(v as ExpressionOperator)} />
+          </span>
+          <ExpressionControl expr={props.breakpoint.expression2}
+            setExpr={handleExpressionChange2}
+            disabled={props.breakpoint.expression1.register === "" || props.breakpoint.expressionOperator === ""}
+          />
+        </div>
+        <Droplist name="Memory&nbsp;Bank: "
+          value={MEMORY_BANKS[props.breakpoint.memoryBank].name}
+          values={MemoryBankNames}
+          setValue={handleMemoryBankChange}
+          userdata={props.breakpoint.address}
+          isDisabled={isBankDisabledForAddress} />
 
-      <Breakpoint_Actions breakpoint={props.breakpoint} setBreakpoint={props.setBreakpoint}/>
+        <Breakpoint_Actions breakpoint={props.breakpoint} setBreakpoint={props.setBreakpoint}/>
+      </div>}
       <Breakpoint_Once breakpoint={props.breakpoint} setBreakpoint={props.setBreakpoint}/>
     </div>
   )

--- a/src/worker/cpu6502.ts
+++ b/src/worker/cpu6502.ts
@@ -16,12 +16,16 @@ export const doSetBreakpointSkipOnce = () => {
   breakpointSkipOnce = true
 }
 
-export const setStepOut = () => {
-  // If we have a new Step Out, remove any old "hit once" breakpoints
+const removeHiddenHitOnceBreakpoints = () => {
   const bpTmp = new BreakpointMap(breakpointMap)
   bpTmp.forEach((bp, key) => {
-    if (bp.once) breakpointMap.delete(key)
+    if (bp.once && bp.hidden) breakpointMap.delete(key)
   })
+}
+
+export const setStepOut = () => {
+  // If we have a new Step Out, remove any old hidden stepping breakpoints.
+  removeHiddenHitOnceBreakpoints()
   const addr = getLastJSR()
   if (addr < 0) return
   if (breakpointMap.get(addr)) return
@@ -33,11 +37,9 @@ export const setStepOut = () => {
 }
 
 export const doSetBasicStep = () => {
-  const bpTmp = new BreakpointMap(breakpointMap)
-  bpTmp.forEach((bp, key) => {
-    if (bp.once) breakpointMap.delete(key)
-  })
+  removeHiddenHitOnceBreakpoints()
   const addr = 0xD805
+  if (breakpointMap.get(addr)) return
   const bp = BreakpointNew()
   bp.address = addr
   bp.once = true
@@ -46,7 +48,7 @@ export const doSetBasicStep = () => {
 }
 
 export const doSetBreakpoints = (bp: BreakpointMap) => {
-  // This will automatically erase any "hit once" breakpoints, which is okay.
+  // Replacing the UI-configured map also erases hidden stepping breakpoints.
   breakpointMap = bp
 }
 
@@ -120,7 +122,9 @@ export const isWatchpoint = (addr: number, value: number, set: boolean) => {
   if (!bp || !bp.watchpoint || bp.disabled) return false
   if (bp.hexvalue >= 0 && bp.hexvalue !== value) return false
   if (bp.memoryBank && !checkMemoryBank(bp.memoryBank, addr)) return false
-  return set ? bp.memset : bp.memget
+  const matched = set ? bp.memset : bp.memget
+  if (matched && bp.once) breakpointMap.delete(addr)
+  return matched
 }
 
 
@@ -265,16 +269,29 @@ export const hitBreakpoint = (instr = -1, vLo = 0, vHi = 0, code: PCodeInstr | n
     // Look for BASIC breakpoints
     const lineNum = memGet(0x75) + (memGet(0x76) << 8)
     const bp = breakpointMap.get(lineNum)
-    if (bp && !bp.disabled) {
+    if (bp?.basic && !bp.disabled) {
       if (bp.once) breakpointMap.delete(lineNum)
       return BREAKPOINT_RESULT.HIDDEN_BREAK
     }
   }
-  const bp = breakpointMap.get(s6502.PC) ||
-    breakpointMap.get(-1) ||
-    breakpointMap.get(instr | BRK_INSTR) ||
-    (instr >= 0 && breakpointMap.get(BRK_ILLEGAL_65C02)) ||
-    (instr >= 0 && breakpointMap.get(BRK_ILLEGAL_6502))
+  let breakpointKey = s6502.PC
+  let bp = breakpointMap.get(breakpointKey)
+  if (!bp) {
+    breakpointKey = -1
+    bp = breakpointMap.get(breakpointKey)
+  }
+  if (!bp) {
+    breakpointKey = instr | BRK_INSTR
+    bp = breakpointMap.get(breakpointKey)
+  }
+  if (!bp && instr >= 0) {
+    breakpointKey = BRK_ILLEGAL_65C02
+    bp = breakpointMap.get(breakpointKey)
+  }
+  if (!bp && instr >= 0) {
+    breakpointKey = BRK_ILLEGAL_6502
+    bp = breakpointMap.get(breakpointKey)
+  }
 
     if (!bp || bp.disabled || bp.watchpoint) return BREAKPOINT_RESULT.NO_BREAK
 
@@ -307,7 +324,7 @@ export const hitBreakpoint = (instr = -1, vLo = 0, vHi = 0, code: PCodeInstr | n
   if (bp.memoryBank && !checkMemoryBank(bp.memoryBank, s6502.PC)) {
     return BREAKPOINT_RESULT.NO_BREAK
   }
-  if (bp.once) breakpointMap.delete(s6502.PC)
+  if (bp.once) breakpointMap.delete(breakpointKey)
   return processBreakpointActions(bp, vLo, vHi, code)
 }
 

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -1,4 +1,4 @@
-import { processInstruction } from "./cpu6502"
+import { BREAKPOINT_RESULT, breakpointMap, doSetBreakpoints, hitBreakpoint, processInstruction } from "./cpu6502"
 import { getHires, memGet, memory, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
@@ -6,6 +6,7 @@ import { parseAssembly } from "./utility/assembler"
 import { doBoot, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSpeedMode, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
+import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
 
 // Make sure we don't accidentally leave debug mode on.
 test("debugMode", () => {
@@ -107,5 +108,29 @@ test("test VBL $C019 value", () => {
     doSetRunMode(RUN_MODE.PAUSED)
     jest.clearAllTimers()
     jest.useRealTimers()
+  }
+})
+
+test.each([
+  ["$C061", SWITCHES.PB0.isSetAddr],
+  ["$C062", SWITCHES.PB1.isSetAddr],
+  ["$0038", 0x0038],
+  ["$0039", 0x0039],
+])("machine-state polling does not consume a watchpoint at %s", (_label, address) => {
+  const breakpoints = new BreakpointMap()
+  const breakpoint = BreakpointNew()
+  breakpoint.address = address
+  breakpoint.watchpoint = true
+  breakpoint.memget = true
+  breakpoint.once = true
+  breakpoints.set(breakpoint.address, breakpoint)
+  doSetBreakpoints(breakpoints)
+
+  try {
+    getExternalMachineState()
+    expect(breakpointMap.get(breakpoint.address)).toBe(breakpoint)
+    expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.NO_BREAK)
+  } finally {
+    doSetBreakpoints(new BreakpointMap())
   }
 })

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -669,8 +669,8 @@ let didPassSoftSwitchDescriptions = false
 export const getExternalMachineState = () => {
   // Make sure the push button values are up to date, since they can
   // be modifed by other softswitches (like for the Sirius Joyport).
-  memGet(SWITCHES.PB0.isSetAddr)
-  memGet(SWITCHES.PB1.isSetAddr)
+  memGet(SWITCHES.PB0.isSetAddr, false)
+  memGet(SWITCHES.PB1.isSetAddr, false)
   const state: MachineState = {
     addressGetTable: addressGetTable,
     altChar: SWITCHES.ALTCHARSET.isSet,
@@ -681,7 +681,7 @@ export const getExternalMachineState = () => {
     canGoBackward: getGoBackwardIndex() >= 0,
     canGoForward: getGoForwardIndex() >= 0,
     c800Slot: C800SlotGet(),
-    cout: memGet(0x0039) << 8 | memGet(0x0038),
+    cout: memGet(0x0039, false) << 8 | memGet(0x0038, false),
     cpuSpeed: cpuSpeed,
     extraRamSize: 64 * (RamWorksMaxBank + 1),
     hires: getHires(),

--- a/src/worker/utility/breakpoint.test.ts
+++ b/src/worker/utility/breakpoint.test.ts
@@ -1,4 +1,4 @@
-import { BREAKPOINT_RESULT, doSetBreakpoints, hitBreakpoint } from "../cpu6502"
+import { BREAKPOINT_RESULT, doSetBasicStep, doSetBreakpoints, hitBreakpoint } from "../cpu6502"
 import { setPC, setX } from "../instructions"
 import { memGet, memSet } from "../memory"
 import { BreakpointMap, BreakpointNew } from "../../common/breakpoint"
@@ -70,6 +70,76 @@ test("hitBreakpoint", () => {
   expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.BREAK)
 })
 
+test("hit-once any-address breakpoint removes its map entry", () => {
+  bpMap.clear()
+  const bp = BreakpointNew()
+  bp.once = true
+  bpMap.set(-1, bp)
+  setPC(0x2000)
+
+  expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.BREAK)
+  expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.NO_BREAK)
+})
+
+test("BASIC line lookup ignores a non-BASIC breakpoint with the same key", () => {
+  bpMap.clear()
+  const lineNumber = 100
+  const bp = BreakpointNew()
+  bp.address = lineNumber
+  bp.once = true
+  bpMap.set(bp.address, bp)
+  memSet(0x75, lineNumber & 0xFF)
+  memSet(0x76, lineNumber >> 8)
+  setPC(0xD805)
+
+  expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.NO_BREAK)
+  expect(bpMap.get(bp.address)).toBe(bp)
+})
+
+test("hit-once BASIC breakpoint removes its line-number map entry", () => {
+  bpMap.clear()
+  const lineNumber = 100
+  const bp = BreakpointNew()
+  bp.address = lineNumber
+  bp.basic = true
+  bp.once = true
+  bpMap.set(bp.address, bp)
+  memSet(0x75, lineNumber & 0xFF)
+  memSet(0x76, lineNumber >> 8)
+  setPC(0xD805)
+
+  expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.HIDDEN_BREAK)
+  expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.NO_BREAK)
+})
+
+test("stepping preserves user-created hit-once breakpoints", () => {
+  bpMap.clear()
+  const bp = BreakpointNew()
+  bp.address = 0x2000
+  bp.once = true
+  bpMap.set(bp.address, bp)
+  const oldHiddenStep = BreakpointNew()
+  oldHiddenStep.address = 0x3000
+  oldHiddenStep.once = true
+  oldHiddenStep.hidden = true
+  bpMap.set(oldHiddenStep.address, oldHiddenStep)
+
+  doSetBasicStep()
+  expect(bpMap.get(bp.address)).toBe(bp)
+  expect(bpMap.has(oldHiddenStep.address)).toBe(false)
+})
+
+test("BASIC stepping preserves a user breakpoint at its internal stop address", () => {
+  bpMap.clear()
+  const bp = BreakpointNew()
+  bp.address = 0xD805
+  bp.once = true
+  bpMap.set(bp.address, bp)
+
+  doSetBasicStep()
+
+  expect(bpMap.get(bp.address)).toBe(bp)
+})
 
 // ************ Breakpoints memory bank ************
 

--- a/src/worker/utility/breakpoint_instr.test.ts
+++ b/src/worker/utility/breakpoint_instr.test.ts
@@ -55,6 +55,19 @@ test("hitInstruction All Opcodes", () => {
   }
 })
 
+test("hit-once instruction breakpoint removes its opcode-keyed map entry", () => {
+  bpMap.clear()
+  const bp = BreakpointNew()
+  bp.address = testOpcode | BRK_INSTR
+  bp.instruction = true
+  bp.once = true
+  bpMap.set(bp.address, bp)
+  setPC(0x0300)
+
+  expectInstructionBreakpoint(BREAKPOINT_RESULT.BREAK)
+  expectInstructionBreakpoint(BREAKPOINT_RESULT.NO_BREAK)
+})
+
 test("hitInstruction Illegal Opcodes", () => {
   // Now test all illegal opcodes
   bpMap.clear()

--- a/src/worker/utility/breakpoint_watch.test.ts
+++ b/src/worker/utility/breakpoint_watch.test.ts
@@ -34,6 +34,21 @@ test("watchpoints", () => {
   expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.NO_BREAK)
 })
 
+test("hit-once watchpoint removes its map entry", () => {
+  bpMap.clear()
+  const bp = BreakpointNew()
+  bp.address = 0x3000
+  bp.watchpoint = true
+  bp.memget = true
+  bp.once = true
+  bpMap.set(bp.address, bp)
+
+  memGet(bp.address, true)
+  expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.BREAK)
+  memGet(bp.address, true)
+  expect(hitBreakpoint()).toEqual(BREAKPOINT_RESULT.NO_BREAK)
+})
+
 // ************ Watchpoints memory bank ************
 
 test("watchpoints memory bank", () => {


### PR DESCRIPTION
#267 exposed Break Once for address, BASIC, instruction, and watchpoint entries. This follow-up makes each path disarm the breakpoint that actually matched.

- Remove the exact matching entry after its first qualifying hit.
- Preserve user-created one-shot breakpoints when internal stepping breakpoints are replaced.
- Prevent debugger state collection from triggering or consuming watchpoints.
- Keep unsupported advanced controls hidden for BASIC breakpoints.
- Add focused regression coverage for the exposed breakpoint types and debugger bookkeeping reads.

Tests:

- `npm test -- --runInBand` — 20 suites, 491 tests passed.
- `npm run lint -- --quiet`