### PR TITLE
fix(i18n): allow aliased catalog filenames

### DIFF
--- a/tools/i18n/catalog-config.test.mjs
+++ b/tools/i18n/catalog-config.test.mjs
@@ -85,8 +85,10 @@ describe("catalog configuration", () => {
   it("covers every translator and generated catalog", () => {
     const configured = localeNames(catalogs)
     assert.deepEqual(
-      fileStems(catalogDirectory, ".po"),
-      configured.filter(locale => locale !== "en"),
+      globSync(resolve(catalogDirectory, "*.po")).sort(),
+      catalogs.filter(({sourceLanguage}) => !sourceLanguage)
+        .map(({input}) => input)
+        .sort(),
     )
     assert.deepEqual(
       fileStems(outputDirectory, ".ts"),


### PR DESCRIPTION
Automatic catalog discovery allows a translation-platform filename to map to a canonical runtime locale. The catalog-coverage test still compared raw PO filename stems with runtime IDs, so a valid alias caused CI to fail even though catalog generation succeeded.

- Compare PO files with the discovered catalog input paths.
- Continue checking generated TypeScript against canonical runtime locale IDs.

Tests: 56 i18n tests and 515 Jest tests passed. Lint also passes.