### PR TITLE
fix(audio): recover sound after initialization failure

### DIFF
--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Ton Umschalten"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Alternar Sonido"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Basculer le Son"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Attiva/Disattiva Suono"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "音声切替"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "소리 토글"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -37,6 +37,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr ""
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 msgctxt "controls.settings"
 msgid "Settings"
 msgstr ""

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Geluid Omschakelen"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Alternar Som"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Переключить звук"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "Växla Ljud"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "切换音效"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -46,6 +46,10 @@ msgctxt "controls.toggleSound"
 msgid "Toggle Sound"
 msgstr "切換音效"
 
+msgctxt "controls.retrySound"
+msgid "Sound unavailable. Retry sound."
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.settings"
 msgid "Settings"

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -10,6 +10,7 @@ export const en = {
     "saveState": "Save State",
     "restoreState": "Restore State",
     "toggleSound": "Toggle Sound",
+    "retrySound": "Sound unavailable. Retry sound.",
     "settings": "Settings",
     "debugPanel": "Debug Panel",
     "reportIssue": "Report an Issue"

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -171,6 +171,24 @@ body.dark-mode .push-button:active {
   pointer-events: none;
 }
 
+.control-availability-icon {
+  display: inline-flex;
+  position: relative;
+}
+
+.control-unavailable-badge {
+  position: absolute;
+  right: -0.35em;
+  bottom: -0.25em;
+  color: #d00000;
+  font-size: 0.55em;
+  filter: drop-shadow(0 0 1px white);
+}
+
+body.dark-mode .control-unavailable-badge {
+  filter: drop-shadow(0 0 1px black);
+}
+
 .key-button {
   color: var(--text-color);
   border-width: 1px;

--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -11,9 +11,15 @@ import { resetPreferences, setPreferenceBoolean, setPreferenceTheme } from "../l
 import { DisplayConfig } from "../devices/displayconfig"
 import RunTour from "../tours/runtour"
 import { appleOutline } from "../img/icon_appleoutline"
-import { useState } from "react"
+import { useState, useSyncExternalStore } from "react"
 import PopupMenu from "./popupmenu"
-import { audioEnable, isAudioEnabled } from "../devices/audio/speaker"
+import {
+  audioEnable,
+  canShowAudioControl,
+  getAudioStatus,
+  retrySpeakerAudio,
+  subscribeAudioStatus,
+} from "../devices/audio/speaker"
 import { SerialPortSelect } from "../devices/serial/serialselect"
 import { SpeedDropdown } from "./speeddropdown"
 import { getLowercaseMode, getUseOpenAppleKey, getTheme, isGameMode } from "../ui_settings"
@@ -21,6 +27,7 @@ import { useTranslation } from "../../i18n/useTranslation"
 import { AudioConfig } from "../devices/audio/audioconfig"
 import { GamepadConfig } from "../devices/gamepadconfig"
 import LinkBuilder from "./linkbuilder"
+import { ControlAvailabilityIcon } from "./controlavailabilityicon"
 
 const isTouchDevice = "ontouchstart" in document.documentElement
 const isMac = navigator.platform.startsWith("Mac")
@@ -31,6 +38,11 @@ const ConfigButtons = (props: DisplayProps) => {
   const useOpenAppleKey = getUseOpenAppleKey()
   const modKey = (isMac ? "Cmd" : "Alt")
   const themeNames = [t("themes.classic"), t("themes.dark"), t("themes.minimal")]
+  const audioStatus = useSyncExternalStore(subscribeAudioStatus, getAudioStatus)
+  const audioUnavailable = audioStatus === "unavailable"
+  const audioTitle = audioUnavailable
+    ? t("controls.retrySound")
+    : t("controls.toggleSound")
 
   const [popupLocation, setPopupLocation] = useState<[number, number]>()
 
@@ -45,10 +57,21 @@ const ConfigButtons = (props: DisplayProps) => {
       <DisplayConfig updateDisplay={props.updateDisplay} />
 
       <button className="push-button"
-        title={t("controls.toggleSound")}
-        style={{ display: typeof AudioContext !== "undefined" ? "" : "none" }}
-        onClick={() => { audioEnable(!isAudioEnabled()); props.updateDisplay() }}>
-        <FontAwesomeIcon icon={isAudioEnabled() ? faVolumeHigh : faVolumeXmark} />
+        title={audioTitle}
+        aria-label={audioTitle}
+        style={{
+          display: canShowAudioControl() ? "" : "none",
+        }}
+        onClick={() => {
+          if (audioUnavailable) {
+            void retrySpeakerAudio()
+          } else {
+            audioEnable(audioStatus === "muted")
+          }
+        }}>
+        <ControlAvailabilityIcon unavailable={audioUnavailable}>
+          <FontAwesomeIcon icon={audioStatus === "muted" ? faVolumeXmark : faVolumeHigh} />
+        </ControlAvailabilityIcon>
       </button>
     </div>
 

--- a/src/ui/controls/controlavailabilityicon.test.tsx
+++ b/src/ui/controls/controlavailabilityicon.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { ControlAvailabilityIcon } from "./controlavailabilityicon"
+
+describe("ControlAvailabilityIcon", () => {
+  it("renders its normal icon without an unavailable overlay", () => {
+    const html = renderToStaticMarkup(
+      <ControlAvailabilityIcon><span>control</span></ControlAvailabilityIcon>,
+    )
+
+    expect(html).toContain("control-availability-icon")
+    expect(html).not.toContain("control-unavailable-badge")
+  })
+
+  it("adds a decorative unavailable overlay", () => {
+    const html = renderToStaticMarkup(
+      <ControlAvailabilityIcon unavailable>
+        <span>control</span>
+      </ControlAvailabilityIcon>,
+    )
+
+    expect(html).toContain("control-unavailable-badge")
+    expect(html).toContain("aria-hidden=\"true\"")
+  })
+})

--- a/src/ui/controls/controlavailabilityicon.tsx
+++ b/src/ui/controls/controlavailabilityicon.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCircleXmark } from "@fortawesome/free-solid-svg-icons"
+
+type ControlAvailabilityIconProps = {
+  children: ReactNode
+  unavailable?: boolean
+}
+
+export const ControlAvailabilityIcon = ({
+  children,
+  unavailable = false,
+}: ControlAvailabilityIconProps) => (
+  <span className="control-availability-icon">
+    {children}
+    {unavailable && <FontAwesomeIcon
+      className="control-unavailable-badge"
+      icon={faCircleXmark}
+      aria-hidden="true"
+    />}
+  </span>
+)

--- a/src/ui/devices/audio/speaker.test.ts
+++ b/src/ui/devices/audio/speaker.test.ts
@@ -1,0 +1,151 @@
+type TestAudioContext = {
+  audioWorklet: { addModule: jest.Mock<Promise<void>, [string]> }
+  destination: object
+  state: AudioContextState
+  close: jest.Mock<Promise<void>, []>
+  resume: jest.Mock<Promise<void>, []>
+  suspend: jest.Mock<Promise<void>, []>
+}
+
+const makeTestAudioContext = (): TestAudioContext => ({
+  audioWorklet: { addModule: jest.fn().mockResolvedValue(undefined) },
+  destination: {},
+  state: "running",
+  close: jest.fn().mockResolvedValue(undefined),
+  resume: jest.fn().mockResolvedValue(undefined),
+  suspend: jest.fn().mockResolvedValue(undefined),
+})
+
+describe("speaker audio state", () => {
+  const originalAudioContext = globalThis.AudioContext
+  const originalAudioWorkletNode = globalThis.AudioWorkletNode
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.resetModules()
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: originalAudioContext,
+    })
+    Object.defineProperty(globalThis, "AudioWorkletNode", {
+      configurable: true,
+      value: originalAudioWorkletNode,
+    })
+  })
+
+  const installBrowserAudioMocks = (context: TestAudioContext) => {
+    const connect = jest.fn()
+    const postMessage = jest.fn()
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: jest.fn(() => context),
+    })
+    Object.defineProperty(globalThis, "AudioWorkletNode", {
+      configurable: true,
+      value: jest.fn(() => ({connect, port: {postMessage}})),
+    })
+    return {connect, postMessage}
+  }
+
+  it("keeps the user's enabled state while emulation is paused", async () => {
+    const speaker = await import("./speaker")
+
+    speaker.emulatorSoundEnable(false)
+
+    expect(speaker.isAudioEnabled()).toBe(false)
+    expect(speaker.getAudioStatus()).toBe("enabled")
+  })
+
+  it("distinguishes a user mute from paused emulation", async () => {
+    const speaker = await import("./speaker")
+
+    speaker.audioEnable(false)
+    expect(speaker.getAudioStatus()).toBe("muted")
+    expect(speaker.isAudioEnabled()).toBe(false)
+
+    speaker.audioEnable(true)
+    expect(speaker.getAudioStatus()).toBe("enabled")
+    expect(speaker.isAudioEnabled()).toBe(true)
+  })
+
+  it("keeps the global sound control when only AudioWorkletNode is absent", async () => {
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: jest.fn(),
+    })
+    Object.defineProperty(globalThis, "AudioWorkletNode", {
+      configurable: true,
+      value: undefined,
+    })
+    const speaker = await import("./speaker")
+
+    expect(speaker.canShowAudioControl()).toBe(true)
+  })
+
+  it("reports the failed initialization stage and becomes unavailable", async () => {
+    const context = makeTestAudioContext()
+    const failure = new DOMException("module load failed", "AbortError")
+    context.audioWorklet.addModule.mockRejectedValue(failure)
+    installBrowserAudioMocks(context)
+    const log = jest.spyOn(console, "error").mockImplementation(() => undefined)
+    const speaker = await import("./speaker")
+
+    speaker.clickSpeaker(100)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(speaker.getAudioStatus()).toBe("unavailable")
+    expect(speaker.isAudioEnabled()).toBe(false)
+    expect(context.close).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenCalledWith(
+      "Unable to initialize speaker audio while loading the speaker worklet.",
+      failure,
+    )
+  })
+
+  it("suspends other audio after speaker failure and resumes it after recovery", async () => {
+    const failedContext = makeTestAudioContext()
+    failedContext.audioWorklet.addModule.mockRejectedValue(new Error("speaker failed"))
+    installBrowserAudioMocks(failedContext)
+    jest.spyOn(console, "error").mockImplementation(() => undefined)
+    const speaker = await import("./speaker")
+    const setOtherAudioEnabled = jest.fn()
+    speaker.registerAudioContext(setOtherAudioEnabled)
+
+    speaker.clickSpeaker(100)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(setOtherAudioEnabled).toHaveBeenLastCalledWith(false)
+
+    const recoveredContext = makeTestAudioContext()
+    installBrowserAudioMocks(recoveredContext)
+    await speaker.retrySpeakerAudio()
+    expect(setOtherAudioEnabled).toHaveBeenLastCalledWith(true)
+  })
+
+  it("retries with a fresh context and clears unavailable only after success", async () => {
+    const failedContext = makeTestAudioContext()
+    failedContext.audioWorklet.addModule.mockRejectedValue(new Error("first attempt"))
+    installBrowserAudioMocks(failedContext)
+    jest.spyOn(console, "error").mockImplementation(() => undefined)
+    const speaker = await import("./speaker")
+
+    speaker.clickSpeaker(100)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(speaker.getAudioStatus()).toBe("unavailable")
+
+    const recoveredContext = makeTestAudioContext()
+    const recovered = installBrowserAudioMocks(recoveredContext)
+    const retry = speaker.retrySpeakerAudio()
+    const duplicateRetry = speaker.retrySpeakerAudio()
+    expect(speaker.getAudioStatus()).toBe("unavailable")
+    await Promise.all([retry, duplicateRetry])
+
+    expect(speaker.getAudioStatus()).toBe("enabled")
+    expect(speaker.isAudioEnabled()).toBe(true)
+    expect(globalThis.AudioContext).toHaveBeenCalledTimes(1)
+    expect(recovered.connect).toHaveBeenCalledWith(recoveredContext.destination)
+    expect(recoveredContext.suspend).not.toHaveBeenCalled()
+  })
+})

