### PR TITLE
fix(ui): accurately display 64K memory for Apple II+ and Apple IIe w/o Aux Card

### DIFF
--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -6,6 +6,8 @@ import {
   doOnMessage,
   setMain2Worker,
   handleGetMemSize,
+  handleGetMachineName,
+  handleGetSlotConfig,
   passSetRunMode,
   setBootCallback} from "./main2worker"
 import Apple2Canvas from "./canvas"
@@ -178,7 +180,11 @@ const DisplayApple2 = () => {
       document.body.style.marginTop = isLandscape ? "10px" : "0"
     }
   }, [isTouchDevice, isLandscape])
-  const mem = handleGetMemSize() + 64
+  const machineName = handleGetMachineName()
+  const slotConfig = handleGetSlotConfig()
+  const isApple2Plus = machineName === "APPLE2P"
+  const hasAuxCard = !isApple2Plus && slotConfig[3] === "aux"
+  const mem = isApple2Plus ? 64 : (hasAuxCard ? (handleGetMemSize() + 64) : 64)
   const memSize = (mem > 1100) ? ((mem / 1024).toFixed() + " MB") : (mem + " KB")
   const status = <div className="default-font footer-item">
   <>{currentSpeed} MHz, {memSize}, FPS: {avgFPS.toFixed(1)}</>


### PR DESCRIPTION
## Summary

This pull request fixes a minor UI bug in the bottom-left hardware status footer where total system memory was erroneously reported as `128 KB` on Apple II+ models as well as Apple IIe models configured without an Auxiliary memory card (Slot 3 set to `None`).

<img width="1052" height="877" alt="image" src="https://github.com/user-attachments/assets/2fb5cef5-a2c4-44b3-8ec4-528e990e4cdc" />



---

## Root Cause

In `src/ui/display.tsx`, total memory was calculated unconditionally as `handleGetMemSize() + 64`. Because `handleGetMemSize()` defaults to 64 (representing the standard 64KB Extended 80-Column Aux RAM on Apple IIe):
- **Apple II+** (which only has 64KB total memory and no IIe auxiliary slot) displayed `64 + 64 = 128 KB`.
- **Apple IIe with Slot 3 set to None** (unexpanded 64KB motherboard memory) also displayed `128 KB`.

---

## Fix

Updated `src/ui/display.tsx` to check the current machine type and Slot 3 card configuration:
- **Apple II+**: Always reports **64 KB**.
- **Apple IIe with Slot 3 set to `None`**: Accurately reports **64 KB**.
- **Apple IIe with Slot 3 set to `Aux Card`** (Apple 699-0221 / AE RamWorks III): Accurately reports **64 KB + Aux RAM capacity** (e.g. `128 KB` for standard 64KB card, `576 KB` for 512KB card, `1088 KB` for 1MB card, `4 MB` for 4MB card, and `8 MB` for 8MB card).

---

## Verification

1. **Apple II+**: Status footer displays `1.02 MHz, 64 KB, FPS: ...`.
2. **Apple IIe (Slot 3: None)**: Status footer displays `1.02 MHz, 64 KB, FPS: ...`.
3. **Apple IIe (Slot 3: Apple 699-0221 64KB Aux)**: Status footer displays `1.02 MHz, 128 KB, FPS: ...`.
4. **Apple IIe (Slot 3: AE RamWorks III 1MB / 4MB / 8MB)**: Status footer displays `1088 KB`, `4 MB`, and `8 MB` respectively.
