### PR TITLE
feat(emulator): add direct binary load and run operations

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -298,6 +298,17 @@ type SetMemoryBlock = {
   run: boolean
 }
 
+type RunBinary = {
+  address: number,
+  data: Uint8Array,
+  entryAddress: number
+}
+
+type LoadBinary = {
+  address: number,
+  data: Uint8Array
+}
+
 type AudioDevice = {
   context: AudioContext,
   element: HTMLAudioElement,

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -99,6 +99,8 @@ export enum MSG_MAIN {
   VERA_SLOT,
   VIDEO7_OVERRIDE,
   SLOT_CONFIG,
+  RUN_BINARY,
+  LOAD_BINARY,
 }
 
 export const DEFAULT_SLOT_CONFIG: SlotConfig = {

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -27,8 +27,8 @@ import {
   passKeypress,
   passMouseEvent,
   passPasteText,
-  passSetBinaryBlock,
   passSetDebug,
+  passSetBinaryBlock,
   passSetState6502,
   passSetMemory,
   passSetRunMode,
@@ -40,6 +40,7 @@ import {
   passTimeTravelSnapshot,
   passSetShowDebugTab,
 } from "../main2worker"
+import { getBinaryLoadError, loadBinary, runBinary } from "../binaryload"
 import {
   setPreferenceBreakpoints,
   setPreferenceColorMode,
@@ -567,9 +568,61 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
       }
       const address = Number(payload.address ?? 0x300)
       const autoRun = payload.autoRun !== false
-      passSetBinaryBlock(address, decodeBase64(dataBase64), autoRun)
+      const entryAddress = Number(payload.entryAddress ?? address)
+      const data = decodeBase64(dataBase64)
+      const error = getBinaryLoadError(
+        address,
+        data,
+        autoRun ? entryAddress : null,
+        autoRun,
+      )
+      if (error) throw new Error(error)
+      // Deprecated compatibility adapter. Use loadBinary or runBinary.
+      if (autoRun) {
+        runBinary(address, data, entryAddress)
+      } else {
+        passSetBinaryBlock(address, data)
+      }
       return {
+        deprecated: true,
+        replacementAction: autoRun ? "runBinary" : "loadBinary",
         status: collectStatus(),
+      }
+    }
+
+    case "loadBinary": {
+      const dataBase64 = String(payload.dataBase64 || "")
+      if (!dataBase64) {
+        throw new Error("dataBase64 is required")
+      }
+      const address = Number(payload.address ?? 0x300)
+      const data = decodeBase64(dataBase64)
+      const error = getBinaryLoadError(address, data, null)
+      if (error) throw new Error(error)
+      loadBinary(address, data)
+      return {
+        accepted: true,
+        address,
+        size: data.length,
+      }
+    }
+
+    case "runBinary": {
+      const dataBase64 = String(payload.dataBase64 || "")
+      if (!dataBase64) {
+        throw new Error("dataBase64 is required")
+      }
+      const address = Number(payload.address ?? 0x300)
+      const entryAddress = Number(payload.entryAddress ?? address)
+      const data = decodeBase64(dataBase64)
+      const error = getBinaryLoadError(address, data, entryAddress)
+      if (error) throw new Error(error)
+      runBinary(address, data, entryAddress)
+      return {
+        accepted: true,
+        address,
+        entryAddress,
+        size: data.length,
       }
     }
 

--- a/src/ui/binaryload.ts
+++ b/src/ui/binaryload.ts
@@ -1,0 +1,40 @@
+import { passLoadBinary, passRunBinary } from "./main2worker"
+
+export const getBinaryLoadError = (
+  address: number,
+  data: Uint8Array,
+  entryAddress: number | null,
+  requireWritableRam = true,
+) => {
+  if (!Number.isInteger(address) || address < 0 || address > 0xFFFF) {
+    return "Address must be an integer from 0 to 65535"
+  }
+  if (data.length === 0) {
+    return "Binary data must contain at least one byte"
+  }
+  if (address + data.length > 0x10000) {
+    return "Binary data extends beyond address 65535"
+  }
+  if (requireWritableRam && (address > 0xBFFF || address + data.length > 0xC000)) {
+    return "Binary data extends beyond writable RAM at $BFFF"
+  }
+  if (entryAddress !== null && (!Number.isInteger(entryAddress) || entryAddress < 0 || entryAddress > 0xFFFF)) {
+    return "Entry address must be an integer from 0 to 65535"
+  }
+  return null
+}
+
+export const loadBinary = (
+  address: number,
+  data: Uint8Array,
+) => {
+  passLoadBinary(address, data)
+}
+
+export const runBinary = (
+  address: number,
+  data: Uint8Array,
+  entryAddress = address,
+) => {
+  passRunBinary(address, data, entryAddress)
+}

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -186,6 +186,16 @@ export const passSetBinaryBlock = (address: number, data: Uint8Array, run = fals
   doPostMessage(MSG_MAIN.SET_BINARY_BLOCK, memBlock)
 }
 
+export const passRunBinary = (address: number, data: Uint8Array, entryAddress = address) => {
+  const binary: RunBinary = {address, data, entryAddress}
+  doPostMessage(MSG_MAIN.RUN_BINARY, binary)
+}
+
+export const passLoadBinary = (address: number, data: Uint8Array) => {
+  const binary: LoadBinary = {address, data}
+  doPostMessage(MSG_MAIN.LOAD_BINARY, binary)
+}
+
 export const passExecuteBasicCommand = (command: string) => {
   doPostMessage(MSG_MAIN.EXECUTE_BASIC_COMMAND, command)
 }

--- a/src/ui/mcp/mcp_tool_execute.ts
+++ b/src/ui/mcp/mcp_tool_execute.ts
@@ -83,7 +83,8 @@ export async function executeMCPTool(call: MCPToolCall): Promise<MCPToolResult> 
         return toolLoadBinary(
           args.data as number[],
           args.address as number,
-          args.run as boolean
+          args.run as boolean,
+          args.entryAddress as number
         )
 
       // Symbol & Metadata

--- a/src/ui/mcp/mcp_tool_media.test.ts
+++ b/src/ui/mcp/mcp_tool_media.test.ts
@@ -1,0 +1,92 @@
+const passRunBinary = jest.fn()
+const passLoadBinary = jest.fn()
+
+jest.mock("../main2worker", () => ({
+  passAppleCommandKeyPress: jest.fn(),
+  passAppleCommandKeyRelease: jest.fn(),
+  passKeypress: jest.fn(),
+  passKeyRelease: jest.fn(),
+  passPasteText: jest.fn(),
+  passLoadBinary,
+  passRunBinary,
+}))
+jest.mock("../devices/disk/driveprops", () => ({
+  handleEjectDisk: jest.fn(),
+  handleSetDiskFromURL: jest.fn(),
+  handleSetDiskOrFileFromBuffer: jest.fn(),
+}))
+jest.mock("../devices/gamepad", () => ({
+  handleArrowKey: jest.fn(),
+}))
+
+import { toolLoadBinary } from "./mcp_tool_media"
+
+describe("toolLoadBinary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("loads bytes without resetting when run is false", () => {
+    expect(toolLoadBinary([0xEA, 0x60], 0x6000, false)).toMatchObject({
+      success: true,
+      data: {address: 0x6000, entryAddress: null, size: 2, run: false},
+    })
+
+    expect(passLoadBinary).toHaveBeenCalledWith(
+      0x6000,
+      new Uint8Array([0xEA, 0x60]),
+    )
+    expect(passRunBinary).not.toHaveBeenCalled()
+  })
+
+  it("uses the clean run operation and a distinct entry address", () => {
+    expect(toolLoadBinary([0xEA, 0x60], 0x6000, true, 0x6001)).toMatchObject({
+      success: true,
+      data: {address: 0x6000, entryAddress: 0x6001, size: 2, run: true},
+    })
+
+    expect(passRunBinary).toHaveBeenCalledWith(
+      0x6000,
+      new Uint8Array([0xEA, 0x60]),
+      0x6001,
+    )
+    expect(passLoadBinary).not.toHaveBeenCalled()
+  })
+
+  it("accepts a one-byte load at the end of writable RAM", () => {
+    expect(toolLoadBinary([0x60], 0xBFFF)).toMatchObject({
+      success: true,
+      data: {address: 0xBFFF, size: 1, run: false},
+    })
+    expect(passLoadBinary).toHaveBeenCalledWith(
+      0xBFFF,
+      new Uint8Array([0x60]),
+    )
+  })
+
+  it("rejects malformed bytes and blocks outside contiguous writable RAM", () => {
+    expect(toolLoadBinary([256], 0x6000)).toEqual({
+      success: false,
+      error: "Binary data values must be integers from 0 to 255",
+    })
+    expect(toolLoadBinary([0xEA, 0x60], 0xBFFF, true)).toEqual({
+      success: false,
+      error: "Binary data extends beyond writable RAM at $BFFF",
+    })
+    expect(toolLoadBinary([0x60], 0xC000, true)).toEqual({
+      success: false,
+      error: "Binary data extends beyond writable RAM at $BFFF",
+    })
+    expect(toolLoadBinary([0x60], 0xC000, false)).toEqual({
+      success: false,
+      error: "Binary data extends beyond writable RAM at $BFFF",
+    })
+    expect(toolLoadBinary([0xEA, 0x60], 0xFFFF, false)).toEqual({
+      success: false,
+      error: "Binary data extends beyond address 65535",
+    })
+
+    expect(passRunBinary).not.toHaveBeenCalled()
+    expect(passLoadBinary).not.toHaveBeenCalled()
+  })
+})