--- a/src/ui/devices/audio/speaker.ts
+++ b/src/ui/devices/audio/speaker.ts
@@ -1,6 +1,31 @@
-let audioContext: AudioContext
-let speaker: AudioWorkletNode
-export const isAudioEnabled = () => (isAudioButtonEnabled && emulatorSoundEnabled)
+let audioContext: AudioContext | undefined
+let speaker: AudioWorkletNode | undefined
+let initializationPromise: Promise<void> | undefined
+let audioUnavailable = false
+
+export type AudioStatus = "enabled" | "muted" | "unavailable"
+
+export const isAudioEnabled = () => (
+  isAudioButtonEnabled && emulatorSoundEnabled && !audioUnavailable
+)
+
+export const canShowAudioControl = () => typeof AudioContext !== "undefined"
+
+export const getAudioStatus = (): AudioStatus => {
+  if (audioUnavailable) return "unavailable"
+  return isAudioButtonEnabled ? "enabled" : "muted"
+}
+
+const audioStatusListeners = new Set<() => void>()
+
+export const subscribeAudioStatus = (listener: () => void) => {
+  audioStatusListeners.add(listener)
+  return () => audioStatusListeners.delete(listener)
+}
+
+const emitAudioStatus = () => {
+  audioStatusListeners.forEach(listener => listener())
+}
 
 const audioContexts = new Array<(enable: boolean) => void>()
 
