### PR TITLE
test(i18n): allow generated language additions

### DIFF
--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -94,11 +94,13 @@ describe("Portuguese language identity", () => {
 })
 
 describe("generated language registry", () => {
-  test("preserves the current language menu", () => {
-    expect(AllLanguages).toEqual([
+  test("preserves the established language menu order when catalogs are added", () => {
+    const establishedLanguages = [
       "en", "zh-TW", "zh-CN", "es", "de", "fr", "it",
       "pt-BR", "ja", "ko", "nl", "sv", "ru",
-    ])
+    ]
+
+    expect(AllLanguages.slice(0, establishedLanguages.length)).toEqual(establishedLanguages)
     expect(LanguageNames["pt-BR"]).toBe("Português (Brasil)")
     expect(LanguageFlags["zh-TW"]).toBe("🇹🇼")
   })


### PR DESCRIPTION
Apple2TS now discovers PO language catalogs automatically, but the language-menu test still requires the original list to be exact. Adding a valid catalog therefore fails CI even though the generated registry is correct.

Preserve the established language order while allowing newly discovered catalogs to be appended.

Tests: `npm test -- --runInBand` — 515 tests passed.  
Lint: `npm run lint`