### PR TITLE
fix(help): declare and validate disk Help files

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -455,6 +455,7 @@ type DiskCollectionItem = {
   lastUpdated: Date,
   imageUrl?: string,
   diskUrl: string,
+  helpFile?: string,
   detailsUrl?: string,
   bookmarkId?: string,
   cloudData?: CloudData,

--- a/src/ui/devices/disk/diskimages.ts
+++ b/src/ui/devices/disk/diskimages.ts
@@ -10,6 +10,7 @@ export const diskImages: DiskCollectionItem[] = [
   {
     title: "Eamon",
     diskUrl: "Eamon%201.po",
+    helpFile: "Eamon 1.txt",
     imageUrl: "disks/Eamon%201.png",
     detailsUrl: "https://eamon.wiki/Source:Eamon_Player%27s_Manual_(revised)",
     type: undefined,
@@ -87,6 +88,7 @@ export const diskImages: DiskCollectionItem[] = [
   {
     title: "Total Replay",
     diskUrl: "https://ct6502.org/wp-content/uploads/2026/06/TotalReplay.hdv_.zip",
+    helpFile: "TotalReplay.txt",
     // diskUrl: "TotalReplay.hdv",
     // diskUrl: "https://archive.org/download/TotalReplay/Total%20Replay%20v5.2.hdv",
     imageUrl: "disks/Total%20Replay.png",
@@ -98,6 +100,7 @@ export const diskImages: DiskCollectionItem[] = [
   {
     title: "Instant Replay",
     diskUrl: "https://ct6502.org/wp-content/uploads/2026/01/TotalReplayII.hdv_.zip",
+    helpFile: "TotalReplayII.txt",
     // diskUrl: "https://archive.org/download/TotalReplay2/Total%20Replay%20II%20v1.0-alpha.4.hdv",
     imageUrl: "disks/Instant%20Replay.png",
     detailsUrl: "https://github.com/a2-4am/4sports",
@@ -108,6 +111,7 @@ export const diskImages: DiskCollectionItem[] = [
   {
     title: "Pitch Dark",
     diskUrl: "https://ct6502.org/wp-content/uploads/2026/01/PitchDark.hdv_.zip",
+    helpFile: "PitchDark.txt",
     // diskUrl: "https://archive.org/download/PitchDark/00playable.hdv",
     imageUrl: "disks/Pitch%20Dark.png",
     detailsUrl: "https://archive.org/details/PitchDark",
@@ -146,6 +150,7 @@ export const diskImages: DiskCollectionItem[] = [
   {
     title: "Wizard Replay",
     diskUrl: "https://ct6502.org/wp-content/uploads/2026/01/WizardReplay.hdv_.zip",
+    helpFile: "WizardReplay.txt",
     // diskUrl: "https://archive.org/download/WizardReplay/Wizard%20Replay%20v2.0.hdv",
     imageUrl: "disks/WizardReplay.png",
     detailsUrl: "https://archive.org/details/WizardReplay",
@@ -154,3 +159,10 @@ export const diskImages: DiskCollectionItem[] = [
     fileSize: 33553920
     }
   ]
+
+export const internalDiskResources = [
+  {
+    diskUrl: "blank.po",
+    helpFile: "blank.txt"
+  }
+]

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -15,7 +15,12 @@ import { parseGameList } from "./totalreplayutilities"
 import { getHotReload, setHelpText } from "../../ui_settings"
 import { getDiskImageFromLocalStorage, setDiskImageToLocalStorage } from "../../localstorage"
 import { DISK_COLLECTION_ITEM_TYPE } from "../../diskdialog/diskpanel_utils"
-import { createHelpTextSelector, findCatalogHelpFile } from "./helpfile"
+import {
+  createHelpTextSelector,
+  findCatalogHelpFile,
+  getHelpFileUrl,
+  readHelpResponseText
+} from "./helpfile"
 
 // Technically, all of these properties should be in the main2worker.ts file,
 // since they just maintain the state that needs to be passed to/from the
@@ -862,16 +867,9 @@ const resetAllDiskDrives = () => {
 
 const loadHelpText = async (helpFile: string) => {
   try {
-    const help = await fetch("disks/" + helpFile, { credentials: "include", redirect: "error" })
-    if (!help.ok) {
-      return "<Default>"
-    }
-    let helptext = await help.text()
-    // Hack: when running on localhost, if the file is missing it just
-    // returns the index.html. So just return an empty string instead.
-    if (helptext.startsWith("<!DOCTYPE html>")) {
-      helptext = "<Default>"
-    }
+    const help = await fetch(getHelpFileUrl(helpFile), { credentials: "include", redirect: "error" })
+    let helptext = await readHelpResponseText(help)
+    if (helptext === null) return "<Default>"
     if (helpFile === "TotalReplay.txt") {
       helptext = parseGameList(helptext)
     }

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -3,7 +3,7 @@ import { diskImages } from "./diskimages"
 import * as fflate from "fflate"
 import { OneDriveCloudDrive } from "./onedriveclouddrive"
 import { GoogleDrive } from "./googledrive"
-import { isHardDriveImage, RUN_MODE, MAX_DRIVES, replaceSuffix, FILE_SUFFIXES_DISK } from "../../../common/utility"
+import { isHardDriveImage, RUN_MODE, MAX_DRIVES, FILE_SUFFIXES_DISK } from "../../../common/utility"
 
 import { passSetDriveNewData, passSetDriveProps, passSetBinaryBlock, passPasteText, handleGetRunMode, passSetRunMode } from "../../main2worker"
 import { showGlobalProgressModal } from "../../ui_utilities"
@@ -15,6 +15,7 @@ import { parseGameList } from "./totalreplayutilities"
 import { getHotReload, setHelpText } from "../../ui_settings"
 import { getDiskImageFromLocalStorage, setDiskImageToLocalStorage } from "../../localstorage"
 import { DISK_COLLECTION_ITEM_TYPE } from "../../diskdialog/diskpanel_utils"
+import { createHelpTextSelector, findCatalogHelpFile } from "./helpfile"
 
 // Technically, all of these properties should be in the main2worker.ts file,
 // since they just maintain the state that needs to be passed to/from the
@@ -110,7 +111,9 @@ export const handleSetDiskData = (
   filename: string,
   cloudData: CloudData | null,
   writableFileHandle: WritableFileHandle | null,
-  lastLocalFileWriteTime: number) => {
+  lastLocalFileWriteTime: number,
+  helpFile?: string,
+  applyHelpText: (helpText: string) => void = setHelpText) => {
   if (cloudData) {
     cloudData.fileSize = data.length
   }
@@ -129,7 +132,7 @@ export const handleSetDiskData = (
   }
   passSetDriveNewData(propsForWorker)
   if (filename) {
-    checkForHelpFile(filename)
+    selectHelpText(helpFile, applyHelpText)
   }
 
 }
@@ -178,7 +181,8 @@ export const handleSetDiskOrFileFromBuffer = (
   buffer: ArrayBuffer,
   filename: string,
   cloudData: CloudData | null,
-  writableFileHandle: WritableFileHandle | null) => {
+  writableFileHandle: WritableFileHandle | null,
+  helpFile?: string) => {
 
   // Sanity check for strange downloads with no filename.
   if (buffer.byteLength === 143360 && !filename.includes(".")) {
@@ -206,7 +210,7 @@ export const handleSetDiskOrFileFromBuffer = (
     } else {
       if (index < 2) newIndex = 2
     }
-    handleSetDiskData(newIndex, new Uint8Array(buffer), filename, cloudData, writableFileHandle, Date.now())
+    handleSetDiskData(newIndex, new Uint8Array(buffer), filename, cloudData, writableFileHandle, Date.now(), helpFile)
     if (handleGetRunMode() === RUN_MODE.IDLE) {
       passSetRunMode(RUN_MODE.NEED_BOOT)
     } else {
@@ -518,6 +522,7 @@ export const handleSetDiskFromURL = async (url: string,
   updateDisplay?: UpdateDisplay, index = 0, cloudData?: CloudData, callback?: (buffer: ArrayBuffer | null) => void,
   debug?: (message: string) => void): Promise<boolean> => {
   debug?.(`handleSetDiskFromURL(${url}) drive=${index}`)
+  let helpFile = findCatalogHelpFile(url)
   // Check if it's a local file (not http/https URL and not Internet Archive)
   const isLocalFile = !url.startsWith("http://") && !url.startsWith("https://") && !url.startsWith(internetArchiveUrlProtocol)
   
@@ -528,13 +533,13 @@ export const handleSetDiskFromURL = async (url: string,
         const state = getDiskImageFromLocalStorage()
         if (state) {
           resetAllDiskDrives()
-          index = handleSetDiskOrFileFromBuffer(state.index, state.data.buffer, url, null, null)
+          index = handleSetDiskOrFileFromBuffer(state.index, state.data.buffer, url, null, null, helpFile)
         } else {
           const response = await fetch(url)
           const buffer = await response.arrayBuffer()
           const fileName = url.split("/").pop() || url        
           resetAllDiskDrives()
-          index = handleSetDiskOrFileFromBuffer(index, buffer, fileName, cloudData || null, null)
+          index = handleSetDiskOrFileFromBuffer(index, buffer, fileName, cloudData || null, null, helpFile)
           setDiskImageToLocalStorage(index, new Uint8Array(buffer))
         }
         diskImageLocalStorageSync(url, index)
@@ -551,6 +556,7 @@ export const handleSetDiskFromURL = async (url: string,
       return false
     }
     url = match.diskUrl
+    helpFile ??= match.helpFile
     if (!URL.canParse(url) && updateDisplay) {
       handleSetDiskFromFile(url, updateDisplay, index)
       return true
@@ -779,7 +785,7 @@ export const handleSetDiskFromURL = async (url: string,
         // If we are loading from a URL, reset all drives. Fixes issue#186
         resetAllDiskDrives()
         
-        handleSetDiskOrFileFromBuffer(index, buffer, name, cloudData || null, null)
+        handleSetDiskOrFileFromBuffer(index, buffer, name, cloudData || null, null, helpFile)
         // Loading a disk from a remote URL must boot it even when the
         // emulator was already paused or had previously run a program.
         passSetRunMode(RUN_MODE.NEED_BOOT)
@@ -854,31 +860,34 @@ const resetAllDiskDrives = () => {
   }
 }
 
-const checkForHelpFile = async (disk: string) => {
-  const helpFile = replaceSuffix(disk, "txt")
+const loadHelpText = async (helpFile: string) => {
   try {
     const help = await fetch("disks/" + helpFile, { credentials: "include", redirect: "error" })
-    let helptext = "<Default>"
-    if (help.ok) {
-      helptext = await help.text()
-      // Hack: when running on localhost, if the file is missing it just
-      // returns the index.html. So just return an empty string instead.
-      if (helptext.startsWith("<!DOCTYPE html>")) {
-        helptext = "<Default>"
-      }
-      if (helpFile === "TotalReplay.txt") {
-        helptext = parseGameList(helptext)
-      }
-      setHelpText(helptext)
-    }      
+    if (!help.ok) {
+      return "<Default>"
+    }
+    let helptext = await help.text()
+    // Hack: when running on localhost, if the file is missing it just
+    // returns the index.html. So just return an empty string instead.
+    if (helptext.startsWith("<!DOCTYPE html>")) {
+      helptext = "<Default>"
+    }
+    if (helpFile === "TotalReplay.txt") {
+      helptext = parseGameList(helptext)
+    }
+    return helptext
   } catch {
     // If we don't have a help text file, just revert to the default text.
-    setHelpText("<Default>")  }
+    return "<Default>"
+  }
 }
+
+const selectHelpText = createHelpTextSelector(loadHelpText)
 
 export const handleSetDiskFromFile = async (disk: string,
   updateDisplay: UpdateDisplay | null, driveIndex: number = -1,
   callback?: (buffer: ArrayBuffer | null) => void) => {
+  const configuredHelpFile = findCatalogHelpFile(disk)
   let data: ArrayBuffer
   try {
     const res = await fetch("disks/" + disk)
@@ -907,32 +916,24 @@ export const handleSetDiskFromFile = async (disk: string,
       driveIndex = 0
     }
 
-    handleSetDiskData(driveIndex, new Uint8Array(data), disk, null, null, -1)
+    handleSetDiskData(
+      driveIndex,
+      new Uint8Array(data),
+      disk,
+      null,
+      null,
+      -1,
+      configuredHelpFile,
+      (helpText) => {
+        setHelpText(helpText)
+        updateDisplay?.(0, helpText)
+      }
+    )
 
     if (needsBoot) {
       passSetRunMode(RUN_MODE.NEED_BOOT)
     }
 
-    const helpFile = replaceSuffix(disk, "txt")
-    try {
-      const help = await fetch("disks/" + helpFile, { credentials: "include", redirect: "error" })
-      let helptext = "<Default>"
-      if (help.ok) {
-        helptext = await help.text()
-        // Hack: when running on localhost, if the file is missing it just
-        // returns the index.html. So just return an empty string instead.
-        if (helptext.startsWith("<!DOCTYPE html>")) {
-          helptext = "<Default>"
-        }
-        if (helpFile.includes("Total%20Replay")) {
-        helptext = parseGameList(helptext)
-      }
-        updateDisplay?.(0, helptext)
-      }      
-    } catch {
-      // If we don't have a help text file, just revert to the default text.
-      updateDisplay?.(0, "<Default>")
-    }
   }
 }
 

--- a/src/ui/devices/disk/helpfile.test.ts
+++ b/src/ui/devices/disk/helpfile.test.ts
@@ -1,4 +1,9 @@
-import { createHelpTextSelector, findCatalogHelpFile } from "./helpfile"
+import {
+  createHelpTextSelector,
+  findCatalogHelpFile,
+  getHelpFileUrl,
+  readHelpResponseText
+} from "./helpfile"
 import { diskImages, internalDiskResources } from "./diskimages"
 import { newReleases } from "./newreleases"
 import fs from "node:fs"
@@ -34,6 +39,50 @@ describe("findCatalogHelpFile", () => {
     ({ helpFile }) => {
       expect(fs.existsSync(path.resolve(__dirname, "../../../../public/disks", helpFile ?? "")))
         .toBe(true)
+    }
+  )
+})
+
+describe("getHelpFileUrl", () => {
+  it("encodes a declared filesystem filename for an HTTP request", () => {
+    expect(getHelpFileUrl("Eamon 1.txt")).toBe("disks/Eamon%201.txt")
+  })
+})
+
+describe("readHelpResponseText", () => {
+  const response = (ok: boolean, contentType: string | null, body: string) => {
+    const text = jest.fn().mockResolvedValue(body)
+    return {
+      value: {
+        ok,
+        headers: { get: jest.fn().mockReturnValue(contentType) },
+        text
+      } as unknown as Pick<Response, "ok" | "headers" | "text">,
+      text
+    }
+  }
+
+  it("rejects an unsuccessful response without reading its body", async () => {
+    const result = response(false, "text/plain", "Missing")
+
+    await expect(readHelpResponseText(result.value)).resolves.toBeNull()
+    expect(result.text).not.toHaveBeenCalled()
+  })
+
+  it("rejects an HTML fallback without inspecting its body", async () => {
+    const result = response(true, "text/html; charset=utf-8", "<!DOCTYPE html>")
+
+    await expect(readHelpResponseText(result.value)).resolves.toBeNull()
+    expect(result.text).not.toHaveBeenCalled()
+  })
+
+  it.each(["text/plain; charset=utf-8", null])(
+    "reads Help text with content type %p",
+    async (contentType) => {
+      const result = response(true, contentType, "Disk Help")
+
+      await expect(readHelpResponseText(result.value)).resolves.toBe("Disk Help")
+      expect(result.text).toHaveBeenCalledTimes(1)
     }
   )
 })

--- a/src/ui/devices/disk/helpfile.test.ts
+++ b/src/ui/devices/disk/helpfile.test.ts
@@ -1,0 +1,57 @@
+import { createHelpTextSelector, findCatalogHelpFile } from "./helpfile"
+import { diskImages, internalDiskResources } from "./diskimages"
+import { newReleases } from "./newreleases"
+import fs from "node:fs"
+import path from "node:path"
+
+describe("findCatalogHelpFile", () => {
+  it.each([
+    ["Eamon", "Eamon 1.txt"],
+    ["Total Replay", "TotalReplay.txt"],
+    ["Instant Replay", "TotalReplayII.txt"],
+    ["Pitch Dark", "PitchDark.txt"],
+    ["Wizard Replay", "WizardReplay.txt"]
+  ])("finds the Help file declared for %s", (title, helpFile) => {
+    const disk = diskImages.find((item) => item.title === title)
+
+    expect(findCatalogHelpFile(disk?.diskUrl ?? "")).toBe(helpFile)
+  })
+
+  it("finds the Help file declared for the internal blank disk", () => {
+    expect(findCatalogHelpFile("blank.po")).toBe("blank.txt")
+  })
+
+  it("finds Help when a direct loader uses the bundled-disk URL prefix", () => {
+    expect(findCatalogHelpFile("/disks/Eamon%201.po")).toBe("Eamon 1.txt")
+  })
+
+  it("does not infer a Help file from an uncataloged disk filename", () => {
+    expect(findCatalogHelpFile("Tass Times.2mg")).toBeUndefined()
+  })
+
+  it.each([...diskImages, ...newReleases, ...internalDiskResources].filter((disk) => disk.helpFile))(
+    "references an existing Help file for $diskUrl",
+    ({ helpFile }) => {
+      expect(fs.existsSync(path.resolve(__dirname, "../../../../public/disks", helpFile ?? "")))
+        .toBe(true)
+    }
+  )
+})
+
+describe("createHelpTextSelector", () => {
+  it("does not apply Help from a disk that is no longer selected", async () => {
+    let finishOldLoad: (helpText: string) => void = () => undefined
+    const loadHelpText = () => new Promise<string>((resolve) => {
+      finishOldLoad = resolve
+    })
+    const appliedHelp: string[] = []
+    const selectHelpText = createHelpTextSelector(loadHelpText)
+
+    selectHelpText("old.txt", (helpText) => appliedHelp.push(helpText))
+    selectHelpText(undefined, (helpText) => appliedHelp.push(helpText))
+    finishOldLoad("Old disk Help")
+    await Promise.resolve()
+
+    expect(appliedHelp).toEqual(["<Default>"])
+  })
+})

--- a/src/ui/devices/disk/helpfile.ts
+++ b/src/ui/devices/disk/helpfile.ts
@@ -1,6 +1,17 @@
 import { diskImages, internalDiskResources } from "./diskimages"
 import { newReleases } from "./newreleases"
 
+export const getHelpFileUrl = (helpFile: string) => `disks/${encodeURIComponent(helpFile)}`
+
+export const readHelpResponseText = async (
+  response: Pick<Response, "ok" | "headers" | "text">
+) => {
+  if (!response.ok) return null
+  const contentType = response.headers.get("content-type")?.toLowerCase()
+  if (contentType?.includes("text/html")) return null
+  return response.text()
+}
+
 export const findCatalogHelpFile = (diskUrl: string) => {
   const catalogDiskUrl = diskUrl.replace(/^\/disks\//, "")
   return [...diskImages, ...newReleases, ...internalDiskResources]

--- a/src/ui/devices/disk/helpfile.ts
+++ b/src/ui/devices/disk/helpfile.ts
@@ -1,0 +1,27 @@
+import { diskImages, internalDiskResources } from "./diskimages"
+import { newReleases } from "./newreleases"
+
+export const findCatalogHelpFile = (diskUrl: string) => {
+  const catalogDiskUrl = diskUrl.replace(/^\/disks\//, "")
+  return [...diskImages, ...newReleases, ...internalDiskResources]
+    .find((item) => item.diskUrl === catalogDiskUrl)?.helpFile
+}
+
+export const createHelpTextSelector = (loadHelpText: (helpFile: string) => Promise<string>) => {
+  let selection = 0
+
+  return (helpFile: string | undefined, applyHelpText: (helpText: string) => void) => {
+    const currentSelection = ++selection
+    if (!helpFile) {
+      applyHelpText("<Default>")
+      return
+    }
+    void loadHelpText(helpFile)
+      .catch(() => "<Default>")
+      .then((helpText) => {
+        if (selection === currentSelection) {
+          applyHelpText(helpText)
+        }
+      })
+  }
+}


### PR DESCRIPTION
Disk-specific Help was selected by swapping the mounted disk image’s filename extension for `.txt`. That convention broke when Wizard Replay moved into a ZIP with a differently named disk image.

- Declare supported Help files alongside their disk catalog entries and carry those declarations through every disk-loading path.
- Use default Help when no Help file is declared or its request fails.
- Replace fragile HTML inspection with response status and content-type validation when detecting missing Help files.
- Encode declared Help filenames when constructing request URLs.
- Prevent a potential race where an older Help request could overwrite the currently selected disk’s Help.

Tests: `npm test -- --runInBand --detectOpenHandles` - 32 suites, 568 tests passed.