@@ -12,14 +37,20 @@ export const registerAudioContext = (fn: (enable: boolean) => void) => {
   if (!isAudioEnabled()) {
     fn(false)
   }
+  return () => {
+    const index = audioContexts.indexOf(fn)
+    if (index >= 0) audioContexts.splice(index, 1)
+  }
 }
 
 let isAudioButtonEnabled = true
 let emulatorSoundEnabled = true
 
 export const audioEnable = (enable: boolean) => {
+  if (isAudioButtonEnabled === enable) return
   isAudioButtonEnabled = enable
   changeAudioContexts()
+  emitAudioStatus()
 }
 
 export const emulatorSoundEnable = (enable: boolean) => {
@@ -28,54 +59,107 @@ export const emulatorSoundEnable = (enable: boolean) => {
 }
 
 const changeAudioContexts = () => {
-  if (isAudioButtonEnabled && emulatorSoundEnabled) {
+  if (isAudioEnabled()) {
     audioContexts.forEach(fn => fn(true))
   } else {
     audioContexts.forEach(fn => fn(false))
   }
 }
 
-const enableContext = (enable: boolean) => {
+const enableContext = (context: AudioContext, enable: boolean) => {
   if (enable) {
-    audioContext.resume()
+    void context.resume()
   } else {
-    audioContext.suspend()
+    void context.suspend()
   }
 }
 
-const startOscillator = async () => {
-  audioContext = new AudioContext({latencyHint: 0, sampleRate: 44100})
-  registerAudioContext(enableContext)
+let unregisterSpeakerContext: (() => void) | undefined
+
+const closeContext = (context: AudioContext) => {
+  if (context.state === "closed") return
+  void context.close().catch(error => {
+    console.error("Unable to close the failed speaker audio context.", error)
+  })
+}
+
+const makeAudioUnavailable = (message: string, error: unknown) => {
+  console.error(message, error)
+  const failedContext = audioContext
+  unregisterSpeakerContext?.()
+  unregisterSpeakerContext = undefined
+  audioContext = undefined
+  speaker = undefined
+  initializationPromise = undefined
+  audioUnavailable = true
+  changeAudioContexts()
+  emitAudioStatus()
+  if (failedContext) closeContext(failedContext)
+}
+
+type SpeakerInitializationStage =
+  | "creating the audio context"
+  | "loading the speaker worklet"
+  | "creating the speaker worklet node"
+  | "connecting the speaker output"
+
+const initializeOscillator = async () => {
+  let context: AudioContext | undefined
+  let stage: SpeakerInitializationStage = "creating the audio context"
   try {
-    await audioContext.audioWorklet.addModule("worklet/oscillator.js")
-    speaker = new AudioWorkletNode(audioContext, "oscillator")
-    speaker.connect(audioContext.destination)
-  } catch {
-    console.error("audioWorklet not available - must run on https")
-    isAudioButtonEnabled = false
-    emulatorSoundEnabled = false
+    const createdContext = new AudioContext({latencyHint: 0, sampleRate: 44100})
+    context = createdContext
+    stage = "loading the speaker worklet"
+    await createdContext.audioWorklet.addModule("worklet/oscillator.js")
+    stage = "creating the speaker worklet node"
+    const node = new AudioWorkletNode(createdContext, "oscillator")
+    stage = "connecting the speaker output"
+    node.connect(createdContext.destination)
+
+    audioContext = createdContext
+    speaker = node
+    audioUnavailable = false
+    unregisterSpeakerContext = registerAudioContext(
+      enable => enableContext(createdContext, enable),
+    )
+    changeAudioContexts()
+    emitAudioStatus()
+  } catch (error) {
+    makeAudioUnavailable(
+      `Unable to initialize speaker audio while ${stage}.`,
+      error,
+    )
+    if (context) closeContext(context)
   }
 }
 
-const getAudioContext = () => {
-  if (!audioContext) {
-    startOscillator()
-  }
-  return audioContext
+const startOscillator = () => {
+  initializationPromise ??= initializeOscillator()
+  return initializationPromise
+}
+
+export const retrySpeakerAudio = async () => {
+  if (!audioUnavailable) return
+  if (initializationPromise) return initializationPromise
+  await startOscillator()
 }
 
 // https://marcgg.com/blog/2016/11/01/javascript-audio/
 export const clickSpeaker = (cycleCount: number) => {
   if (!(isAudioEnabled())) return
-  if (getAudioContext().state !== "running") {
-    audioContext.resume()
+  if (!audioContext || !speaker) {
+    void startOscillator()
+    return
+  }
+  if (audioContext.state !== "running") {
+    void audioContext.resume()
   }
   try {
-    if (speaker) {
-      speaker.port.postMessage(cycleCount)
-    }
-  } catch {
-    console.error("error")
+    speaker.port.postMessage(cycleCount)
+  } catch (error) {
+    makeAudioUnavailable(
+      "Unable to send a speaker event to the audio worklet.",
+      error,
+    )
   }
 }
-

--- a/src/ui/mcp/mcp_tool_settings.test.ts
+++ b/src/ui/mcp/mcp_tool_settings.test.ts
@@ -1,0 +1,55 @@
+const audioEnable = jest.fn()
+const getAudioStatus = jest.fn()
+const retrySpeakerAudio = jest.fn()
+
+jest.mock("../devices/audio/speaker", () => ({
+  audioEnable,
+  getAudioStatus,
+  retrySpeakerAudio,
+}))
+jest.mock("../main2worker", () => ({
+  passSetMachineName: jest.fn(),
+  passSpeedMode: jest.fn(),
+}))
+jest.mock("../localstorage", () => ({
+  setPreferenceColorMode: jest.fn(),
+}))
+
+import { toolSetSound } from "./mcp_tool_settings"
+
+describe("toolSetSound", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("retries unavailable audio before reporting it enabled", async () => {
+    getAudioStatus
+      .mockReturnValueOnce("unavailable")
+      .mockReturnValueOnce("enabled")
+
+    await expect(toolSetSound(true)).resolves.toMatchObject({
+      success: true,
+      data: {enabled: true},
+    })
+    expect(retrySpeakerAudio).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports failure when retry leaves audio unavailable", async () => {
+    getAudioStatus.mockReturnValue("unavailable")
+
+    await expect(toolSetSound(true)).resolves.toEqual({
+      success: false,
+      error: "Sound is unavailable",
+    })
+  })
+
+  it("disables sound without retrying an unavailable speaker", async () => {
+    getAudioStatus.mockReturnValue("unavailable")
+
+    await expect(toolSetSound(false)).resolves.toMatchObject({
+      success: true,
+      data: {enabled: false},
+    })
+    expect(retrySpeakerAudio).not.toHaveBeenCalled()
+  })
+})

--- a/src/ui/mcp/mcp_tool_settings.ts
+++ b/src/ui/mcp/mcp_tool_settings.ts
@@ -6,7 +6,11 @@
 import { COLOR_MODE } from "../../common/utility"
 import { passSetMachineName, passSpeedMode } from "../main2worker"
 import { setPreferenceColorMode } from "../localstorage"
-import { audioEnable } from "../devices/audio/speaker"
+import {
+  audioEnable,
+  getAudioStatus,
+  retrySpeakerAudio,
+} from "../devices/audio/speaker"
 import type { MCPToolResult } from "./mcp_server"
 
 /**
@@ -136,9 +140,18 @@ export function toolSetColorMode(colorMode: string): MCPToolResult {
  * Enable or disable sound
  * @param enabled true to enable sound, false to disable
  */
-export function toolSetSound(enabled: boolean): MCPToolResult {
+export async function toolSetSound(enabled: boolean): Promise<MCPToolResult> {
   try {
     audioEnable(enabled)
+    if (enabled && getAudioStatus() === "unavailable") {
+      await retrySpeakerAudio()
+    }
+    if (enabled && getAudioStatus() === "unavailable") {
+      return {
+        success: false,
+        error: "Sound is unavailable",
+      }
+    }
 
     return {
       success: true,


### PR DESCRIPTION
I observed the sound button sometimes appearing muted and not recovering through the GUI.

While tracing the control, I found that its displayed state combined the user’s mute choice with the emulator’s effective audio state. Speaker-worklet initialization could also fail without giving the user a distinct unavailable state or a way to retry.

This change separates user mute, emulator pause, and unavailable audio. When speaker initialization fails, the sound button now:

- displays a small red unavailable badge;
- provides the accessible label “Sound unavailable. Retry sound.”;
- logs the exact initialization stage and original browser error;
- retries with a fresh audio context on the next click.

Registered audio contexts are suspended and restored consistently during failure and recovery. MCP sound enablement also reports failure instead of success when recovery remains unavailable.

The original intermittent observation remains difficult to reproduce, so I verified the recovery path by injecting a one-time worklet-loading failure in the browser. This does not change the existing iOS startup workaround or browser autoplay policy.

Tests:

- `npm test -- --runInBand` — 502 tests passed
- `npm run lint`
- `npm run build`
- Isolated and visible browser failure-injection and recovery checks