--- a/src/ui/mcp/mcp_tool_media.ts
+++ b/src/ui/mcp/mcp_tool_media.ts
@@ -6,11 +6,11 @@
 import {
   passKeypress,
   passKeyRelease,
-  passSetBinaryBlock,
   passPasteText,
   passAppleCommandKeyPress,
   passAppleCommandKeyRelease,
 } from "../main2worker"
+import { getBinaryLoadError, loadBinary, runBinary } from "../binaryload"
 import {
   handleEjectDisk,
   handleSetDiskOrFileFromBuffer,
@@ -223,30 +223,52 @@ export function toolSendText(text: string): MCPToolResult {
 }
 
 /**
- * Loads a binary file directly into memory
+ * Loads bytes directly into memory
  * @param data Binary data as array of bytes
  * @param address Starting address (default: 0x300)
- * @param run Whether to execute after loading (default: false)
+ * @param run Whether to reset and execute after loading (default: false)
+ * @param entryAddress Execution address (default: starting address)
  */
-export function toolLoadBinary(data: number[], address = 0x300, run = false): MCPToolResult {
+export function toolLoadBinary(data: number[], address = 0x300, run = false, entryAddress = address): MCPToolResult {
   try {
-    if (address < 0 || address > 0xFFFF) {
+    if (!Array.isArray(data)) {
       return {
         success: false,
-        error: `Invalid address: ${address}. Must be 0-65535`,
+        error: "Binary data must be an array of bytes",
+      }
+    }
+
+    if (data.some((byte) => !Number.isInteger(byte) || byte < 0 || byte > 0xFF)) {
+      return {
+        success: false,
+        error: "Binary data values must be integers from 0 to 255",
       }
     }
 
     const uint8Data = new Uint8Array(data)
-    passSetBinaryBlock(address, uint8Data, run)
+    const loadError = getBinaryLoadError(address, uint8Data, run ? entryAddress : null)
+    if (loadError) {
+      return {
+        success: false,
+        error: loadError,
+      }
+    }
+    if (run) {
+      runBinary(address, uint8Data, entryAddress)
+    } else {
+      loadBinary(address, uint8Data)
+    }
 
     return {
       success: true,
       data: {
         address: address,
+        entryAddress: run ? entryAddress : null,
         size: data.length,
         run: run,
-        message: `Binary loaded at $${address.toString(16).padStart(4, "0").toUpperCase()}`,
+        message: run
+          ? `Binary accepted for execution at $${entryAddress.toString(16).padStart(4, "0").toUpperCase()}`
+          : `Binary accepted for loading at $${address.toString(16).padStart(4, "0").toUpperCase()}`,
       },
     }
   } catch (error) {

--- a/src/ui/mcp/mcp_tools.ts
+++ b/src/ui/mcp/mcp_tools.ts
@@ -304,23 +304,36 @@ export function listMCPTools(): Array<{
     },
     {
       name: "load_binary",
-      description: "Loads a binary file directly into memory",
+      description: "Loads bytes directly into memory without mounting disk media, and optionally resets and runs them",
       inputSchema: {
         type: "object",
         properties: {
           data: {
             type: "array",
-            items: { type: "number" },
+            items: {
+              type: "integer",
+              minimum: 0,
+              maximum: 0xFF,
+            },
+            minItems: 1,
             description: "Binary data as array of bytes",
           },
           address: {
-            type: "number",
-            description: "Starting address (default: 0x300)",
+            type: "integer",
+            description: "Starting address (default: 0x300); the complete block must fit in $0000-$BFFF",
+            minimum: 0,
+            maximum: 0xFFFF,
             default: 0x300,
+          },
+          entryAddress: {
+            type: "integer",
+            description: "Execution address when run is true (default: starting address)",
+            minimum: 0,
+            maximum: 0xFFFF,
           },
           run: {
             type: "boolean",
-            description: "Whether to execute after loading",
+            description: "Whether to reset the emulator and execute after loading",
             default: false,
           },
         },
@@ -435,4 +448,3 @@ export function listMCPTools(): Array<{
     },
   ]
 }
-

--- a/src/worker/memory.ts
+++ b/src/worker/memory.ts
@@ -726,6 +726,18 @@ export const setMemoryBlock = (addr: number, data: Uint8Array) => {
   memory.set(data, offset)
 }
 
+export const setMappedMemoryBlock = (addr: number, data: Uint8Array) => {
+  let dataOffset = 0
+  while (dataOffset < data.length) {
+    const currentAddress = addr + dataOffset
+    const pageOffset = currentAddress & 0xFF
+    const pageLength = Math.min(0x100 - pageOffset, data.length - dataOffset)
+    const memoryOffset = addressSetTable[currentAddress >>> 8] + pageOffset
+    memory.set(data.subarray(dataOffset, dataOffset + pageLength), memoryOffset)
+    dataOffset += pageLength
+  }
+}
+
 export const matchMemory = (addr: number, data: number[]) => {
   for (let i = 0; i < data.length; i++) {
    if (memGet(addr + i, false) !== data[i]) return false

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -1,17 +1,118 @@
 import { BREAKPOINT_RESULT, breakpointMap, doSetBreakpoints, hitBreakpoint, processInstruction } from "./cpu6502"
 import { getHires, memGet, memory, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
-import { hiresLineToAddress, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
+import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
-import { doBoot, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSpeedMode, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
+import { doBoot, doLoadBinary, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSpeedMode, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
+import { getCurrentDriveState } from "./devices/drivestate"
 
 // Make sure we don't accidentally leave debug mode on.
 test("debugMode", () => {
   expect(TEST_DEBUG).toEqual(false)
   expect(TEST_GRAPHICS).toEqual(false)
+})
+
+test("run binary resets hardware before loading and starting the program", () => {
+  jest.useFakeTimers()
+  setIsTesting()
+  const drive = getCurrentDriveState()
+  const previousFilename = drive.filename
+  const previousMotorRunning = drive.motorRunning
+
+  try {
+    drive.filename = "mounted.woz"
+    drive.motorRunning = true
+    s6502.Accum = 0x99
+
+    // Keep execution at the distinct entry address after the first refresh.
+    const program = new Uint8Array([0xEA, 0x4C, 0x01, 0x60])
+    doRunBinary(0x6000, program, 0x6001)
+
+    expect(memory.slice(0x6000, 0x6004)).toEqual(program)
+    expect(s6502.PC).toEqual(0x6001)
+    expect(s6502.Accum).toEqual(0)
+    expect(getExternalMachineState().runMode).toEqual(RUN_MODE.RUNNING)
+    expect(drive.motorRunning).toEqual(false)
+    expect(drive.filename).toEqual("mounted.woz")
+  } finally {
+    doSetRunMode(RUN_MODE.PAUSED, false)
+    resetCpuSpeedForTesting()
+    drive.filename = previousFilename
+    drive.motorRunning = previousMotorRunning
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  }
+})
+
+test("load binary changes memory without changing execution or device state", () => {
+  setIsTesting()
+  const drive = getCurrentDriveState()
+  const previousMotorRunning = drive.motorRunning
+  const previousPC = s6502.PC
+  const previousAccum = s6502.Accum
+  const previousRunMode = getExternalMachineState().runMode
+
+  try {
+    s6502.PC = 0x4321
+    s6502.Accum = 0x99
+    drive.motorRunning = true
+    const program = new Uint8Array([0xEA, 0x60])
+
+    doLoadBinary(0x6000, program)
+
+    expect(memory.slice(0x6000, 0x6002)).toEqual(program)
+    expect(s6502.PC).toEqual(0x4321)
+    expect(s6502.Accum).toEqual(0x99)
+    expect(getExternalMachineState().runMode).toEqual(previousRunMode)
+    expect(drive.motorRunning).toEqual(true)
+  } finally {
+    s6502.PC = previousPC
+    s6502.Accum = previousAccum
+    drive.motorRunning = previousMotorRunning
+  }
+})
+
+test("load binary follows auxiliary-memory mappings across page boundaries", () => {
+  const previousAltZp = SWITCHES.ALTZP.isSet
+  const previousPage2 = SWITCHES.PAGE2.isSet
+  const previousRamWrite = SWITCHES.RAMWRT.isSet
+  const previousStore80 = SWITCHES.STORE80.isSet
+  const touchedAddresses = [
+    RamWorksMemoryStart + 0x01FF,
+    0x0200,
+    0x03FF,
+    RamWorksMemoryStart + 0x0400,
+  ]
+  const previousMemory = touchedAddresses.map((address) => memory[address])
+
+  try {
+    SWITCHES.ALTZP.isSet = true
+    SWITCHES.RAMWRT.isSet = false
+    updateAddressTables()
+    doLoadBinary(0x01FF, new Uint8Array([0xA1, 0xB2]))
+    expect(memory[RamWorksMemoryStart + 0x01FF]).toEqual(0xA1)
+    expect(memory[0x0200]).toEqual(0xB2)
+
+    SWITCHES.ALTZP.isSet = false
+    SWITCHES.STORE80.isSet = true
+    SWITCHES.PAGE2.isSet = true
+    updateAddressTables()
+    doLoadBinary(0x03FF, new Uint8Array([0xC3, 0xD4]))
+    expect(memory[0x03FF]).toEqual(0xC3)
+    expect(memory[RamWorksMemoryStart + 0x0400]).toEqual(0xD4)
+  } finally {
+    SWITCHES.ALTZP.isSet = previousAltZp
+    SWITCHES.PAGE2.isSet = previousPage2
+    SWITCHES.RAMWRT.isSet = previousRamWrite
+    SWITCHES.STORE80.isSet = previousStore80
+    touchedAddresses.forEach((address, index) => {
+      memory[address] = previousMemory[index]
+    })
+    updateAddressTables()
+  }
 })
 
 test("processInstruction", () => {

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -9,6 +9,7 @@ import { SWITCHES, overrideSoftSwitch, resetSoftSwitches, setVideo7Override,
   syncSoftSwitchStatusFlags} from "./softswitches"
 import { memory, memGet, getTextPage, getHires, memoryReset,
   updateAddressTables, setMemoryBlock, addressGetTable,
+  setMappedMemoryBlock,
   getBasePlusAuxMemory,
   setRamWorks,
   setAuxCardEnabled,
@@ -730,6 +731,22 @@ export const doSetBinaryBlock = (addr: number, data: Uint8Array, run: boolean) =
     }
   }
   doAutoboot(loadBlock)
+}
+
+export const doRunBinary = (addr: number, data: Uint8Array, entryAddress = addr) => {
+  // A direct run starts from reset hardware state before execution resumes.
+  configureMachine()
+  doReset()
+  setMemoryBlock(addr, data)
+  setPC(entryAddress)
+  doSetRunMode(RUN_MODE.RUNNING, false)
+}
+
+export const doLoadBinary = (addr: number, data: Uint8Array) => {
+  // A direct load changes memory without changing CPU or device state.
+  configureMachine()
+  updateAddressTables()
+  setMappedMemoryBlock(addr, data)
 }
 
 export const doSetPastedText = (text: string) => {

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -1,5 +1,5 @@
 import { doSetRunMode, doSetSpeedMode,
-  doStepInto, doStepOver, doStepOut, doSetBinaryBlock, doSetIsDebugging, doSetState6502, doTakeSnapshot, doSetPastedText, forceSoftSwitches,
+  doStepInto, doStepOver, doStepOut, doSetBinaryBlock, doLoadBinary, doRunBinary, doSetIsDebugging, doSetState6502, doTakeSnapshot, doSetPastedText, forceSoftSwitches,
   forceVideo7Override,
   doSetMemory,
   doSetMachineName,
@@ -247,6 +247,16 @@ if (typeof self !== "undefined") {
       case MSG_MAIN.SET_BINARY_BLOCK: {
         const memBlock = e.data.payload as SetMemoryBlock
         doSetBinaryBlock(memBlock.address, memBlock.data, memBlock.run)
+        break
+      }
+      case MSG_MAIN.RUN_BINARY: {
+        const binary = e.data.payload as RunBinary
+        doRunBinary(binary.address, binary.data, binary.entryAddress)
+        break
+      }
+      case MSG_MAIN.LOAD_BINARY: {
+        const binary = e.data.payload as LoadBinary
+        doLoadBinary(binary.address, binary.data)
         break
       }
       case MSG_MAIN.SET_CYCLECOUNT:


### PR DESCRIPTION
While debugging a directly injected program, I saw an empty Disk II drive continue running because the caller had booted the machine before loading and starting the binary. The existing combined binary action makes this kind of result depend on prior emulator state.

- Add `loadBinary` to load bytes into currently mapped RAM without changing the program counter, run mode, or device state.
- Add `runBinary` to configure and reset the machine, load the program, select its entry address, and start execution.
- Route the built-in MCP binary tool through these explicit operations.
- Validate that direct binary loads fit within writable RAM at `$0000-$BFFF`.
- Follow active main/auxiliary memory mappings when a load crosses page boundaries.

`mountBinaryBlock` combines two different operations behind its `autoRun` option. Its load-only mode is replaced by `loadBinary`, while its auto-run mode is replaced by `runBinary`. Separating them gives callers a direct operation for each intent and avoids composing boot, memory, and execution commands that can leave unrelated hardware state behind.

`mountBinaryBlock` remains temporarily as a deprecated compatibility adapter and reports the appropriate replacement to callers.

Existing GUI, URL, and VS Code loaders that intentionally establish a booted environment remain unchanged.

Tests: `npm test -- --runInBand` - 29 suites, 540 tests passed.