### PR TITLE
fix(i18n): prevent browser translation from changing controls

### DIFF
--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -3,6 +3,7 @@ import {
   I18n,
   LanguageFlags,
   LanguageNames,
+  synchronizeDocumentLanguage,
   translateFromCatalogs,
 } from "./index"
 
@@ -111,5 +112,22 @@ describe("generated language registry", () => {
     const i18n = new I18n(createStorage(null), "not_a_locale")
 
     expect(i18n.getLanguage()).toBe("en")
+  })
+})
+
+describe("document language", () => {
+  test("stays synchronized with the selected locale", () => {
+    const i18n = new I18n(createStorage("pt-BR"), "en-US")
+    const root = {lang: ""}
+    const unsubscribe = synchronizeDocumentLanguage(i18n, root)
+
+    expect(root.lang).toBe("pt-BR")
+
+    i18n.setLanguage("fr")
+    expect(root.lang).toBe("fr")
+
+    unsubscribe()
+    i18n.setLanguage("de")
+    expect(root.lang).toBe("fr")
   })
 })

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -146,5 +146,17 @@ export class I18n {
   }
 }
 
+export const synchronizeDocumentLanguage = (
+  languageSource: Pick<I18n, "getLanguage" | "subscribe">,
+  root: Pick<HTMLElement, "lang"> = document.documentElement,
+) => {
+  const updateLanguage = (language: Language) => {
+    root.lang = language
+  }
+
+  updateLanguage(languageSource.getLanguage())
+  return languageSource.subscribe(updateLanguage)
+}
+
 export const i18n = new I18n()
 export const t = i18n.t.bind(i18n)

--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -84,7 +84,9 @@ const ConfigButtons = (props: DisplayProps) => {
         <button className={lockedKeyStyle(lowercaseMode ? 0 : 2)}
           title={`${t("config.capsLock")} (${lowercaseMode ? t("messages.off") : t("messages.on")})`}
           onClick={() => { setPreferenceBoolean("lowercaseMode", !lowercaseMode); props.updateDisplay() }}>
-          <span className="text-key" style={{ fontSize: "18pt" }}>{lowercaseMode ? "a" : "A"}</span>
+          <span translate="no" className="text-key" style={{ fontSize: "18pt" }}>
+            {lowercaseMode ? "a" : "A"}
+          </span>
         </button>
         <button className="push-button"
           title={cmdKeyTitle}

--- a/src/ui/controls/languageswitch.test.tsx
+++ b/src/ui/controls/languageswitch.test.tsx
@@ -1,0 +1,10 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import LanguageSwitch from "./languageswitch"
+
+describe("LanguageSwitch", () => {
+  test("protects native language names from browser translation", () => {
+    const html = renderToStaticMarkup(<LanguageSwitch />)
+
+    expect(html).toMatch(/^<span translate="no">/)
+  })
+})

--- a/src/ui/controls/languageswitch.tsx
+++ b/src/ui/controls/languageswitch.tsx
@@ -20,7 +20,7 @@ const LanguageSwitch: React.FC = () => {
   }
 
   return (
-    <span>
+    <span translate="no">
       <button
         className="push-button"
         title={`${getCurrentLanguageName()} - Language 語言`}

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -1,7 +1,9 @@
 import { createRoot } from "react-dom/client"
 import App from "./App"
+import { i18n, synchronizeDocumentLanguage } from "../i18n"
 
 const container = document.getElementById("root")
+synchronizeDocumentLanguage(i18n)
 const root = createRoot(container)
 root.render(
     <App/>


### PR DESCRIPTION
Chrome’s page translation can mistake Apple II controls and native language names for prose. While testing translations, the Caps Lock `A` changed into words such as `THE` or `TO`, and the Dutch language entry lost its flag.

Apple2TS also continued to identify the document as English after selecting another interface language.

- Keep the document language synchronized with the selected Apple2TS locale.
- Protect the Caps Lock `A`/`a` glyph from browser translation.
- Keep language-menu flags and native language names unchanged.
- Add focused regression coverage.

Tests: 518 passed. Lint and production build passed. The behavior was also verified in Chrome.
