### PR TITLE
feat(ui): stabilize GUI layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ src/worker/roms/65C02_extended_opcodes_test.bin
 # production
 /build
 /dist
+/playwright-report
+/test-results
 
 # generated from gettext catalogs
 /src/i18n/languages/*.ts

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ Run in watch mode:
 
 `npm test -- --watch`
 
+Run the focused Chromium layout-acceptance suite:
+
+```sh
+npm run setup:ui-layout # First run, and after Playwright upgrades
+npm run test:ui-layout
+```
+
+The layout suite requires a clean Git worktree, builds Apple2TS, starts and
+stops its own isolated preview server, and stores failure artifacts under
+`test-results/`. It complements
+manual review in Safari, Electron, native browser zoom, and real touch devices.
+See [Desktop Layout Behavior](docs/desktop-layout.md) for the requirements the
+suite enforces and the remaining human-review boundary.
+
 ### Building the Package
 
 To builds the app for production:

--- a/docs/desktop-layout.md
+++ b/docs/desktop-layout.md
@@ -1,0 +1,81 @@
+# Desktop Layout Behavior
+
+The desktop layout keeps the emulator usable while its side-panel content
+changes size. These rules describe visible behavior rather than a particular
+CSS implementation.
+
+## Stable geometry
+
+- Switching tabs does not move or resize the monitor, panel shell, tab rail,
+  layout controls, or fixed virtual-keyboard control.
+- BASIC, exPectin, and Agent keep their primary action rows at the same vertical
+  position within a given panel orientation.
+- Showing BASIC variables appends the variable table below the primary BASIC
+  workspace. It does not move or resize the editor or action row, and the
+  appended table uses document scrolling rather than adding a tab scrollbar.
+- BASIC, exPectin, and Agent action rows remain fully visible in both normal
+  and wide modes. Showing BASIC variables also leaves its header visible.
+- The normal panel starts at a compact minimum and consumes width left unused
+  after the monitor reaches its height limit. Long translated Help actions may
+  wrap at that minimum. Wide mode may take
+  additional width from the monitor, but the panel remains inside the available
+  desktop row until that row reaches its minimum supported width. Tab content
+  does not choose either width.
+
+## Viewport anchors
+
+- The monitor remains fixed while a side panel makes the document scroll
+  vertically.
+- The side-panel tab rail and layout controls belong to the same panel plane.
+  They stay put with a pinned panel; when the Debugger or
+  BASIC variables extend the document, the layout controls do not remain
+  pinned over the scrolling tabs.
+- Ordinary bounded tabs remain pinned with the monitor and do not create
+  document scrolling. The Debugger and an expanded BASIC variable table may
+  extend the document when their content needs the space.
+- Collapsing the side panel keeps the yellow restore control at the same
+  vertical position and releases the panel's grid track.
+- Moving the panel changes the layout immediately and scrolls only far enough
+  to reveal the relocated tab and layout-control row. The move does not use a
+  decorative transition.
+
+## Scroll ownership
+
+- Every visible scrollbar reveals content along its axis.
+- Bounded tab content uses the panel's internal scrolling.
+- Content deliberately taller or wider than the panel, such as the wide
+  Debugger or BASIC variables, can use document scrolling.
+- Nested scrolling remains limited to the controls needed to reach distinct
+  content. Empty or duplicate scroll ranges are defects.
+
+## Debug overlays
+
+- The HGR magnifier uses viewport coordinates and keeps the same dimensions
+  regardless of the content underneath it.
+- The magnifier paints above the monitor and panel controls, but below dialogs.
+- Leaving an HGR memory range or leaving the Debugger removes the magnifier.
+
+## Primary status and devices
+
+- The monitor, emulator controls, devices, and status readout share
+  one fixed primary footprint.
+- The monitor receives the available height first. The compact control and
+  device rows follow it. When viewport height limits the monitor, the device
+  controls end at the page's bottom margin.
+- The status readout fits beside the controls, while the device row uses the
+  full width below them.
+- The device row scales its disk and printer controls enough to show them
+  without its own scrollbar.
+- Narrow desktop windows preserve the device row's minimum width and let the
+  page scroll horizontally instead of clipping controls.
+- Panel-owned dialogs are centered over their panel and paint above the primary
+  column.
+
+## Acceptance
+
+`npm run test:ui-layout` verifies geometry relationships, scroll ownership,
+state transitions, input behavior, overlays, and browser errors in an isolated
+Chromium context. Unit tests continue to own exact layout-policy calculations.
+
+Human review remains responsible for visual balance, typography and translated
+text fit, native browser zoom, Safari, Electron, and real touch gestures.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,5 +3,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
-  testPathIgnorePatterns: ["/node_modules/", "/tools/"],
+  testPathIgnorePatterns: ["/node_modules/", "/tools/", "/tests/ui-layout/"],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",
+        "@playwright/test": "1.62.1",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/audioworklet": "^0.0.100",
         "@types/gapi.client.drive-v3": "^0.0.5",
@@ -1926,6 +1927,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -8271,6 +8288,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "preview": "vite preview",
     "pretest": "npm run check-qr-hgr-assembly && npm run test-po-catalog",
     "test": "jest",
+    "setup:ui-layout": "playwright install chromium",
+    "pretest:ui-layout": "npm run build",
+    "test:ui-layout": "playwright test --config=playwright.layout.config.ts",
     "generate-qr-hgr-assembly": "node tools/generate-qr-hgr-assembly.mjs",
     "check-qr-hgr-assembly": "node tools/generate-qr-hgr-assembly.mjs --check",
     "prereview-disassembly-tooltips": "npm run generate-i18n-catalogs",
@@ -70,6 +73,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",
+    "@playwright/test": "1.62.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/audioworklet": "^0.0.100",
     "@types/gapi.client.drive-v3": "^0.0.5",

--- a/playwright.layout.config.ts
+++ b/playwright.layout.config.ts
@@ -1,0 +1,48 @@
+import { execFileSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { defineConfig } from "@playwright/test"
+
+const git = (...args: string[]) => execFileSync("git", args, {
+  encoding: "utf8",
+}).trim()
+
+const sourceCommit = git("rev-parse", "HEAD")
+const sourceState = git("status", "--short")
+if (sourceState) {
+  throw new Error("UI layout acceptance requires a clean Git worktree")
+}
+const buildIndexSha256 = createHash("sha256")
+  .update(readFileSync("dist/index.html"))
+  .digest("hex")
+
+export default defineConfig({
+  testDir: "tests/ui-layout",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: true,
+  reporter: "line",
+  outputDir: "test-results/ui-layout",
+  metadata: {
+    sourceCommit,
+    sourceState: "clean",
+    buildIndexSha256,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:4174",
+    browserName: "chromium",
+    locale: "en-US",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "off",
+  },
+  webServer: {
+    command: "npm run preview -- --host 127.0.0.1 --port 4174 --strictPort",
+    url: "http://127.0.0.1:4174",
+    reuseExistingServer: false,
+    timeout: 30_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+})

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -87,6 +87,11 @@ type Apple2SaveState = {
 
 type UpdateDisplay = (speed = 0, helptext = "") => void
 
+type CanvasBounds = {
+  height: number,
+  width: number,
+}
+
 type DisplayProps = {
   speed: number,
   renderCount: number,
@@ -100,6 +105,7 @@ type DisplayProps = {
   handleOpenAppleDown: (mode: number) => void,
   handleClosedAppleDown: (mode: number) => void,
   setShowFileOpenDialog: (show: boolean, index: number) => void,
+  canvasBounds?: CanvasBounds,
 }
 
 type MACHINE_NAME = "APPLE2EU" | "APPLE2EE" | "APPLE2P"

--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -13,40 +13,34 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#, fuzzy
 msgctxt "controls.boot"
 msgid "Boot"
 msgstr "Starten"
 
-#, fuzzy
 msgctxt "controls.reset"
 msgid "Reset"
-msgstr "Zurücksetzen"
+msgstr "Reset"
 
-#, fuzzy
 msgctxt "controls.copyScreen"
 msgid "Copy Screen"
-msgstr "Bildschirm Kopieren"
+msgstr "Bildkopie"
 
 #, fuzzy
 msgctxt "controls.copyText"
 msgid "Copy Text"
 msgstr "Text Kopieren"
 
-#, fuzzy
 msgctxt "controls.pasteText"
 msgid "Paste Text"
-msgstr "Text Einfügen"
+msgstr "Einfügen"
 
-#, fuzzy
 msgctxt "controls.saveState"
 msgid "Save State"
-msgstr "Zustand Speichern"
+msgstr "Speichern"
 
-#, fuzzy
 msgctxt "controls.restoreState"
 msgid "Restore State"
-msgstr "Zustand Wiederherstellen"
+msgstr "Laden"
 
 #, fuzzy
 msgctxt "controls.toggleSound"
@@ -179,7 +173,6 @@ msgctxt "machine.ram.8mb"
 msgid "8 MB"
 msgstr ""
 
-#, fuzzy
 msgctxt "speed.snail"
 msgid "Snail Speed (0.1 MHz)"
 msgstr "Schneckentempo (0.1 MHz)"
@@ -189,28 +182,25 @@ msgctxt "speed.slow"
 msgid "Slow Speed (0.5 MHz)"
 msgstr "Langsam (0.5 MHz)"
 
-#, fuzzy
 msgctxt "speed.normal"
 msgid "Normal Speed (1 MHz)"
 msgstr "Normal (1 MHz)"
 
 msgctxt "speed.two"
 msgid "2 MHz"
-msgstr ""
+msgstr "2 MHz"
 
 msgctxt "speed.three"
 msgid "3 MHz"
-msgstr ""
+msgstr "3 MHz"
 
-#, fuzzy
 msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Schnell (4 MHz)"
 
-#, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Lächerlich/Warp-Geschwindigkeit"
+msgid "Ludicrous Speed"
+msgstr "Wahnsinnige Geschwindigkeit"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -1286,7 +1276,6 @@ msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
 msgstr ""
 
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkürzel"
@@ -1812,20 +1801,18 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Exportproblem melden"
 
-#, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
-msgstr "In der Zeit zurückgehen"
+msgstr "Zurückspulen"
 
 #, fuzzy
 msgctxt "debugControls.takeSnapshot"
 msgid "Take a Snapshot"
 msgstr "Schnappschuss erstellen"
 
-#, fuzzy
 msgctxt "debugControls.goForwardInTime"
 msgid "Go Forward in Time"
-msgstr "In der Zeit vorwärts gehen"
+msgstr "Vorspulen"
 
 #, fuzzy
 msgctxt "debugControls.saveStateWithSnapshots"
@@ -2302,7 +2289,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -61,6 +61,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "Debug-Panel"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2032,6 +2060,14 @@ msgstr ""
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Wert"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -57,6 +57,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "Debuggin' Deck"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Report Scurvy Trouble"
@@ -1854,6 +1882,14 @@ msgstr ""
 
 msgctxt "basic.value"
 msgid "Value"
+msgstr ""
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
 msgstr ""
 
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -177,8 +177,10 @@ msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Full Sail (4 MHz)"
 
+#, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
 msgstr "Kraken Speed"
 
 msgctxt "colors.color"
@@ -2099,8 +2101,10 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr "4 MHz (Full sail)"
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr "Kraken!"
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -61,6 +61,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "Panel de Depuración"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2019,6 +2047,14 @@ msgstr ""
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Valor"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -13,17 +13,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#, fuzzy
 msgctxt "controls.boot"
 msgid "Boot"
 msgstr "Arrancar"
 
-#, fuzzy
 msgctxt "controls.reset"
 msgid "Reset"
 msgstr "Reiniciar"
 
-#, fuzzy
 msgctxt "controls.copyScreen"
 msgid "Copy Screen"
 msgstr "Copiar Pantalla"
@@ -33,17 +30,14 @@ msgctxt "controls.copyText"
 msgid "Copy Text"
 msgstr "Copiar texto"
 
-#, fuzzy
 msgctxt "controls.pasteText"
 msgid "Paste Text"
 msgstr "Pegar Texto"
 
-#, fuzzy
 msgctxt "controls.saveState"
 msgid "Save State"
 msgstr "Guardar Estado"
 
-#, fuzzy
 msgctxt "controls.restoreState"
 msgid "Restore State"
 msgstr "Restaurar Estado"
@@ -191,18 +185,18 @@ msgstr "Velocidad normal (1 MHz)"
 
 msgctxt "speed.two"
 msgid "2 MHz"
-msgstr ""
+msgstr "2 MHz"
 
 msgctxt "speed.three"
 msgid "3 MHz"
-msgstr ""
+msgstr "3 MHz"
 
 msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Velocidad rápida (4 MHz)"
 
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
 msgstr "Velocidad absurda"
 
 msgctxt "colors.color"
@@ -1271,7 +1265,6 @@ msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
 msgstr ""
 
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Atajos de Teclado"
@@ -1795,7 +1788,6 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Reportar un problema de exportación"
 
-#, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
 msgstr "Retroceder en el Tiempo"
@@ -1805,7 +1797,6 @@ msgctxt "debugControls.takeSnapshot"
 msgid "Take a Snapshot"
 msgstr "Tomar Captura"
 
-#, fuzzy
 msgctxt "debugControls.goForwardInTime"
 msgid "Go Forward in Time"
 msgstr "Avanzar en el Tiempo"
@@ -2285,7 +2276,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -13,17 +13,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#, fuzzy
 msgctxt "controls.boot"
 msgid "Boot"
 msgstr "Démarrer"
 
-#, fuzzy
 msgctxt "controls.reset"
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#, fuzzy
 msgctxt "controls.copyScreen"
 msgid "Copy Screen"
 msgstr "Copier l'Écran"
@@ -33,17 +30,14 @@ msgctxt "controls.copyText"
 msgid "Copy Text"
 msgstr "Copier le texte"
 
-#, fuzzy
 msgctxt "controls.pasteText"
 msgid "Paste Text"
 msgstr "Coller le Texte"
 
-#, fuzzy
 msgctxt "controls.saveState"
 msgid "Save State"
 msgstr "Sauvegarder l'État"
 
-#, fuzzy
 msgctxt "controls.restoreState"
 msgid "Restore State"
 msgstr "Restaurer l'État"
@@ -179,7 +173,6 @@ msgctxt "machine.ram.8mb"
 msgid "8 MB"
 msgstr ""
 
-#, fuzzy
 msgctxt "speed.snail"
 msgid "Snail Speed (0.1 MHz)"
 msgstr "Vitesse d'Escargot (0.1 MHz)"
@@ -189,28 +182,25 @@ msgctxt "speed.slow"
 msgid "Slow Speed (0.5 MHz)"
 msgstr "Lente (0.5 MHz)"
 
-#, fuzzy
 msgctxt "speed.normal"
 msgid "Normal Speed (1 MHz)"
 msgstr "Vitesse Normale (1 MHz)"
 
 msgctxt "speed.two"
 msgid "2 MHz"
-msgstr ""
+msgstr "2 MHz"
 
 msgctxt "speed.three"
 msgid "3 MHz"
-msgstr ""
+msgstr "3 MHz"
 
-#, fuzzy
 msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Rapide (4 MHz)"
 
-#, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Vitesse Ridicule/Warp"
+msgid "Ludicrous Speed"
+msgstr "Vitesse ridicule"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -1284,7 +1274,6 @@ msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
 msgstr ""
 
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis Clavier"
@@ -1814,7 +1803,6 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Signaler un problème d'exportation"
 
-#, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
 msgstr "Remonter dans le Temps"
@@ -1824,7 +1812,6 @@ msgctxt "debugControls.takeSnapshot"
 msgid "Take a Snapshot"
 msgstr "Prendre un Instantané"
 
-#, fuzzy
 msgctxt "debugControls.goForwardInTime"
 msgid "Go Forward in Time"
 msgstr "Avancer dans le Temps"
@@ -2301,7 +2288,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -62,6 +62,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "Panneau de Débogage"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2031,6 +2059,14 @@ msgstr ""
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Valeur"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -54,6 +54,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "Pannello di Debug"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2012,6 +2040,14 @@ msgstr "Variabile"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Valore"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -6,17 +6,14 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#, fuzzy
 msgctxt "controls.boot"
 msgid "Boot"
 msgstr "Avvia"
 
-#, fuzzy
 msgctxt "controls.reset"
 msgid "Reset"
 msgstr "Ripristina"
 
-#, fuzzy
 msgctxt "controls.copyScreen"
 msgid "Copy Screen"
 msgstr "Copia Schermo"
@@ -26,17 +23,14 @@ msgctxt "controls.copyText"
 msgid "Copy Text"
 msgstr "Copia testo"
 
-#, fuzzy
 msgctxt "controls.pasteText"
 msgid "Paste Text"
 msgstr "Incolla Testo"
 
-#, fuzzy
 msgctxt "controls.saveState"
 msgid "Save State"
 msgstr "Salva Stato"
 
-#, fuzzy
 msgctxt "controls.restoreState"
 msgid "Restore State"
 msgstr "Ripristina Stato"
@@ -171,38 +165,34 @@ msgctxt "machine.ram.8mb"
 msgid "8 MB"
 msgstr ""
 
-#, fuzzy
 msgctxt "speed.snail"
 msgid "Snail Speed (0.1 MHz)"
-msgstr "Velocità Lumaca (0.1 MHz)"
+msgstr "Lumaca (0.1 MHz)"
 
 #, fuzzy
 msgctxt "speed.slow"
 msgid "Slow Speed (0.5 MHz)"
 msgstr "Lenta (0.5 MHz)"
 
-#, fuzzy
 msgctxt "speed.normal"
 msgid "Normal Speed (1 MHz)"
 msgstr "Velocità Normale (1 MHz)"
 
 msgctxt "speed.two"
 msgid "2 MHz"
-msgstr ""
+msgstr "2 MHz"
 
 msgctxt "speed.three"
 msgid "3 MHz"
-msgstr ""
+msgstr "3 MHz"
 
-#, fuzzy
 msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Veloce (4 MHz)"
 
-#, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Velocità Ridicola/Warp"
+msgid "Ludicrous Speed"
+msgstr "Velocità ridicola"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -1269,7 +1259,6 @@ msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
 msgstr ""
 
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie Tastiera"
@@ -1793,17 +1782,15 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Segnala un problema di esportazione"
 
-#, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
-msgstr "Torna Indietro nel Tempo"
+msgstr "Riavvolgi"
 
 #, fuzzy
 msgctxt "debugControls.takeSnapshot"
 msgid "Take a Snapshot"
 msgstr "Cattura Istantanea"
 
-#, fuzzy
 msgctxt "debugControls.goForwardInTime"
 msgid "Go Forward in Time"
 msgstr "Vai Avanti nel Tempo"
@@ -2282,7 +2269,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -60,6 +60,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "デバッグパネル"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -1975,6 +2003,14 @@ msgstr "変数"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "値"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -199,9 +199,10 @@ msgid "Fast Speed (4 MHz)"
 msgstr "高速 (4 MHz)"
 
 #, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "ばかげた/ワープ速度"
+msgid "Ludicrous Speed"
+msgstr "ばかげた速度"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2231,7 +2232,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -199,9 +199,10 @@ msgid "Fast Speed (4 MHz)"
 msgstr "빠른 속도 (4 MHz)"
 
 #, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "터무니없는/워프 속도"
+msgid "Ludicrous Speed"
+msgstr "터무니없는 속도"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2240,7 +2241,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -60,6 +60,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "디버그 패널"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -1984,6 +2012,14 @@ msgstr "변수"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "값"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -49,6 +49,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr ""
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr ""
@@ -1699,6 +1727,14 @@ msgstr ""
 
 msgctxt "basic.value"
 msgid "Value"
+msgstr ""
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
 msgstr ""
 
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -170,7 +170,7 @@ msgid "Fast Speed (4 MHz)"
 msgstr ""
 
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
 msgstr ""
 
 msgctxt "colors.color"
@@ -1946,7 +1946,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -59,6 +59,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr ""
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2009,6 +2037,14 @@ msgstr "Variabele"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Waarde"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -198,9 +198,10 @@ msgid "Fast Speed (4 MHz)"
 msgstr "Snel (4 MHz)"
 
 #, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Belachelijk/Warp Snelheid"
+msgid "Ludicrous Speed"
+msgstr "Belachelijke snelheid"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2265,7 +2266,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -60,6 +60,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "Painel de Debug"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2015,6 +2043,14 @@ msgstr "Variável"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Valor"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -199,9 +199,10 @@ msgid "Fast Speed (4 MHz)"
 msgstr "Rápida (4 MHz)"
 
 #, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Velocidade Ridícula/Warp"
+msgid "Ludicrous Speed"
+msgstr "Velocidade ridícula"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2271,7 +2272,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -6,17 +6,14 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#, fuzzy
 msgctxt "controls.boot"
 msgid "Boot"
 msgstr "Загрузка"
 
-#, fuzzy
 msgctxt "controls.reset"
 msgid "Reset"
 msgstr "Сброс"
 
-#, fuzzy
 msgctxt "controls.copyScreen"
 msgid "Copy Screen"
 msgstr "Скопировать экран"
@@ -26,17 +23,14 @@ msgctxt "controls.copyText"
 msgid "Copy Text"
 msgstr "Копировать текст"
 
-#, fuzzy
 msgctxt "controls.pasteText"
 msgid "Paste Text"
 msgstr "Вставить текст"
 
-#, fuzzy
 msgctxt "controls.saveState"
 msgid "Save State"
 msgstr "Сохранить состояние"
 
-#, fuzzy
 msgctxt "controls.restoreState"
 msgid "Restore State"
 msgstr "Восстановить состояние"
@@ -170,7 +164,6 @@ msgctxt "machine.ram.8mb"
 msgid "8 MB"
 msgstr ""
 
-#, fuzzy
 msgctxt "speed.snail"
 msgid "Snail Speed (0.1 MHz)"
 msgstr "Скорость улитки (0.1 МГц)"
@@ -180,30 +173,25 @@ msgctxt "speed.slow"
 msgid "Slow Speed (0.5 MHz)"
 msgstr "Медленная (0.5 МГц)"
 
-#, fuzzy
 msgctxt "speed.normal"
 msgid "Normal Speed (1 MHz)"
 msgstr "Нормальная (1 МГц)"
 
-#, fuzzy
 msgctxt "speed.two"
 msgid "2 MHz"
 msgstr "2 МГц"
 
-#, fuzzy
 msgctxt "speed.three"
 msgid "3 MHz"
 msgstr "3 МГц"
 
-#, fuzzy
 msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Быстрая (4 МГц)"
 
-#, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Безумная/Варп скорость"
+msgid "Ludicrous Speed"
+msgstr "Безумная скорость"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -1272,7 +1260,6 @@ msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
 msgstr ""
 
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Горячие клавиши"
@@ -1796,7 +1783,6 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Сообщить о проблеме экспорта"
 
-#, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
 msgstr "Вернуться во времени"
@@ -1806,7 +1792,6 @@ msgctxt "debugControls.takeSnapshot"
 msgid "Take a Snapshot"
 msgstr "Сделать снимок"
 
-#, fuzzy
 msgctxt "debugControls.goForwardInTime"
 msgid "Go Forward in Time"
 msgstr "Вперёд во времени"
@@ -2285,7 +2270,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -54,6 +54,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "Панель отладки"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2013,6 +2041,14 @@ msgstr "Переменная"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Значение"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -59,6 +59,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr ""
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -2020,6 +2048,14 @@ msgstr "Variabel"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "Värde"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -198,9 +198,10 @@ msgid "Fast Speed (4 MHz)"
 msgstr "Snabb (4 MHz)"
 
 #, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Löjlig/Warp Hastighet"
+msgid "Ludicrous Speed"
+msgstr "Löjlig hastighet"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2276,7 +2277,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -66,6 +66,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "调试面板"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "报告问题"
@@ -1965,6 +1993,14 @@ msgstr "变量"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "值"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -200,9 +200,10 @@ msgid "Fast Speed (4 MHz)"
 msgstr "快速 (4 MHz)"
 
 #, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "极速/曲速"
+msgid "Ludicrous Speed"
+msgstr "极速"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2268,9 +2269,10 @@ msgid "4 MHz"
 msgstr ""
 
 #, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr "极速/曲速"
+msgid "Ludicrous"
+msgstr "极速"
 
 #, fuzzy
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -60,6 +60,34 @@ msgctxt "controls.debugPanel"
 msgid "Debug Panel"
 msgstr "除錯面板"
 
+msgctxt "controls.hideSidePanel"
+msgid "Hide side panel"
+msgstr ""
+
+msgctxt "controls.showSidePanel"
+msgid "Show side panel"
+msgstr ""
+
+msgctxt "controls.widenSidePanel"
+msgid "Widen side panel"
+msgstr ""
+
+msgctxt "controls.restoreSidePanelWidth"
+msgid "Restore side panel width"
+msgstr ""
+
+msgctxt "controls.sidePanelWidthAvailableBeside"
+msgid "Width control is available beside the emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBelow"
+msgid "Move side panel below emulator"
+msgstr ""
+
+msgctxt "controls.moveSidePanelBeside"
+msgid "Move side panel beside emulator"
+msgstr ""
+
 #, fuzzy
 msgctxt "controls.reportIssue"
 msgid "Report an Issue"
@@ -1973,6 +2001,14 @@ msgstr "變數"
 msgctxt "basic.value"
 msgid "Value"
 msgstr "值"
+
+msgctxt "basic.showVariables"
+msgid "Show variables"
+msgstr ""
+
+msgctxt "basic.hideVariables"
+msgid "Hide variables"
+msgstr ""
 
 #, fuzzy
 msgctxt "expectin.runScript"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -201,9 +201,10 @@ msgid "Fast Speed (4 MHz)"
 msgstr "快速 (4 MHz)"
 
 #, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "極速/曲速"
+msgid "Ludicrous Speed"
+msgstr "極速"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2276,9 +2277,10 @@ msgid "4 MHz"
 msgstr ""
 
 #, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr "極速/曲速"
+msgid "Ludicrous"
+msgstr "極速"
 
 #, fuzzy
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -417,6 +417,58 @@ body.dark-mode .desktop-panel-width-toggle {
   width: max-content;
 }
 
+.mobile-controls {
+  align-items: flex-start;
+  display: flex;
+  width: 100%;
+}
+
+.mobile-portrait-stack {
+  width: 100%;
+}
+
+.mobile-landscape-sidebar {
+  flex: 0 1 320px;
+  min-width: 0;
+}
+
+.mobile-control-panel {
+  flex: 1 1 390px;
+  min-width: 0;
+}
+
+.mobile-status {
+  margin-left: 0;
+  margin-right: auto;
+  margin-top: 4px;
+  text-align: left;
+}
+
+.mobile-status .footer-item {
+  margin-left: 2px;
+  margin-right: auto;
+  width: max-content;
+}
+
+.divider.mobile-divider {
+  margin-bottom: 3px;
+  margin-top: 0;
+}
+
+#debug-section.debug-section-horizontal {
+  box-sizing: border-box;
+  max-width: 100vw;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+#debug-section.debug-section-horizontal > .debug-section {
+  box-sizing: border-box;
+  margin-right: 0;
+  max-width: 100%;
+  min-width: 0;
+}
+
 .control-panel-two-rows .push-button,
 .control-panel-two-rows .joystick-button {
   zoom: var(--desktop-control-scale);

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -1,5 +1,14 @@
 html {
   overflow-x: hidden;
+  scrollbar-gutter: stable;
+}
+
+html.desktop-layout {
+  overflow-x: auto;
+}
+
+html.desktop-layout body.no-scroll {
+  overflow: visible;
 }
 
 :root {
@@ -117,6 +126,481 @@ input:focus {
 
 .flexwrap {
   flex-wrap: wrap;
+}
+
+.desktop-emulator-layout {
+  display: grid;
+  align-items: start;
+  grid-template-columns: auto auto;
+  width: max-content;
+}
+
+.desktop-emulator-layout.desktop-panel-layout-below {
+  grid-template-columns: auto;
+}
+
+.desktop-primary-column,
+.desktop-tab-column {
+  min-width: 0;
+}
+
+.desktop-primary-column {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+}
+
+.desktop-emulator-layout:not(.desktop-panel-layout-below) .desktop-primary-column {
+  position: relative;
+  z-index: 1;
+}
+
+.desktop-emulator-layout:not(.desktop-panel-layout-below) .desktop-primary-sticky {
+  position: sticky;
+  top: 10px;
+}
+
+.desktop-panel-shell:has(.modal-overlay) {
+  z-index: 3;
+}
+
+.desktop-emulator-layout .desktop-primary-column:has(.modal-overlay) {
+  z-index: 4;
+}
+
+.desktop-primary-sticky {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.desktop-device-strip {
+  display: flex;
+  width: 100%;
+}
+
+.desktop-status-strip {
+  align-items: center;
+  background-color: var(--panel-background);
+  border: 1px solid var(--text-color);
+  box-sizing: border-box;
+  display: flex;
+  flex: 0 0 auto;
+  font-size: 0.72em;
+  justify-content: center;
+  line-height: 1.1;
+  overflow: hidden;
+  padding: 2px 6px;
+  text-align: center;
+  width: max-content;
+}
+
+body.dark-mode .desktop-status-strip {
+  background-color: var(--panel-background-dark);
+  border-color: var(--text-color-dark);
+}
+
+.desktop-status-strip .footer-item {
+  margin: 0;
+  position: static;
+  white-space: normal;
+  width: auto;
+}
+
+.desktop-status-strip .footer-item > div {
+  white-space: nowrap;
+}
+
+.desktop-tab-column {
+  box-sizing: border-box;
+}
+
+.desktop-panel-shell {
+  --desktop-horizontal-tab-height: 0px;
+  position: relative;
+}
+
+.desktop-panel-shell.desktop-panel-below {
+  --desktop-horizontal-tab-height: 34px;
+}
+
+.desktop-panel-controls {
+  height: 0;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 34px;
+  z-index: 2;
+}
+
+.desktop-panel-below .desktop-panel-controls {
+  position: absolute;
+  top: 0;
+  width: 108px;
+}
+
+.desktop-panel-below .desktop-panel-toggle {
+  border-radius: 10px 10px 0 0;
+  height: var(--desktop-horizontal-tab-height);
+}
+
+.desktop-panel-shell.desktop-panel-wide {
+  overflow-x: clip;
+}
+
+.desktop-panel-toggle {
+  align-items: center;
+  background-color: var(--background-color);
+  border: 1px solid black;
+  border-radius: 10px 0 0 10px;
+  color: var(--text-color);
+  cursor: pointer;
+  display: flex;
+  height: 28px;
+  justify-content: center;
+  left: 0;
+  padding: 0;
+  position: absolute;
+  top: 0;
+  width: 34px;
+  z-index: 1;
+}
+
+.desktop-panel-width-toggle {
+  font-family: monospace;
+  font-size: 15px;
+  font-weight: 700;
+  top: 60px;
+}
+
+.desktop-panel-orientation-toggle {
+  font-size: 26px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.desktop-panel-orientation-glyph {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  line-height: 1;
+  transform: translateY(1px) scaleY(-1);
+  width: 100%;
+}
+
+.desktop-panel-below .desktop-panel-orientation-glyph {
+  transform: translateY(-1px) scaleX(-1);
+}
+
+.desktop-panel-shell:not(.desktop-panel-below) .desktop-panel-collapse-toggle {
+  top: 30px;
+}
+
+.desktop-panel-below .desktop-panel-orientation-toggle {
+  left: 0;
+  top: 0;
+}
+
+.desktop-panel-below .desktop-panel-collapse-toggle {
+  left: 36px;
+}
+
+.desktop-panel-below .desktop-panel-width-toggle {
+  left: 72px;
+  top: 0;
+}
+
+body.dark-mode .desktop-panel-toggle {
+  background-color: var(--background-color-dark);
+  border-color: var(--text-color-dark);
+  color: var(--text-color-dark);
+}
+
+.desktop-panel-orientation-toggle,
+body.dark-mode .desktop-panel-orientation-toggle {
+  background-color: #ff5f57;
+  color: #222;
+}
+
+.desktop-panel-collapse-toggle,
+body.dark-mode .desktop-panel-collapse-toggle {
+  background-color: #febc2e;
+  color: #222;
+}
+
+.desktop-panel-width-toggle,
+body.dark-mode .desktop-panel-width-toggle {
+  background-color: #28c840;
+  color: #222;
+}
+
+.desktop-panel-orientation-toggle:hover,
+.desktop-panel-orientation-toggle:focus-visible,
+.desktop-panel-collapse-toggle:hover,
+.desktop-panel-collapse-toggle:focus-visible,
+.desktop-panel-width-toggle:hover,
+.desktop-panel-width-toggle:focus-visible {
+  filter: brightness(0.88);
+}
+
+.desktop-panel-toggle:disabled {
+  cursor: default;
+  filter: none;
+  opacity: 0.55;
+}
+
+.desktop-panel-body {
+  height: 100%;
+  overflow: visible;
+  width: 100%;
+}
+
+.desktop-panel-shell:not(.desktop-panel-collapsed) .dbg-tab-row {
+  padding-top: 90px;
+}
+
+.desktop-emulator-layout:not(.desktop-panel-layout-below) .desktop-panel-shell .dbg-tab-row {
+  align-self: flex-start;
+  position: relative;
+  z-index: 1;
+}
+
+/* Ordinary bounded panels stay with the monitor even if the document has a
+   small amount of unrelated overflow. Debugger output and BASIC variables
+   intentionally remain in document flow. */
+.desktop-emulator-layout:not(.desktop-panel-layout-below) .desktop-panel-shell.desktop-panel-collapsed,
+.desktop-emulator-layout:not(.desktop-panel-layout-below) .desktop-panel-shell:not(.desktop-panel-collapsed):not(:has(.desktop-panel-content-debug)):not(:has(.desktop-basic-variables-visible)) {
+  align-self: start;
+  position: sticky;
+  top: 10px;
+}
+
+.desktop-panel-shell.desktop-panel-below:not(.desktop-panel-collapsed) .dbg-tab-row {
+  padding-left: 108px;
+  padding-top: 0;
+}
+
+.desktop-panel-body > .flyout,
+.desktop-tab-column #debug-section {
+  box-sizing: border-box;
+  min-height: 100%;
+  width: 100%;
+}
+
+.desktop-panel-body > .flyout {
+  height: 100%;
+}
+
+.desktop-tab-column #debug-section {
+  height: 100%;
+  min-width: 0;
+  overflow: visible;
+}
+
+.desktop-tab-column .help-parent {
+  box-sizing: border-box;
+  height: 100%;
+  margin-right: 0;
+  max-width: none;
+}
+
+.desktop-tab-column .help-paper {
+  min-height: 100%;
+}
+
+.desktop-control-strip {
+  width: 100%;
+}
+
+.desktop-control-fit-content {
+  width: max-content;
+}
+
+.control-panel-two-rows .push-button,
+.control-panel-two-rows .joystick-button {
+  zoom: var(--desktop-control-scale);
+}
+
+.control-panel-two-rows .modal-overlay .push-button,
+.control-panel-two-rows .modal-overlay .joystick-button,
+.control-panel-two-rows .floating-dialog .push-button,
+.control-panel-two-rows .floating-dialog .joystick-button {
+  zoom: 1;
+}
+
+.desktop-controls-and-status {
+  align-items: flex-start;
+  display: flex;
+  width: 100%;
+}
+
+.desktop-controls-and-status .desktop-control-strip {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.desktop-controls-and-status .desktop-status-strip {
+  align-self: flex-start;
+  flex: 0 0 auto;
+}
+
+.desktop-disk-strip {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.desktop-disk-strip .desktop-control-fit-content {
+  zoom: var(--desktop-control-scale);
+}
+
+.desktop-disk-strip .modal-overlay,
+.desktop-disk-strip .floating-dialog:not(.modal-overlay .floating-dialog) {
+  zoom: var(--desktop-control-inverse-scale);
+}
+
+.control-panel-two-rows,
+.control-panel-row,
+.disk-interface-single-row {
+  display: flex;
+  width: max-content;
+}
+
+.control-panel-two-rows {
+  flex-direction: column;
+}
+
+.control-panel-row,
+.disk-interface-single-row {
+  flex-direction: row;
+  flex-wrap: nowrap;
+}
+
+.control-panel-row {
+  align-items: flex-start;
+}
+
+.disk-interface-single-row > span {
+  display: flex;
+  flex-direction: row;
+}
+
+.desktop-panel-content {
+  box-sizing: border-box;
+  flex: 1;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+}
+
+.desktop-panel-shell:not(.desktop-panel-wide) .desktop-panel-content {
+  margin-right: 2px;
+  max-width: calc(100% - 2px);
+}
+
+.desktop-panel-shell:has(.desktop-panel-content-debug) .desktop-panel-body,
+.desktop-panel-shell:has(.desktop-panel-content-debug) .desktop-panel-body > .flyout,
+.desktop-panel-shell:has(.desktop-panel-content-debug) #debug-section {
+  height: auto;
+  overflow: visible;
+}
+
+.desktop-panel-shell:has(.desktop-panel-content-debug) .desktop-panel-content {
+  height: auto;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.desktop-panel-shell:not(.desktop-panel-collapsed):has(.desktop-panel-content-debug),
+.desktop-panel-shell:not(.desktop-panel-collapsed):has(.desktop-basic-variables-visible) {
+  height: auto !important;
+  min-height: var(--desktop-panel-height);
+}
+
+.desktop-panel-content > .debug-section {
+  box-sizing: border-box;
+  margin-right: 0;
+}
+
+.desktop-panel-content > .desktop-code-workspace {
+  height: calc(100% - 24px);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.desktop-basic-primary > .basic-editor,
+.desktop-code-workspace > .expectin-editor {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 180px;
+  width: 100%;
+}
+
+.desktop-panel-wide .desktop-panel-content > .desktop-code-workspace {
+  height: calc(var(--desktop-bounded-panel-height) - 24px);
+}
+
+.desktop-panel-content > .agent-container {
+  box-sizing: border-box;
+  height: calc(100% - 24px);
+}
+
+.desktop-panel-wide .desktop-panel-content > .agent-container {
+  height: calc(var(--desktop-bounded-panel-height) - 24px);
+}
+
+.desktop-basic-primary {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 7px;
+  height: 100%;
+  min-height: 0;
+}
+
+.desktop-panel-content .desktop-basic-primary {
+  height: calc(var(--desktop-bounded-panel-height) - 24px - var(--desktop-horizontal-tab-height));
+}
+
+.desktop-panel-content > .desktop-basic-variables-visible {
+  height: auto;
+  overflow: visible;
+}
+
+.desktop-panel-shell:has(.desktop-basic-variables-visible) .desktop-panel-body,
+.desktop-panel-shell:has(.desktop-basic-variables-visible) .desktop-panel-body > .flyout,
+.desktop-panel-shell:has(.desktop-basic-variables-visible) #debug-section,
+.desktop-panel-shell:has(.desktop-basic-variables-visible) .desktop-panel-content {
+  height: auto;
+  overflow: visible;
+}
+
+.desktop-code-controls {
+  flex: 0 0 auto;
+}
+
+.desktop-panel-content .desktop-code-controls,
+.desktop-panel-content .agent-controls {
+  box-sizing: border-box;
+  padding-right: 60px;
+  width: 100%;
+}
+
+.basic-debug-view {
+  flex: 0 0 auto;
+}
+
+.basic-debug-view > .basic-variables-pane {
+  max-height: none;
+  overflow: visible;
+}
+
+.vera-panel {
+  display: flex;
+  height: 100%;
+  width: 100%;
 }
 
 .push-button {
@@ -251,7 +735,7 @@ body.dark-mode .button-locked {
   border-radius: 50%;
   box-shadow: 0px 6px 0px rgba(81, 2, 2, 0.8);
   transform: translateY(-2px);
-  transition: all 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out, transform 0.1s ease-in-out;
 }
 
 .joystick-active {

--- a/src/ui/App.minimal.css
+++ b/src/ui/App.minimal.css
@@ -31,6 +31,12 @@ body {
   user-select: none;
 }
 
+.desktop-status-strip .footer-item {
+  bottom: auto;
+  position: static;
+  width: auto;
+}
+
 #reportIssue {
   display: none;
 }

--- a/src/ui/canvas.css
+++ b/src/ui/canvas.css
@@ -23,17 +23,22 @@
 }
 
 .hgr-view {
-  position: absolute;
+  align-items: flex-start;
+  position: fixed;
   user-select: none;
   pointer-events: none;
+  width: max-content;
+  z-index: 2;
 }
 
 .hgr-view-box {
   border: 2px solid red;
+  box-sizing: border-box;
+  flex: none;
 }
 
 .hgr-view-text {
-  z-index: 9999;
+  flex: none;
   background-color: var(--input-background);
   color: var(--text-color);
   user-select: none;
@@ -46,6 +51,12 @@
   padding-top: 2px;
   border-radius: 10px;
   margin-left: 15px;
+}
+
+#hgr-info-canvas {
+  border: 2px solid red;
+  box-sizing: border-box;
+  flex: none;
 }
 
 body.dark-mode .hgr-view-text {

--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -54,6 +54,7 @@ const Apple2Canvas = (props: DisplayProps) => {
 
   const myCanvas = useRef<HTMLCanvasElement>(null)
   const hiddenCanvas = useRef<HTMLCanvasElement>(null)
+  const canvasBounds = useRef(props.canvasBounds)
   const hardwareKeyboardKey = useRef<{ code: string, key: number } | null>(null)
 
   const pasteHandler = (e: ClipboardEvent) => {
@@ -437,7 +438,11 @@ const Apple2Canvas = (props: DisplayProps) => {
     }
   }
 
-  const [width, height] = getCanvasSize()
+  useEffect(() => {
+    canvasBounds.current = props.canvasBounds
+  }, [props.canvasBounds])
+
+  const [width, height] = getCanvasSize(props.canvasBounds)
 
   const RenderCanvas = (timestamp: number) => {
     const elapsed = timestamp - lastFrameTimeRef.current
@@ -454,7 +459,7 @@ const Apple2Canvas = (props: DisplayProps) => {
         const ctx = (mainCanvas as HTMLCanvasElement).getContext("2d")
         const hiddenCtx = (hiddenCanvas.current as HTMLCanvasElement).getContext("2d")
         if (ctx && hiddenCtx) {
-          const [w, h] = getCanvasSize()   // always current
+          const [w, h] = getCanvasSize(canvasBounds.current)   // always current
           ProcessDisplay(ctx, hiddenCtx, w, h)
         }
         checkGamepad()
@@ -604,7 +609,7 @@ const Apple2Canvas = (props: DisplayProps) => {
 
   const setFocus = () => {
     if (mainCanvas) {
-      (mainCanvas as HTMLCanvasElement).focus()
+      (mainCanvas as HTMLCanvasElement).focus({ preventScroll: true })
     }
   }
 
@@ -636,6 +641,11 @@ const Apple2Canvas = (props: DisplayProps) => {
         id="apple2canvas"
         className="main-canvas"
         style={{
+          ...(props.canvasBounds ? {
+            boxSizing: "border-box",
+            height,
+            width,
+          } : {}),
           cursor: cursor,
           borderColor: (machine === "APPLE2P" || getTheme() === UI_THEME.DARK) ? "black" : "#583927",
           borderRadius: noBackgroundImage ? "0" : "18px",

--- a/src/ui/controls/controlpanel.tsx
+++ b/src/ui/controls/controlpanel.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "../../i18n/useTranslation"
 import { useState } from "react"
 import { isGameMode } from "../ui_settings"
 
-const ControlPanel = (props: DisplayProps) => {
+const ControlPanel = (props: DisplayProps & { singleRow?: boolean }) => {
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
   const { t } = useTranslation()
 
@@ -24,6 +24,18 @@ const ControlPanel = (props: DisplayProps) => {
       isOpen={() => { return isFlyoutOpen }}
       onClick={handleFlyoutClick}
       position="top-left">
+      {props.singleRow ?
+        <div className="control-panel-two-rows">
+          <div className="control-panel-row">
+            <ControlButtons {...props} />
+            <DebugButtons {...props} />
+            <FullScreenButton />
+          </div>
+          <div className="control-panel-row">
+            <ConfigButtons {...props} />
+            <KeyboardButtons {...props} />
+          </div>
+        </div> :
       <span className="flex-column">
         <span className={isGameMode() ? "flex-row flexwrap" : ""}>
           <span className={isGameMode() ? "flex-row" : "flex-row flexwrap"} id="tour-controlbuttons">
@@ -34,7 +46,7 @@ const ControlPanel = (props: DisplayProps) => {
           <ConfigButtons {...props} />
           <KeyboardButtons {...props} />
         </span>
-      </span>
+      </span>}
     </Flyout>
   )
 }

--- a/src/ui/controls/fitcontrolrow.test.tsx
+++ b/src/ui/controls/fitcontrolrow.test.tsx
@@ -1,0 +1,89 @@
+import { act, useState } from "react"
+import { createRoot, Root } from "react-dom/client"
+import FitControlRow, { getControlRowScale } from "./fitcontrolrow"
+
+let resizeObserverCallback: ResizeObserverCallback
+
+class TestResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback
+  }
+  observe() {}
+  disconnect() {}
+}
+
+const DialogHarness = () => {
+  const [open, setOpen] = useState(false)
+  return <>
+    <button onClick={() => setOpen(true)}>open</button>
+    {open && <div className="modal-overlay">
+      dialog
+      <button onClick={() => setOpen(false)}>close</button>
+    </div>}
+  </>
+}
+
+const reactEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean,
+}
+
+describe("getControlRowScale", () => {
+  it("preserves controls that already fit", () => {
+    expect(getControlRowScale(600, 500)).toBe(1)
+  })
+
+  it("scales controls to the available width", () => {
+    expect(getControlRowScale(600, 800)).toBe(0.75)
+  })
+
+  it("can cap controls below their natural size", () => {
+    expect(getControlRowScale(600, 500, 0.8)).toBe(0.8)
+  })
+})
+
+describe("FitControlRow", () => {
+  let container: HTMLDivElement
+  let originalResizeObserver: typeof ResizeObserver
+  let previousActEnvironment: boolean | undefined
+  let root: Root
+
+  beforeEach(() => {
+    previousActEnvironment = reactEnvironment.IS_REACT_ACT_ENVIRONMENT
+    reactEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    originalResizeObserver = global.ResizeObserver
+    global.ResizeObserver = TestResizeObserver as unknown as typeof ResizeObserver
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    global.ResizeObserver = originalResizeObserver
+    reactEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
+  })
+
+  it("keeps button scaling stable while a viewport dialog is open", async () => {
+    act(() => root.render(<FitControlRow minHeight={38}><DialogHarness /></FitControlRow>))
+
+    const fitContainer = container.querySelector<HTMLElement>(".desktop-control-strip")
+    const fitted = container.querySelector<HTMLElement>(".desktop-control-fit-content")
+    if (!fitContainer || !fitted) throw new Error("Control fit elements were not rendered")
+    Object.defineProperty(fitContainer, "clientWidth", { configurable: true, value: 400 })
+    fitted.getBoundingClientRect = () => ({ width: 800 } as DOMRect)
+    act(() => resizeObserverCallback([], {} as ResizeObserver))
+    expect(fitted.style.getPropertyValue("--desktop-control-scale")).toBe("0.5")
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")?.click()
+      await Promise.resolve()
+    })
+    expect(fitted.style.getPropertyValue("--desktop-control-scale")).toBe("0.5")
+
+    await act(async () => {
+      container.querySelectorAll<HTMLButtonElement>("button")[1]?.click()
+      await Promise.resolve()
+    })
+    expect(fitted.style.getPropertyValue("--desktop-control-scale")).toBe("0.5")
+  })
+})

--- a/src/ui/controls/fitcontrolrow.tsx
+++ b/src/ui/controls/fitcontrolrow.tsx
@@ -1,0 +1,62 @@
+import { CSSProperties, ReactNode, useLayoutEffect, useRef, useState } from "react"
+
+export const getControlRowScale = (
+  availableWidth: number,
+  contentWidth: number,
+  maxScale = 1,
+) => (
+  contentWidth > 0 ? Math.max(0, Math.min(maxScale, availableWidth / contentWidth)) : maxScale
+)
+
+const FitControlRow = ({
+  children,
+  maxScale = 1,
+  minHeight,
+}: {
+  children: ReactNode,
+  maxScale?: number,
+  minHeight: number,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const scaleRef = useRef(1)
+  const [scale, setScale] = useState(1)
+
+  useLayoutEffect(() => {
+    const measure = () => {
+      const container = containerRef.current
+      const content = contentRef.current
+      if (!container || !content) return
+      const renderedWidth = content.getBoundingClientRect().width
+      const naturalWidth = scaleRef.current > 0
+        ? renderedWidth / scaleRef.current
+        : renderedWidth
+      const nextScale = getControlRowScale(container.clientWidth, naturalWidth, maxScale)
+      scaleRef.current = nextScale
+      setScale(nextScale)
+    }
+
+    measure()
+    const resizeObserver = new ResizeObserver(measure)
+    if (containerRef.current) resizeObserver.observe(containerRef.current)
+    if (contentRef.current) resizeObserver.observe(contentRef.current)
+    window.addEventListener("resize", measure)
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener("resize", measure)
+    }
+  }, [maxScale])
+
+  return <div ref={containerRef} className="desktop-control-strip" style={{
+    minHeight,
+  }}>
+    <div ref={contentRef} className="desktop-control-fit-content" style={{
+      "--desktop-control-scale": scale,
+      "--desktop-control-inverse-scale": scale > 0 ? 1 / scale : 1,
+    } as CSSProperties}>
+      {children}
+    </div>
+  </div>
+}
+
+export default FitControlRow

--- a/src/ui/controls/keyboardcontrol.css
+++ b/src/ui/controls/keyboardcontrol.css
@@ -11,7 +11,7 @@
   border: 2px solid #675b47;
   font-size: 24px;
   cursor: pointer;
-  z-index: 9998;
+  z-index: 9991;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   display: flex;
   align-items: center;

--- a/src/ui/controls/popupmenu.tsx
+++ b/src/ui/controls/popupmenu.tsx
@@ -14,7 +14,6 @@ type PopupMenuProps = {
 
 const PopupMenu = (props: PopupMenuProps) => {
 
-  const isTouchDevice = "ontouchstart" in document.documentElement
   const menuRef = useRef<HTMLDivElement>(null)
   const [posStyle, setPosStyle] = useState<{ left: number, top: number } | undefined>(undefined)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
@@ -126,13 +125,16 @@ const PopupMenu = (props: PopupMenuProps) => {
               }
               props.onClose()
             }}>
-            <span>
-              {menuItem.isSelected != undefined && menuItem.isSelected()
-                ? "\u2714\u2009"
-                : `${isTouchDevice ? "\u2003" : "\u2004"}\u2007`}
-              {menuItem.icon && <FontAwesomeIcon icon={menuItem.icon} style={{ width: "24px" }} />}
-              {menuItem.svg && menuItem.svg}
-              {`${menuItem.label}\u2004`}
+            <span className="popup-item-main">
+              <span
+                className="popup-selection-marker">
+                {menuItem.isSelected?.() ? "\u2714" : ""}
+              </span>
+              <span className="popup-item-label">
+                {menuItem.icon && <FontAwesomeIcon icon={menuItem.icon} style={{ width: "24px" }} />}
+                {menuItem.svg && menuItem.svg}
+                {`${menuItem.label}\u2004`}
+              </span>
             </span>
             {menuItem.subMenu && menuItem.subMenu.length > 0 && (
               <FontAwesomeIcon icon={faCaretRight} style={{ marginLeft: "12px", opacity: 0.7 }} />

--- a/src/ui/devices/disk/diskinterface.tsx
+++ b/src/ui/devices/disk/diskinterface.tsx
@@ -9,7 +9,7 @@ import { isMinimalTheme } from "../../ui_settings"
 import { useTranslation } from "../../../i18n/useTranslation"
 import { handleGetSlotConfig } from "../../main2worker"
 
-const DiskInterface = (props: DisplayProps) => {
+const DiskInterface = (props: DisplayProps & { singleRow?: boolean }) => {
   const { t } = useTranslation()
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
   const height = window.innerHeight ? window.innerHeight : (window.outerHeight - 120)
@@ -27,7 +27,9 @@ const DiskInterface = (props: DisplayProps) => {
         isOpen={() => { return isFlyoutOpen && !allSlotsDisabled }}
         onClick={() => { if (!allSlotsDisabled) setIsFlyoutOpen(!isFlyoutOpen) }}
         position="bottom-left">
-      <div className={`${isMinimalTheme() && isScreenNarrow ? "flex-column" : "flex-row"} flexwrap`}>
+      <div className={props.singleRow
+        ? "disk-interface-single-row"
+        : `${isMinimalTheme() && isScreenNarrow ? "flex-column" : "flex-row"} flexwrap`}>
         <span className="flex-row">
           {!isMinimalTheme() && <DiskImageChooser {...props} />}
           <DiskDrive key={0} index={0} renderCount={props.renderCount}

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -31,12 +31,17 @@ import { useTranslation } from "../i18n/useTranslation"
 import { desktopLayoutPolicy, getDesktopLayout } from "./layout"
 import FitControlRow from "./controls/fitcontrolrow"
 import DesktopPanel from "./panels/desktoppanel"
+import { subscribeViewportResize } from "./viewport"
 
 // The classic emulator and Help panel need about this much room side by side.
 const specialLayoutNarrowWidth = 1000
 
 const getViewport = () => ({
-  height: window.innerHeight || window.outerHeight - 120,
+  height: Math.max(
+    document.documentElement.clientHeight,
+    window.innerHeight,
+    window.visualViewport?.height ?? 0,
+  ) || window.outerHeight - 120,
   width: document.documentElement.clientWidth || window.innerWidth || window.outerWidth - 20,
 })
 
@@ -58,8 +63,7 @@ const DisplayApple2 = () => {
 
   useEffect(() => {
     const handleResize = () => setViewport(getViewport())
-    window.addEventListener("resize", handleResize)
-    return () => window.removeEventListener("resize", handleResize)
+    return subscribeViewportResize(handleResize)
   }, [])
 
   // We need to create our worker here so it has access to our properties
@@ -293,16 +297,30 @@ const DisplayApple2 = () => {
     <div className={narrow ? "flex-column-gap" : "flex-row-gap"} style={{ alignItems: "inherit" }}>
     <div className={isLandscape ? "flex-row" : "flex-column"}>
     <Apple2Canvas {...props} />
-    <div className={"flex-row-gap" + " flexwrap"}  style={{ paddingLeft: "2px" }}>
-      <ControlPanel {...props} />
-      {!isGameMode() && <DiskInterface {...props} />}
+    {isTouchDevice ? <div className={isLandscape ? "mobile-landscape-sidebar" : "mobile-portrait-stack"}>
+      <div className="mobile-controls">
+        <div className="mobile-control-panel">
+          <FitControlRow minHeight={desktopLayoutPolicy.controlStripHeight}>
+            <ControlPanel {...props} singleRow />
+          </FitControlRow>
+        </div>
+      </div>
+      {!isGameMode() && <div className="mobile-device-row flex-row-gap flexwrap" style={{ paddingLeft: "2px" }}>
+        <DiskInterface {...props} />
+      </div>}
+    </div> : <>
+      <div className="flex-row-gap flexwrap" style={{ paddingLeft: "2px" }}>
+        <ControlPanel {...props} />
+        {!isGameMode() && <DiskInterface {...props} />}
+      </div>
+      {!isLandscape && !isGameMode() && status}
+    </>}
     </div>
-    {!isLandscape && !isGameMode() && status}
-    </div>
-    {isLandscape && !isGameMode() && status}
-    {narrow && !isMinimalTheme() && !isGameMode() && <div className="divider"></div>}
+    {!isTouchDevice && isLandscape && !isGameMode() && status}
+    {narrow && !isMinimalTheme() && !isGameMode() && <div className={`divider${isTouchDevice ? " mobile-divider" : ""}`}></div>}
     {!isGameMode() && <DebugSection updateDisplay={updateDisplay} narrow={narrow}/>}
     </div>
+    {isTouchDevice && !isGameMode() && <div className="mobile-status">{status}</div>}
     {isMinimalTheme() && <DiskCollectionPanel {...props} />}
     {isMinimalTheme() && isTouchDevice && <TouchJoystick />}
     <FileInput {...props} />

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -29,6 +29,9 @@ import { CRTStartup } from "./graphics"
 import { startRemoteControlBridge } from "./api/remotecontrol"
 import { useTranslation } from "../i18n/useTranslation"
 
+// The classic emulator and Help panel need about this much room side by side.
+const wideLayoutMinWidth = 1000
+
 const DisplayApple2 = () => {
   const { t } = useTranslation()
   const [myInit, setMyInit] = useState(false)
@@ -40,6 +43,19 @@ const DisplayApple2 = () => {
   const [closedAppleKeyMode, setClosedAppleKeyMode] = useState(0)
   const [showFileOpenDialog, setShowFileOpenDialog] = useState({ show: false, index: 0 })
   const [worker, setWorker] = useState<Worker | null>(null)
+  const [viewport, setViewport] = useState(() => ({
+    height: window.innerHeight || window.outerHeight - 120,
+    width: window.innerWidth || window.outerWidth - 20,
+  }))
+
+  useEffect(() => {
+    const handleResize = () => setViewport({
+      height: window.innerHeight || window.outerHeight - 120,
+      width: window.innerWidth || window.outerWidth - 20,
+    })
+    window.addEventListener("resize", handleResize)
+    return () => window.removeEventListener("resize", handleResize)
+  }, [])
 
   // We need to create our worker here so it has access to our properties
   // such as cpu speed and help text. Otherwise, if the emulator changed
@@ -169,9 +185,8 @@ const DisplayApple2 = () => {
   handleSetTheme(theme)
 
   const isTouchDevice = "ontouchstart" in document.documentElement
-  const height = window.innerHeight ? window.innerHeight : (window.outerHeight - 120)
-  const width = window.innerWidth ? window.innerWidth : (window.outerWidth - 20)
-  const narrow = isTouchDevice || (width < (1.1 * height))
+  const { height, width } = viewport
+  const narrow = isTouchDevice || width < wideLayoutMinWidth
   const isLandscape = isTouchDevice && (width > height)
   useEffect(() => {
     if (isTouchDevice) {

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -28,9 +28,17 @@ import { messagelistener } from "./api/messagelistener"
 import { CRTStartup } from "./graphics"
 import { startRemoteControlBridge } from "./api/remotecontrol"
 import { useTranslation } from "../i18n/useTranslation"
+import { desktopLayoutPolicy, getDesktopLayout } from "./layout"
+import FitControlRow from "./controls/fitcontrolrow"
+import DesktopPanel from "./panels/desktoppanel"
 
 // The classic emulator and Help panel need about this much room side by side.
-const wideLayoutMinWidth = 1000
+const specialLayoutNarrowWidth = 1000
+
+const getViewport = () => ({
+  height: window.innerHeight || window.outerHeight - 120,
+  width: document.documentElement.clientWidth || window.innerWidth || window.outerWidth - 20,
+})
 
 const DisplayApple2 = () => {
   const { t } = useTranslation()
@@ -42,17 +50,14 @@ const DisplayApple2 = () => {
   const [openAppleKeyMode, setOpenAppleKeyMode] = useState(0)
   const [closedAppleKeyMode, setClosedAppleKeyMode] = useState(0)
   const [showFileOpenDialog, setShowFileOpenDialog] = useState({ show: false, index: 0 })
+  const [desktopPanelBelow, setDesktopPanelBelow] = useState(false)
+  const [desktopPanelCollapsed, setDesktopPanelCollapsed] = useState(false)
+  const [wideDesktopPanel, setWideDesktopPanel] = useState(false)
   const [worker, setWorker] = useState<Worker | null>(null)
-  const [viewport, setViewport] = useState(() => ({
-    height: window.innerHeight || window.outerHeight - 120,
-    width: window.innerWidth || window.outerWidth - 20,
-  }))
+  const [viewport, setViewport] = useState(getViewport)
 
   useEffect(() => {
-    const handleResize = () => setViewport({
-      height: window.innerHeight || window.outerHeight - 120,
-      width: window.innerWidth || window.outerWidth - 20,
-    })
+    const handleResize = () => setViewport(getViewport())
     window.addEventListener("resize", handleResize)
     return () => window.removeEventListener("resize", handleResize)
   }, [])
@@ -186,7 +191,8 @@ const DisplayApple2 = () => {
 
   const isTouchDevice = "ontouchstart" in document.documentElement
   const { height, width } = viewport
-  const narrow = isTouchDevice || width < wideLayoutMinWidth
+  const desktop = !isTouchDevice && !isEmbedMode() && !isMinimalTheme() && !isGameMode()
+  const narrow = isTouchDevice || (!desktop && width < specialLayoutNarrowWidth)
   const isLandscape = isTouchDevice && (width > height)
   useEffect(() => {
     if (isTouchDevice) {
@@ -195,24 +201,93 @@ const DisplayApple2 = () => {
       document.body.style.marginTop = isLandscape ? "10px" : "0"
     }
   }, [isTouchDevice, isLandscape])
+  useEffect(() => {
+    document.documentElement.classList.toggle("desktop-layout", desktop)
+    return () => document.documentElement.classList.remove("desktop-layout")
+  }, [desktop])
   const machineName = handleGetMachineName()
   const slotConfig = handleGetSlotConfig()
   const isApple2Plus = machineName === "APPLE2P"
   const hasAuxCard = !isApple2Plus && slotConfig[3] === "aux"
   const mem = isApple2Plus ? 64 : (hasAuxCard ? (handleGetMemSize() + 64) : 64)
-  const memSize = (mem > 1100) ? ((mem / 1024).toFixed() + " MB") : (mem + " KB")
+  const memSize = (mem > 1100) ? ((mem / 1024).toFixed() + "MB") : (mem + "KB")
   const status = <div className="default-font footer-item">
-  <>{currentSpeed} MHz, {memSize}, FPS: {avgFPS.toFixed(1)}</>
-  <br />
-  <span>©{new Date().getFullYear()}&nbsp;Chris Torrence and the Apple2TS contributors<br/>
-  <a id="reportIssue" href="https://github.com/ct6502/apple2ts/issues">{t("controls.reportIssue")}</a>&nbsp;&nbsp;
-  <a href="https://ct6502.org/privacy/">Privacy Policy</a>
-  </span>
+    <div>{currentSpeed}MHz, {memSize}, {avgFPS.toFixed(1)} FPS</div>
+    <div>©{new Date().getFullYear()} Chris Torrence and</div>
+    <div>the Apple2TS contributors</div>
+    <div><a id="reportIssue" href="https://github.com/ct6502/apple2ts/issues">{t("controls.reportIssue")}</a></div>
+    <div><a href="https://ct6502.org/privacy/">Privacy Policy</a></div>
   </div>
 
   if (isEmbedMode()) {
     return <Apple2Canvas {...props} />
   }
+
+  if (desktop) {
+    const layout = getDesktopLayout(width, height, {
+      panelBelow: desktopPanelBelow,
+      panelCollapsed: desktopPanelCollapsed,
+      widePanel: wideDesktopPanel,
+    })
+    const desktopProps = {
+      ...props,
+      canvasBounds: { height: layout.screenHeight, width: layout.screenWidth },
+    }
+    return <>
+      <div className={`desktop-emulator-layout${desktopPanelBelow ? " desktop-panel-layout-below" : ""}`} style={{
+        gap: desktopLayoutPolicy.columnGap,
+        gridTemplateColumns: desktopPanelBelow
+          ? `${layout.monitorWidth}px`
+          : `${layout.monitorWidth}px ${layout.panelWidth}px`,
+      }}>
+        <div className="desktop-primary-column" style={{
+          minHeight: desktopPanelBelow
+            ? undefined
+            : layout.boundedPanelHeight,
+          width: layout.monitorWidth,
+        }}>
+          <div className="desktop-primary-sticky">
+            <Apple2Canvas {...desktopProps} />
+            <div className="desktop-controls-and-status">
+              <FitControlRow minHeight={desktopLayoutPolicy.controlStripHeight}>
+                <ControlPanel {...desktopProps} singleRow />
+              </FitControlRow>
+              <div className="desktop-status-strip">
+                {status}
+              </div>
+            </div>
+            <div className="desktop-device-strip" style={{
+              minHeight: desktopLayoutPolicy.deviceStripHeight,
+            }}>
+              <div className="desktop-disk-strip">
+                <FitControlRow maxScale={0.8} minHeight={desktopLayoutPolicy.deviceStripHeight}>
+                  <DiskInterface {...desktopProps} singleRow />
+                </FitControlRow>
+              </div>
+            </div>
+          </div>
+        </div>
+        <DesktopPanel
+          boundedHeight={layout.boundedPanelHeight}
+          collapsed={desktopPanelCollapsed}
+          expandedWidth={layout.panelWidth}
+          height={layout.panelHeight}
+          below={desktopPanelBelow}
+          onBelowChange={setDesktopPanelBelow}
+          onCollapsedChange={setDesktopPanelCollapsed}
+          wide={wideDesktopPanel}
+          onWideChange={setWideDesktopPanel}>
+          <DebugSection
+            updateDisplay={updateDisplay}
+            narrow={false}
+            desktop
+            horizontalTabs={desktopPanelBelow} />
+        </DesktopPanel>
+      </div>
+      <FileInput {...desktopProps} />
+    </>
+  }
+
   return (
     <>
     <div className={narrow ? "flex-column-gap" : "flex-row-gap"} style={{ alignItems: "inherit" }}>

--- a/src/ui/graphics.ts
+++ b/src/ui/graphics.ts
@@ -9,6 +9,7 @@ import { TEXT_AMBER, TEXT_GREEN, TEXT_WHITE, loresAmber, loresColors, loresGreen
 import { getColorMode, getCrtDistortion, getGhosting, isEmbedMode, isGameMode, isMinimalTheme } from "./ui_settings"
 import { doCRTStartup } from "./crtstartup"
 let frameCount = 0
+const maximumTouchViewportHeight = { landscape: 0, portrait: 0 }
 
 export const nRowsHgrMagnifier = 16
 export const nColsHgrMagnifier = 2
@@ -639,9 +640,25 @@ export const getCanvasSize = (bounds?: CanvasBounds) => {
   if (bounds && !isCanvasFullScreen) {
     return [Math.floor(bounds.width), Math.floor(bounds.height)]
   }
-  let width = window.innerWidth ? window.innerWidth : window.outerWidth
-  let height = window.innerHeight ? window.innerHeight : (window.outerHeight - 150)
-  const isLandscape = isTouchDevice && (window.innerWidth > window.innerHeight)
+  let width = isTouchDevice
+    ? document.documentElement.clientWidth || window.innerWidth || window.outerWidth
+    : window.innerWidth || window.outerWidth
+  let height = isTouchDevice
+    ? Math.max(
+      document.documentElement.clientHeight,
+      window.innerHeight,
+      window.visualViewport?.height ?? 0,
+    ) || window.outerHeight - 150
+    : window.innerHeight || window.outerHeight - 150
+  const touchOrientation = width > height ? "landscape" : "portrait"
+  if (isTouchDevice && !isCanvasFullScreen) {
+    maximumTouchViewportHeight[touchOrientation] = Math.max(
+      maximumTouchViewportHeight[touchOrientation],
+      height,
+    )
+    height = maximumTouchViewportHeight[touchOrientation]
+  }
+  const isLandscape = isTouchDevice && touchOrientation === "landscape"
   if (isEmbedMode()) {
     height -= noBackgroundImage ? 60 : 25
     width -= noBackgroundImage ? 60 : 25

--- a/src/ui/graphics.ts
+++ b/src/ui/graphics.ts
@@ -625,7 +625,7 @@ export const ProcessDisplay = (ctx: CanvasRenderingContext2D,
   // }
 }
 
-export const getCanvasSize = () => {
+export const getCanvasSize = (bounds?: CanvasBounds) => {
   const isTouchDevice = "ontouchstart" in document.documentElement
   const isCanvasFullScreen = document.fullscreenElement !== null
   const noBackgroundImage = isTouchDevice || isCanvasFullScreen || isMinimalTheme()
@@ -635,6 +635,9 @@ export const getCanvasSize = () => {
   const screenRatio = 1.4583334 // 1.33  // (20 * 40) / (24 * 24)
   if (TEST_GRAPHICS) {
     return [659, 452]  // This will give an actual size of 560 x 384
+  }
+  if (bounds && !isCanvasFullScreen) {
+    return [Math.floor(bounds.width), Math.floor(bounds.height)]
   }
   let width = window.innerWidth ? window.innerWidth : window.outerWidth
   let height = window.innerHeight ? window.innerHeight : (window.outerHeight - 150)

--- a/src/ui/hgrmagnifier.tsx
+++ b/src/ui/hgrmagnifier.tsx
@@ -1,5 +1,6 @@
 import { COLOR_MODE, toHex } from "../common/utility"
-import { useEffect } from "react"
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { useGlobalContext } from "./globalcontext"
 import { nColsHgrMagnifier, nRowsHgrMagnifier, getOverrideHiresPixels, screenBytesToCanvasPixels, screenCoordToCanvasCoord, canvasCoordToNormScreenCoord } from "./graphics"
 import { drawHiresTile } from "./graphicshgr"
@@ -10,10 +11,80 @@ type MagnifyProps = {
   lockHgrMagnifier: boolean
 }
 
+const drawBytes = (canvas: HTMLCanvasElement, pixels: number[][]) => {
+  const context = canvas.getContext("2d")
+  if (!context) return
+
+  context.fillStyle = "black"
+  context.fillRect(0, 0, canvas.width, canvas.height)
+  const tile = new Uint8Array(nColsHgrMagnifier * nRowsHgrMagnifier)
+  for (let j = 0; j < nRowsHgrMagnifier; j++) {
+    for (let i = 0; i < nColsHgrMagnifier; i++) {
+      tile[nColsHgrMagnifier * j + i] = pixels[j][i + 1]
+    }
+  }
+  context.imageSmoothingEnabled = false
+  const addr = pixels[0][0]
+  const isEven = addr % 2 === 0
+  drawHiresTile(context, tile, COLOR_MODE.NOFRINGE,
+    nRowsHgrMagnifier, 0, 0, 11, isEven)
+  const nPixels = 7 * nColsHgrMagnifier
+  for (let i = 1; i < nPixels; i++) {
+    const x = Math.round((canvas.width / nPixels) * i + 0.5) - 0.5
+    context.moveTo(x, 0)
+    context.lineTo(x, canvas.height)
+  }
+  for (let i = 1; i <= nRowsHgrMagnifier - 1; i++) {
+    const y = Math.round((canvas.height / nRowsHgrMagnifier) * i + 0.5) - 0.5
+    context.moveTo(0, y)
+    context.lineTo(canvas.width, y)
+  }
+  context.strokeStyle = "#888"
+  context.stroke()
+}
+
+const HgrInfoCanvas = ({ pixels }: { pixels: number[][] }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  useLayoutEffect(() => {
+    if (canvasRef.current) drawBytes(canvasRef.current, pixels)
+  }, [pixels])
+
+  return <canvas ref={canvasRef} id="hgr-info-canvas"
+    style={{
+      height: `${11 * nRowsHgrMagnifier}px`,
+      width: `${77 * nColsHgrMagnifier}px`,
+    }}
+    width={77 * nColsHgrMagnifier} height={11 * nRowsHgrMagnifier} />
+}
+
 const HgrMagnifier = (props: MagnifyProps) => {
   const { updateHgrMagnifier: updateHgrMagnifier, setUpdateHgrMagnifier: setUpdateHgrMagnifier,
     hgrMagnifierLoc: hgrMagnifierLoc, setHgrMagnifierLoc: setHgrMagnifierLoc,
     setLockHgrMagnifier } = useGlobalContext()
+  const [, setPositionVersion] = useState(0)
+  const wasLockedRef = useRef(props.lockHgrMagnifier)
+
+  useEffect(() => {
+    let animationFrame = 0
+    const updatePosition = () => {
+      cancelAnimationFrame(animationFrame)
+      animationFrame = requestAnimationFrame(() => {
+        setPositionVersion(version => version + 1)
+      })
+    }
+    window.addEventListener("scroll", updatePosition, true)
+    window.addEventListener("resize", updatePosition)
+    const resizeObserver = props.mainCanvas
+      ? new ResizeObserver(updatePosition)
+      : undefined
+    if (props.mainCanvas) resizeObserver?.observe(props.mainCanvas)
+    return () => {
+      cancelAnimationFrame(animationFrame)
+      window.removeEventListener("scroll", updatePosition, true)
+      window.removeEventListener("resize", updatePosition)
+      resizeObserver?.disconnect()
+    }
+  }, [props.mainCanvas])
 
   let x = 0, y = 0
   if (props.mainCanvas) {
@@ -29,14 +100,17 @@ const HgrMagnifier = (props: MagnifyProps) => {
   }
 
   useEffect(() => {
-    if (props.lockHgrMagnifier && props.mainCanvas) {
+    if (props.lockHgrMagnifier && !wasLockedRef.current && props.mainCanvas) {
       setHgrMagnifierLoc([x, y])
     }
+    wasLockedRef.current = props.lockHgrMagnifier
   }, [x, y, props.lockHgrMagnifier, props.mainCanvas, setHgrMagnifierLoc])
 
   useEffect(() => {
     if (updateHgrMagnifier) {
       setUpdateHgrMagnifier(false)
+      // The memory table has already supplied the location for this lock.
+      wasLockedRef.current = true
       setLockHgrMagnifier(true)
     }
   }, [updateHgrMagnifier, setUpdateHgrMagnifier, setLockHgrMagnifier])
@@ -51,44 +125,6 @@ const HgrMagnifier = (props: MagnifyProps) => {
     ? Math.max(Math.min(hgrMagnifierLoc[1], 192), 0)
     : Math.max(Math.min(y, 192), 0)
 
-  const drawBytes = (pixels: number[][]) => {
-    const infoCanvas = document.getElementById("hgr-info-canvas") as HTMLCanvasElement | null
-    if (infoCanvas) {
-      const canvas = infoCanvas
-      const context = canvas.getContext("2d")
-      if (context) {
-        context.fillStyle = "black"
-        context.fillRect(0, 0, canvas.width, canvas.height)
-        const tile = new Uint8Array(nColsHgrMagnifier * nRowsHgrMagnifier)
-        for (let j = 0; j < nRowsHgrMagnifier; j++) {
-          for (let i = 0; i < nColsHgrMagnifier; i++) {
-            tile[nColsHgrMagnifier * j + i] = pixels[j][i + 1]
-          }
-        }
-        context.imageSmoothingEnabled = false
-        const addr = pixels[0][0]
-        const isEven = addr % 2 === 0
-        drawHiresTile(context, tile, COLOR_MODE.NOFRINGE,
-          nRowsHgrMagnifier, 0, 0, 11, isEven)
-        // Draw vertical lines
-        const nPixels = 7 * nColsHgrMagnifier
-        for (let i = 1; i < nPixels; i++) {
-          const x = Math.round((canvas.width / nPixels) * i + 0.5) - 0.5
-          context.moveTo(x, 0)
-          context.lineTo(x, canvas.height)
-        }
-        // Draw horizontal lines
-        for (let i = 1; i <= nRowsHgrMagnifier - 1; i++) {
-          const y = Math.round((canvas.height / nRowsHgrMagnifier) * i + 0.5) - 0.5
-          context.moveTo(0, y)
-          context.lineTo(canvas.width, y)
-        }
-        context.strokeStyle = "#888"
-        context.stroke()
-      }
-    }
-  }
-
   const pixels = getOverrideHiresPixels(displayX, displayY)
   if (!pixels) return <></>
   const pixelText = pixels.map((line: Array<number>, i) => {
@@ -102,16 +138,12 @@ const HgrMagnifier = (props: MagnifyProps) => {
   let [xPos, yPos] = screenCoordToCanvasCoord(props.mainCanvas, col, row)
   xPos -= 2
   yPos -= 2
-  setTimeout(() => drawBytes(pixels), 50)
-
-  return <div className="hgr-view flex-row"
+  return createPortal(<div className="hgr-view flex-row"
     style={{ left: `${xPos}px`, top: `${yPos}px` }}>
     <div className="hgr-view-box" style={{ width: `${dx}px`, height: `${dy}px` }}>&nbsp;</div>
     <div className="hgr-view-text">{pixelText}</div>
-    <canvas id="hgr-info-canvas"
-      style={{ zIndex: "9999", border: "2px solid red" }}
-      width={`${77 * nColsHgrMagnifier}pt`} height={`${11 * nRowsHgrMagnifier}pt`} />
-  </div>
+    <HgrInfoCanvas pixels={pixels} />
+  </div>, document.body)
 
 }
 

--- a/src/ui/layout.test.ts
+++ b/src/ui/layout.test.ts
@@ -1,0 +1,124 @@
+import { desktopLayoutPolicy, getDesktopLayout } from "./layout"
+
+describe("desktop layout", () => {
+  it("reserves a stable panel before sizing the monitor", () => {
+    expect(getDesktopLayout(1200, 800)).toEqual({
+      boundedPanelHeight: 575,
+      monitorWidth: 653,
+      panelHeight: 575,
+      panelWidth: 520,
+      screenHeight: 447,
+      screenWidth: 653,
+    })
+  })
+
+  it("gives unused width to the panel after the monitor reaches its height limit", () => {
+    const layout = getDesktopLayout(1800, 800)
+    expect(layout.screenHeight).toBe(652)
+    expect(layout.screenWidth).toBe(950)
+    expect(layout.panelHeight).toBe(780)
+    expect(layout.panelWidth).toBe(760)
+    expect(layout.screenHeight
+      + desktopLayoutPolicy.controlStripHeight
+      + desktopLayoutPolicy.deviceStripHeight).toBe(780)
+  })
+
+  it("grows the normal panel into width unused by the monitor", () => {
+    const layout = getDesktopLayout(1404, 608)
+    expect(layout.screenWidth).toBe(670)
+    expect(layout.panelWidth).toBe(707)
+  })
+
+  it("widens the panel while preserving a usable monitor", () => {
+    expect(getDesktopLayout(1200, 800, { widePanel: true })).toEqual({
+      boundedPanelHeight: 575,
+      monitorWidth: 570,
+      panelHeight: 780,
+      panelWidth: 760,
+      screenHeight: 390,
+      screenWidth: 570,
+    })
+  })
+
+  it("caps the wide panel and leaves extra space to the monitor", () => {
+    const layout = getDesktopLayout(1800, 800, { widePanel: true })
+    expect(layout.panelHeight).toBe(780)
+    expect(layout.panelWidth).toBe(760)
+    expect(layout.screenWidth).toBe(950)
+  })
+
+  it("keeps the debugger content-sized when the page must scroll", () => {
+    expect(getDesktopLayout(700, 800, { widePanel: true })).toEqual({
+      boundedPanelHeight: 518,
+      monitorWidth: 570,
+      panelHeight: 780,
+      panelWidth: 760,
+      screenHeight: 390,
+      screenWidth: 570,
+    })
+  })
+
+  it("reclaims the side-panel grid track when the panel is collapsed", () => {
+    expect(getDesktopLayout(1200, 800, {
+      panelCollapsed: true,
+      widePanel: true,
+    })).toEqual({
+      boundedPanelHeight: 575,
+      monitorWidth: 950,
+      panelHeight: 780,
+      panelWidth: 34,
+      screenHeight: 652,
+      screenWidth: 950,
+    })
+  })
+
+  it("lets the monitor reclaim the row when the panel moves below it", () => {
+    expect(getDesktopLayout(1200, 800, { panelBelow: true })).toEqual({
+      boundedPanelHeight: 814,
+      monitorWidth: 950,
+      panelHeight: 814,
+      panelWidth: 950,
+      screenHeight: 652,
+      screenWidth: 950,
+    })
+  })
+
+  it("ignores the side-panel width mode while the panel is below", () => {
+    expect(getDesktopLayout(1200, 800, {
+      panelBelow: true,
+      widePanel: true,
+    })).toEqual(getDesktopLayout(1200, 800, { panelBelow: true }))
+  })
+
+  it("preserves both desktop columns when the viewport is unusually narrow", () => {
+    expect(getDesktopLayout(700, 800)).toEqual({
+      boundedPanelHeight: 518,
+      monitorWidth: 570,
+      panelHeight: 518,
+      panelWidth: 520,
+      screenHeight: 390,
+      screenWidth: 570,
+    })
+  })
+
+  it("lets a very short page scroll instead of collapsing the monitor", () => {
+    expect(getDesktopLayout(1200, 200)).toEqual({
+      boundedPanelHeight: 518,
+      monitorWidth: 570,
+      panelHeight: 518,
+      panelWidth: 603,
+      screenHeight: 390,
+      screenWidth: 570,
+    })
+  })
+
+  it("keeps the policy values available to future layout variants", () => {
+    expect(desktopLayoutPolicy.collapsedPanelSize).toBe(34)
+    expect(desktopLayoutPolicy.controlStripHeight).toBe(66)
+    expect(desktopLayoutPolicy.deviceStripHeight).toBe(62)
+    expect(desktopLayoutPolicy.horizontalTabHeight).toBe(34)
+    expect(desktopLayoutPolicy.panelWidth).toBe(520)
+    expect(desktopLayoutPolicy.widePanelWidth).toBe(760)
+    expect(desktopLayoutPolicy.widePanelMinHeight).toBe(700)
+  })
+})

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,0 +1,131 @@
+export const desktopLayoutPolicy = {
+  bodyMargin: 20,
+  collapsedPanelSize: 34,
+  columnGap: 7,
+  controlStripHeight: 66,
+  // Full disk/printer row below the two-row controls.
+  // The natural disk/printer row is about 78px tall and renders at 80%.
+  deviceStripHeight: 62,
+  horizontalTabHeight: 34,
+  // Below this width the device controls become too small to use comfortably.
+  minMonitorWidth: 570,
+  // 34px tab rail + 486px content. The compact width keeps the monitor useful;
+  // the longest Help shortcut translations can wrap when space is constrained.
+  panelWidth: 520,
+  widePanelWidth: 760,
+  widePanelMinHeight: 700,
+  screenAspectRatio: 1.4583334,
+} as const
+
+export type DesktopLayout = {
+  boundedPanelHeight: number,
+  monitorWidth: number,
+  panelHeight: number,
+  panelWidth: number,
+  screenHeight: number,
+  screenWidth: number,
+}
+
+export type DesktopLayoutOptions = {
+  panelBelow?: boolean,
+  panelCollapsed?: boolean,
+  widePanel?: boolean,
+}
+
+export const getDesktopLayout = (
+  viewportWidth: number,
+  viewportHeight: number,
+  { panelBelow = false, panelCollapsed = false, widePanel = false }: DesktopLayoutOptions = {},
+): DesktopLayout => {
+  const requestedWidth = Math.max(0,
+    viewportWidth - desktopLayoutPolicy.bodyMargin - desktopLayoutPolicy.columnGap)
+  const requestedSidePanelWidth = widePanel
+    ? desktopLayoutPolicy.widePanelWidth
+    : desktopLayoutPolicy.panelWidth
+  const sidePanelWidth = panelCollapsed && !panelBelow
+    ? desktopLayoutPolicy.collapsedPanelSize
+    : requestedSidePanelWidth
+  // Keep both columns usable on a narrow desktop. The page can scroll
+  // horizontally instead of collapsing either column or switching layouts.
+  const availableWidth = Math.max(
+    requestedWidth,
+    panelBelow
+      ? desktopLayoutPolicy.minMonitorWidth
+      : desktopLayoutPolicy.minMonitorWidth + sidePanelWidth,
+  )
+  const minimumScreenHeight = desktopLayoutPolicy.minMonitorWidth
+    / desktopLayoutPolicy.screenAspectRatio
+  const availableScreenHeight = Math.max(
+    minimumScreenHeight,
+    viewportHeight
+      - desktopLayoutPolicy.bodyMargin
+      - desktopLayoutPolicy.controlStripHeight
+      - desktopLayoutPolicy.deviceStripHeight,
+  )
+  const widthAvailableForMonitor = Math.max(
+    Math.min(desktopLayoutPolicy.minMonitorWidth, availableWidth),
+    panelBelow ? availableWidth : availableWidth - sidePanelWidth,
+  )
+  const heightLimited = widthAvailableForMonitor
+    >= availableScreenHeight * desktopLayoutPolicy.screenAspectRatio
+  const screenHeight = Math.floor(heightLimited
+    ? availableScreenHeight
+    : widthAvailableForMonitor / desktopLayoutPolicy.screenAspectRatio)
+  const screenWidth = Math.max(
+    desktopLayoutPolicy.minMonitorWidth,
+    Math.floor(heightLimited
+      ? screenHeight * desktopLayoutPolicy.screenAspectRatio
+      : widthAvailableForMonitor),
+  )
+  // A normal panel can consume width that would otherwise remain blank once
+  // the monitor reaches its height limit. Wide mode still reserves its full
+  // width even when it has to reduce the monitor.
+  const expandedSidePanelWidth = !widePanel && !panelBelow && !panelCollapsed
+    ? Math.min(
+      desktopLayoutPolicy.widePanelWidth,
+      Math.max(
+        desktopLayoutPolicy.panelWidth,
+        availableWidth - screenWidth,
+      ),
+    )
+    : sidePanelWidth
+
+  // Wide mode must not shorten code workspaces merely because it gives more
+  // horizontal room to the debugger. Preserve the height that the normal
+  // side-by-side arrangement would have used.
+  const normalAvailableWidth = Math.max(
+    requestedWidth,
+    desktopLayoutPolicy.minMonitorWidth + desktopLayoutPolicy.panelWidth,
+  )
+  const normalScreenWidth = Math.max(
+    desktopLayoutPolicy.minMonitorWidth,
+    normalAvailableWidth - desktopLayoutPolicy.panelWidth,
+  )
+  const normalScreenHeight = Math.floor(Math.min(
+    availableScreenHeight,
+    normalScreenWidth / desktopLayoutPolicy.screenAspectRatio,
+  ))
+  const boundedScreenHeight = widePanel && !panelBelow
+    ? normalScreenHeight
+    : screenHeight
+  const boundedPanelHeight = boundedScreenHeight
+    + desktopLayoutPolicy.controlStripHeight
+    + desktopLayoutPolicy.deviceStripHeight
+    + (panelBelow ? desktopLayoutPolicy.horizontalTabHeight : 0)
+  const panelContentHeight = widePanel && !panelBelow
+    ? Math.max(
+      desktopLayoutPolicy.widePanelMinHeight,
+      viewportHeight - desktopLayoutPolicy.bodyMargin,
+    )
+    : boundedPanelHeight
+  const panelHeight = panelContentHeight
+
+  return {
+    boundedPanelHeight,
+    monitorWidth: screenWidth,
+    panelHeight,
+    panelWidth: panelBelow ? screenWidth : expandedSidePanelWidth,
+    screenHeight,
+    screenWidth,
+  }
+}

--- a/src/ui/panels/agent/agent.css
+++ b/src/ui/panels/agent/agent.css
@@ -10,10 +10,11 @@
 
 /* Chat messages area */
 .agent-messages {
+  box-sizing: border-box;
   flex: 1;
   min-height: 0;
   /* Important for flex children with overflow */
-  width: 667px;
+  width: min(687px, 100%);
   overflow-y: auto;
   padding: 10px;
   background-color: #000;
@@ -174,11 +175,8 @@
 }
 
 .agent-submit {
-  padding: 6px 6px;
   background-color: #000000;
   border: none;
-  border-radius: 4px;
-  cursor: pointer;
   color: #00FF00;
 }
 
@@ -192,11 +190,23 @@
 }
 
 /* Configuration Panel */
+.agent-config-overlay {
+  height: 100%;
+  inset: 0;
+  position: absolute;
+  width: 100%;
+}
+
 .agent-config-panel {
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 10px;
   color: black;
+}
+
+.agent-config-dialog {
+  max-width: 500px;
+  width: min(500px, calc(100vw - 20px));
 }
 
 .agent-config-panel h3 {

--- a/src/ui/panels/agent/agent.css
+++ b/src/ui/panels/agent/agent.css
@@ -197,6 +197,23 @@
   width: 100%;
 }
 
+.agent-config-overlay-mobile {
+  align-items: flex-start;
+  box-sizing: border-box;
+  height: 100dvh;
+  overflow-y: auto;
+  padding: max(8px, env(safe-area-inset-top)) 4px 8px;
+  position: fixed;
+  width: 100vw;
+}
+
+.agent-config-overlay-mobile .agent-config-dialog {
+  flex: 0 0 auto;
+  height: max-content;
+  max-height: none;
+  position: relative;
+}
+
 .agent-config-panel {
   border-radius: 8px;
   padding: 15px;

--- a/src/ui/panels/agent/agent_tab.tsx
+++ b/src/ui/panels/agent/agent_tab.tsx
@@ -363,28 +363,28 @@ const AgentTab = () => {
       </form>
       </div>
       
+      <AgentTabConfig
+        showConfig={showConfig}
+        setShowConfig={setShowConfig}
+        onConfigChange={handleConfigChange}
+      />
+
       <div className="agent-controls">
-            <button
-              type={isProcessing ? "button" : "submit"}
-              onClick={isProcessing ? handleStop : handleSubmit}
-              disabled={!isProcessing && !inputValue.trim()}
-              className="agent-submit"
-              title={isProcessing ? t("agent.stop") : t("agent.send")}
-            >
-              <FontAwesomeIcon icon={isProcessing ? faStop : faPlay} />
-            </button>
+        <button
+          type={isProcessing ? "button" : "submit"}
+          onClick={isProcessing ? handleStop : handleSubmit}
+          disabled={!isProcessing && !inputValue.trim()}
+          className="push-button agent-submit"
+          title={isProcessing ? t("agent.stop") : t("agent.send")}
+        >
+          <FontAwesomeIcon icon={isProcessing ? faStop : faPlay} />
+        </button>
         <button onClick={() => setShowConfig(true)}
-          className="agent-submit"
+          className="push-button agent-submit"
           title={t("agent.changeConfiguration")}>
           <FontAwesomeIcon icon={faCog} />
         </button>
       </div>
-
-      <AgentTabConfig 
-        showConfig={showConfig} 
-        setShowConfig={setShowConfig}
-        onConfigChange={handleConfigChange}
-      />
     </div>
   )
 }

--- a/src/ui/panels/agent/agent_tab_config.tsx
+++ b/src/ui/panels/agent/agent_tab_config.tsx
@@ -18,6 +18,7 @@ const AgentTabConfig = (props: {
   onConfigChange?: () => void
 }) => {
   const { t } = useTranslation()
+  const isTouchDevice = "ontouchstart" in document.documentElement
   const initialConfig = loadAgentConfig()
   const initialProvider: ProviderType = initialConfig?.provider ?? "anthropic"
   const initialModel = initialConfig?.model || getDefaultModel(initialProvider)
@@ -182,7 +183,7 @@ const AgentTabConfig = (props: {
 return (
 <div>
   {props.showConfig &&
-  <div className="modal-overlay agent-config-overlay"
+  <div className={`modal-overlay agent-config-overlay${isTouchDevice ? " agent-config-overlay-mobile" : ""}`}
       tabIndex={0} // Make the div focusable
       onKeyDown={(event) => {
         if (event.key === "Escape") props.setShowConfig(false)

--- a/src/ui/panels/agent/agent_tab_config.tsx
+++ b/src/ui/panels/agent/agent_tab_config.tsx
@@ -182,13 +182,12 @@ const AgentTabConfig = (props: {
 return (
 <div>
   {props.showConfig &&
-  <div className="modal-overlay"
+  <div className="modal-overlay agent-config-overlay"
       tabIndex={0} // Make the div focusable
       onKeyDown={(event) => {
         if (event.key === "Escape") props.setShowConfig(false)
       }}>
-    <div className="floating-dialog flex-column"
-        style={{ left: "35%", top: "25%", width: "70%", maxWidth: "500px" }}>
+    <div className="floating-dialog flex-column agent-config-dialog">
       <div className="agent-config-panel">
       <div className="flex-row-space-between">
         <div className="dialog-title" style={{padding: 0, paddingTop: "6px"}}>{t("agent.configTitle")}</div>

--- a/src/ui/panels/basic/basic_debugview.tsx
+++ b/src/ui/panels/basic/basic_debugview.tsx
@@ -3,7 +3,7 @@ import BasicVariablesView from "./basic_variablesview"
 
 const BasicDebugView = () => {
 
-  return <div className="flex-row">
+  return <div className="flex-row basic-debug-view">
     <BasicVariablesView/>
   </div>
 

--- a/src/ui/panels/basic/basic_editorview.tsx
+++ b/src/ui/panels/basic/basic_editorview.tsx
@@ -234,10 +234,7 @@ const BasicEditor = (props: EditorProps) => {
     }
   }, [props.breakpoints, handleBreakpointToggle])
 
-  return <div ref={editorRef} style={{
-    height: "560px", width: "687px",
-    overflowY: "hidden"
-  }} />
+  return <div ref={editorRef} className="basic-editor" />
 }
 
 export default BasicEditor

--- a/src/ui/panels/basic/basic_tab.tsx
+++ b/src/ui/panels/basic/basic_tab.tsx
@@ -1,5 +1,5 @@
 import "../panels.css"
-import { faDatabase, faFile, faFolderOpen, faForwardStep, faGear, faListOl, faPlay, faRepeat, faSave, faSnowflake, faStop } from "@fortawesome/free-solid-svg-icons"
+import { faDatabase, faDollarSign, faFile, faFolderOpen, faForwardStep, faGear, faListOl, faPlay, faRepeat, faSave, faSlash, faSnowflake, faStop } from "@fortawesome/free-solid-svg-icons"
 import { handleGetManualNumbering, handleGetCapitalizeBasic, isMinimalTheme } from "../../ui_settings"
 import { useEffect, useState } from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -26,6 +26,7 @@ const BasicTab = (props: { updateDisplay: UpdateDisplay }) => {
   })
   const [isBooting, setIsBooting] = useState<boolean>(false)
   const [highlightLine, setHighlightLine] = useState<number>(5)
+  const [showVariables, setShowVariables] = useState(false)
 
   const [popupLocation, setPopupLocation] = useState<[number, number]>()
   const handleSettingsClick = (event: React.MouseEvent) => {
@@ -266,67 +267,67 @@ const BasicTab = (props: { updateDisplay: UpdateDisplay }) => {
   const runMode = handleGetRunMode()
 
   return (
-    <div className="flex-column-gap debug-section">
-      <BasicEditor value={programText} setValue={setProgramText}
-        highlightLine={highlightLine} readOnly={running} />
-      <BasicDebugView/>
-      <div className="flex-row">
-        <div className="flex-row">
-          <button
-            className="push-button"
-            title={t("basic.runFromBeginning")}
-            onClick={handleRunButtonClick}>
-            <FontAwesomeIcon icon={faPlay} />
-          </button>
-          <button
-            className="push-button"
-            title={t("basic.break")}
-            disabled={runMode === RUN_MODE.IDLE || !isRunning()}
-            onClick={handleBreakButtonClick}>
-            <FontAwesomeIcon icon={faStop} />
-          </button>
-          <button
-            className="push-button"
-            title={t("basic.continueRunning")}
-            disabled={runMode === RUN_MODE.IDLE || (running && runMode !== RUN_MODE.PAUSED)}
-            onClick={handleContinueButtonClick}>
-            <FontAwesomeIcon icon={faRepeat} />
-          </button>
-          <button
-            className="push-button"
-            title={t("basic.stepProgram")}
-            disabled={(running && runMode !== RUN_MODE.PAUSED) || runMode === RUN_MODE.IDLE}
-            onClick={handleStepButtonClick}>
-            <FontAwesomeIcon icon={faForwardStep} />
-          </button>
-          <button
-            className={paused ? "push-button button-active" : "push-button"}
-            title={paused ? t("basic.resumeOutput") : t("basic.freezeOutput")}
-            disabled={!running || runMode === RUN_MODE.PAUSED || runMode === RUN_MODE.IDLE}
-            onClick={handlePauseButtonClick}>
-            <FontAwesomeIcon icon={faSnowflake} />
-          </button>
-          <button
-            className="push-button"
-            title={t("basic.importProgram")}
-            onClick={handleImportButtonClick}>
-            <FontAwesomeIcon icon={faFolderOpen} />
-          </button>
-          <button
-            className="push-button"
-            title={t("basic.exportProgram")}
-            onClick={handleExportButtonClick}>
-            <FontAwesomeIcon icon={faSave} />
-          </button>
-          <button
-            className="push-button"
-            title={t("basic.renumberProgram")}
-            onClick={handleRenumberClick}>
-            <FontAwesomeIcon icon={faListOl} />
-          </button>
-        </div>
+    <div className={`flex-column-gap debug-section desktop-code-workspace desktop-basic-workspace${showVariables ? " desktop-basic-variables-visible" : ""}`}>
+      <div className="desktop-basic-primary">
+        <BasicEditor value={programText} setValue={setProgramText}
+          highlightLine={highlightLine} readOnly={running} />
+        <div className="flex-row desktop-code-controls">
+          <div className="flex-row">
+            <button
+              className="push-button"
+              title={t("basic.runFromBeginning")}
+              onClick={handleRunButtonClick}>
+              <FontAwesomeIcon icon={faPlay} />
+            </button>
+            <button
+              className="push-button"
+              title={t("basic.break")}
+              disabled={runMode === RUN_MODE.IDLE || !isRunning()}
+              onClick={handleBreakButtonClick}>
+              <FontAwesomeIcon icon={faStop} />
+            </button>
+            <button
+              className="push-button"
+              title={t("basic.continueRunning")}
+              disabled={runMode === RUN_MODE.IDLE || (running && runMode !== RUN_MODE.PAUSED)}
+              onClick={handleContinueButtonClick}>
+              <FontAwesomeIcon icon={faRepeat} />
+            </button>
+            <button
+              className="push-button"
+              title={t("basic.stepProgram")}
+              disabled={(running && runMode !== RUN_MODE.PAUSED) || runMode === RUN_MODE.IDLE}
+              onClick={handleStepButtonClick}>
+              <FontAwesomeIcon icon={faForwardStep} />
+            </button>
+            <button
+              className={paused ? "push-button button-active" : "push-button"}
+              title={paused ? t("basic.resumeOutput") : t("basic.freezeOutput")}
+              disabled={!running || runMode === RUN_MODE.PAUSED || runMode === RUN_MODE.IDLE}
+              onClick={handlePauseButtonClick}>
+              <FontAwesomeIcon icon={faSnowflake} />
+            </button>
+            <button
+              className="push-button"
+              title={t("basic.importProgram")}
+              onClick={handleImportButtonClick}>
+              <FontAwesomeIcon icon={faFolderOpen} />
+            </button>
+            <button
+              className="push-button"
+              title={t("basic.exportProgram")}
+              onClick={handleExportButtonClick}>
+              <FontAwesomeIcon icon={faSave} />
+            </button>
+            <button
+              className="push-button"
+              title={t("basic.renumberProgram")}
+              onClick={handleRenumberClick}>
+              <FontAwesomeIcon icon={faListOl} />
+            </button>
+          </div>
 
-        <div className="flex-row" style={{ marginLeft: "10px" }}>
+          <div className="flex-row" style={{ marginLeft: "10px" }}>
           <button
             className="push-button"
             title={t("basic.newProgram")}
@@ -350,9 +351,9 @@ const BasicTab = (props: { updateDisplay: UpdateDisplay }) => {
           >
             <FontAwesomeIcon icon={faGear} />
           </button>
-        </div>
+          </div>
 
-        <PopupMenu
+          <PopupMenu
           location={popupLocation}
           onClose={() => { setPopupLocation(undefined) }}
           menuItems={[[
@@ -371,12 +372,28 @@ const BasicTab = (props: { updateDisplay: UpdateDisplay }) => {
               }
             },
           ]]}
-        />
+          />
+          <button
+          type="button"
+          className="push-button basic-variables-toggle"
+          aria-pressed={showVariables}
+          title={showVariables ? t("basic.hideVariables") : t("basic.showVariables")}
+          aria-label={showVariables ? t("basic.hideVariables") : t("basic.showVariables")}
+          onClick={() => setShowVariables(previous => !previous)}>
+          <span className="basic-variables-toggle-icon">
+            <FontAwesomeIcon icon={faDollarSign} />
+            {showVariables && <FontAwesomeIcon
+              className="basic-variables-toggle-slash"
+              icon={faSlash}
+              aria-hidden="true" />}
+          </span>
+          </button>
+        </div>
+        {programError !== "" && <div
+          title={programError}
+          className="dbg-program-error">❌ {programError}</div>}
       </div>
-      {programError !== "" && <div
-        style={{ gridColumn: "span 2" }}
-        title={programError}
-        className="dbg-program-error">❌ {programError}</div>}
+      {showVariables && <BasicDebugView/>}
     </div>
   )
 }

--- a/src/ui/panels/basic/basic_variablesview.tsx
+++ b/src/ui/panels/basic/basic_variablesview.tsx
@@ -154,11 +154,7 @@ const BasicVariablesView = () => {
     passExecuteBasicCommand(command)
   }
 
-  return <div style={{
-      height: "200px",
-      overflowX: "auto",
-      overflowY: "auto"
-    }}>
+  return <div className="basic-variables-pane">
     <table className="basic-vars default-font"
       style={{
         width: "250px",

--- a/src/ui/panels/desktoppanel.test.tsx
+++ b/src/ui/panels/desktoppanel.test.tsx
@@ -1,0 +1,208 @@
+import { act, ComponentProps, useState } from "react"
+import { createRoot, Root } from "react-dom/client"
+
+import DesktopPanel from "./desktoppanel"
+
+const reactEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean,
+}
+
+type TestPanelProps = Omit<
+  ComponentProps<typeof DesktopPanel>,
+  "boundedHeight" | "collapsed" | "onCollapsedChange"
+>
+
+const TestDesktopPanel = (props: TestPanelProps) => {
+  const [collapsed, setCollapsed] = useState(false)
+  return <DesktopPanel
+    {...props}
+    boundedHeight={props.height}
+    collapsed={collapsed}
+    onCollapsedChange={setCollapsed}
+  />
+}
+
+describe("DesktopPanel", () => {
+  let container: HTMLDivElement
+  let previousActEnvironment: boolean | undefined
+  let root: Root
+  let wide = false
+  const onWideChange = jest.fn((nextWide: boolean) => { wide = nextWide })
+
+  beforeEach(() => {
+    previousActEnvironment = reactEnvironment.IS_REACT_ACT_ENVIRONMENT
+    reactEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => root.render(
+      <TestDesktopPanel
+        below={false}
+        expandedWidth={720}
+        height={600}
+        onBelowChange={jest.fn()}
+        wide={wide}
+        onWideChange={onWideChange}>
+        <div id="debug-section">panel content</div>
+      </TestDesktopPanel>,
+    ))
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    reactEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
+    wide = false
+    onWideChange.mockClear()
+  })
+
+  it("collapses to its restore control without discarding panel content", () => {
+    const panel = container.querySelector<HTMLElement>(".desktop-panel-shell")
+    const body = container.querySelector<HTMLElement>(".desktop-panel-body")
+    const button = container.querySelector<HTMLButtonElement>(".desktop-panel-collapse-toggle")
+    if (!panel || !body || !button) throw new Error("Desktop panel was not rendered")
+
+    expect(panel.style.width).toBe("720px")
+    expect(body.hidden).toBe(false)
+    expect(button.getAttribute("aria-expanded")).toBe("true")
+    expect(button.getAttribute("aria-label")).toBe("Hide side panel")
+
+    act(() => button.click())
+
+    expect(panel.style.width).toBe("34px")
+    expect(panel.style.height).toBe("34px")
+    expect(body.hidden).toBe(true)
+    expect(body.textContent).toContain("panel content")
+    expect(button.getAttribute("aria-expanded")).toBe("false")
+    expect(button.getAttribute("aria-label")).toBe("Show side panel")
+
+    act(() => button.click())
+
+    expect(panel.style.width).toBe("720px")
+    expect(body.hidden).toBe(false)
+  })
+
+  it("offers a separate width toggle while the panel is open", () => {
+    const button = container.querySelector<HTMLButtonElement>(".desktop-panel-width-toggle")
+    if (!button) throw new Error("Desktop panel width toggle was not rendered")
+
+    expect(button.getAttribute("aria-pressed")).toBe("false")
+    expect(button.getAttribute("aria-label")).toBe("Widen side panel")
+
+    act(() => button.click())
+
+    expect(onWideChange).toHaveBeenCalledWith(true)
+  })
+
+  it("matches keyboard order to the red, yellow, green visual order", () => {
+    expect(Array.from(container.querySelectorAll<HTMLButtonElement>(".desktop-panel-toggle"))
+      .map(button => button.classList[1])).toEqual([
+        "desktop-panel-orientation-toggle",
+        "desktop-panel-collapse-toggle",
+        "desktop-panel-width-toggle",
+      ])
+  })
+
+  it("keeps a wide shell bounded until its content explicitly expands it", () => {
+    act(() => root.render(
+      <TestDesktopPanel
+        below={false}
+        expandedWidth={760}
+        height={780}
+        onBelowChange={jest.fn()}
+        wide
+        onWideChange={onWideChange}>
+        <div id="debug-section">panel content</div>
+      </TestDesktopPanel>,
+    ))
+
+    const panel = container.querySelector<HTMLElement>(".desktop-panel-shell")
+    expect(panel?.classList.contains("desktop-panel-wide")).toBe(true)
+    expect(panel?.style.height).toBe("780px")
+    expect(panel?.style.minHeight).toBe("")
+    expect(panel?.style.width).toBe("760px")
+    expect(panel?.style.getPropertyValue("--desktop-panel-height")).toBe("780px")
+    expect(panel?.style.getPropertyValue("--desktop-bounded-panel-height")).toBe("780px")
+    expect(container.querySelector<HTMLButtonElement>(".desktop-panel-width-toggle")
+      ?.getAttribute("aria-pressed")).toBe("true")
+  })
+
+  it("hides the width toggle while the panel is collapsed", () => {
+    const collapse = container.querySelector<HTMLButtonElement>(".desktop-panel-collapse-toggle")
+    if (!collapse) throw new Error("Desktop panel collapse toggle was not rendered")
+
+    act(() => collapse.click())
+
+    expect(container.querySelector(".desktop-panel-width-toggle")).toBeNull()
+  })
+
+  it("offers a separate orientation toggle", () => {
+    const onBelowChange = jest.fn()
+    act(() => root.render(
+      <TestDesktopPanel
+        below={false}
+        expandedWidth={720}
+        height={600}
+        onBelowChange={onBelowChange}
+        wide={false}
+        onWideChange={onWideChange}>
+        <div id="debug-section">panel content</div>
+      </TestDesktopPanel>,
+    ))
+    const button = container.querySelector<HTMLButtonElement>(".desktop-panel-orientation-toggle")
+    if (!button) throw new Error("Desktop panel orientation toggle was not rendered")
+
+    expect(button.getAttribute("aria-pressed")).toBe("false")
+    expect(button.getAttribute("aria-label")).toBe("Move side panel below emulator")
+
+    act(() => button.click())
+
+    expect(onBelowChange).toHaveBeenCalledWith(true)
+    expect(container.querySelector(".desktop-panel-moving-below")).toBeNull()
+  })
+
+  it("keeps all three layout controls available below the emulator", () => {
+    act(() => root.render(
+      <TestDesktopPanel
+        below
+        expandedWidth={720}
+        height={600}
+        onBelowChange={jest.fn()}
+        wide={false}
+        onWideChange={onWideChange}>
+        <div id="debug-section">panel content</div>
+      </TestDesktopPanel>,
+    ))
+
+    const panel = container.querySelector<HTMLElement>(".desktop-panel-shell")
+    const button = container.querySelector<HTMLButtonElement>(".desktop-panel-orientation-toggle")
+    const width = container.querySelector<HTMLButtonElement>(".desktop-panel-width-toggle")
+    expect(panel?.classList.contains("desktop-panel-below")).toBe(true)
+    expect(width?.disabled).toBe(true)
+    expect(width?.getAttribute("aria-label")).toBe("Width control is available beside the emulator")
+    expect(button?.getAttribute("aria-pressed")).toBe("true")
+    expect(button?.getAttribute("aria-label")).toBe("Move side panel beside emulator")
+  })
+
+  it("collapses a below-panel layout vertically instead of leaving an empty row", () => {
+    act(() => root.render(
+      <TestDesktopPanel
+        below
+        expandedWidth={720}
+        height={600}
+        onBelowChange={jest.fn()}
+        wide={false}
+        onWideChange={onWideChange}>
+        <div id="debug-section">panel content</div>
+      </TestDesktopPanel>,
+    ))
+    const panel = container.querySelector<HTMLElement>(".desktop-panel-shell")
+    const collapse = container.querySelector<HTMLButtonElement>(".desktop-panel-collapse-toggle")
+    if (!panel || !collapse) throw new Error("Below-panel layout was not rendered")
+
+    act(() => collapse.click())
+
+    expect(panel.style.width).toBe("720px")
+    expect(panel.style.height).toBe("34px")
+  })
+})

--- a/src/ui/panels/desktoppanel.tsx
+++ b/src/ui/panels/desktoppanel.tsx
@@ -1,0 +1,128 @@
+import { CSSProperties, ReactNode, useLayoutEffect, useRef } from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+  faChevronDown,
+  faChevronLeft,
+  faChevronRight,
+  faChevronUp,
+} from "@fortawesome/free-solid-svg-icons"
+
+import { useTranslation } from "../../i18n/useTranslation"
+import { desktopLayoutPolicy } from "../layout"
+
+type DesktopPanelStyle = CSSProperties & {
+  "--desktop-bounded-panel-height": string,
+  "--desktop-panel-height": string,
+}
+
+const DesktopPanel = ({
+  children,
+  boundedHeight,
+  collapsed,
+  expandedWidth,
+  height,
+  below,
+  onBelowChange,
+  onCollapsedChange,
+  wide,
+  onWideChange,
+}: {
+  children: ReactNode,
+  boundedHeight: number,
+  collapsed: boolean,
+  expandedWidth: number,
+  height: number,
+  below: boolean,
+  onBelowChange: (below: boolean) => void,
+  onCollapsedChange: (collapsed: boolean) => void,
+  wide: boolean,
+  onWideChange: (wide: boolean) => void,
+}) => {
+  const { t } = useTranslation()
+  const panelRef = useRef<HTMLDivElement>(null)
+  const revealAfterMove = useRef(false)
+  const title = collapsed
+    ? t("controls.showSidePanel")
+    : t("controls.hideSidePanel")
+
+  useLayoutEffect(() => {
+    if (!revealAfterMove.current) return
+    revealAfterMove.current = false
+    const target = below
+      ? panelRef.current?.querySelector(".dbg-tab-row")
+      : panelRef.current
+    target?.scrollIntoView({
+      behavior: "auto",
+      block: "nearest",
+      inline: "nearest",
+    })
+  }, [below])
+
+  const handleOrientationChange = () => {
+    revealAfterMove.current = true
+    onBelowChange(!below)
+  }
+
+  return (
+    <div
+      ref={panelRef}
+      className={`desktop-tab-column desktop-panel-shell${collapsed ? " desktop-panel-collapsed" : ""}${below ? " desktop-panel-below" : ""}${wide && !below ? " desktop-panel-wide" : ""}`}
+      style={{
+        "--desktop-bounded-panel-height": `${boundedHeight}px`,
+        "--desktop-panel-height": `${height}px`,
+        height: collapsed ? desktopLayoutPolicy.collapsedPanelSize : boundedHeight,
+        width: collapsed && !below ? desktopLayoutPolicy.collapsedPanelSize : expandedWidth,
+      } as DesktopPanelStyle}>
+      <div className="desktop-panel-controls">
+        {!collapsed && <button
+          type="button"
+          className="desktop-panel-toggle desktop-panel-orientation-toggle"
+          aria-pressed={below}
+          aria-label={below
+            ? t("controls.moveSidePanelBeside")
+            : t("controls.moveSidePanelBelow")}
+          title={below
+            ? t("controls.moveSidePanelBeside")
+            : t("controls.moveSidePanelBelow")}
+          onClick={handleOrientationChange}>
+          <span className="desktop-panel-orientation-glyph" aria-hidden="true">↻</span>
+        </button>}
+        <button
+          type="button"
+          className="desktop-panel-toggle desktop-panel-collapse-toggle"
+          aria-controls="debug-section"
+          aria-expanded={!collapsed}
+          aria-label={title}
+          title={title}
+          onClick={() => onCollapsedChange(!collapsed)}>
+          <FontAwesomeIcon icon={below
+            ? (collapsed ? faChevronDown : faChevronUp)
+            : (collapsed ? faChevronRight : faChevronLeft)} />
+        </button>
+        {!collapsed && <button
+          type="button"
+          className="desktop-panel-toggle desktop-panel-width-toggle"
+          disabled={below}
+          aria-pressed={wide}
+          aria-label={below
+            ? t("controls.sidePanelWidthAvailableBeside")
+            : wide
+            ? t("controls.restoreSidePanelWidth")
+            : t("controls.widenSidePanel")}
+          title={below
+            ? t("controls.sidePanelWidthAvailableBeside")
+            : wide
+            ? t("controls.restoreSidePanelWidth")
+            : t("controls.widenSidePanel")}
+          onClick={() => onWideChange(!wide)}>
+          {wide ? "><" : "< >"}
+        </button>}
+      </div>
+      <div className="desktop-panel-body" hidden={collapsed}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default DesktopPanel

--- a/src/ui/panels/droplist.tsx
+++ b/src/ui/panels/droplist.tsx
@@ -53,7 +53,10 @@ export const Droplist = (props: DroplistProps) => {
       style={{
         visibility: "hidden",
         whiteSpace: "nowrap",
-        position: "absolute",
+        position: "fixed",
+        left: 0,
+        top: 0,
+        pointerEvents: "none",
         fontSize: "1rem", // Adjust this to match the font size of the select element
       }}
     />

--- a/src/ui/panels/expectin/editorview.tsx
+++ b/src/ui/panels/expectin/editorview.tsx
@@ -103,10 +103,7 @@ const CodeMirrorEditor = (props: EditorProps) => {
     }
   }, [])
 
-  return <div ref={editorRef} style={{
-    height: "760px", width: "687px",
-    overflowY: "hidden"
-  }} />
+  return <div ref={editorRef} className="expectin-editor" />
 }
 
 export default CodeMirrorEditor

--- a/src/ui/panels/expectin/expectintab.tsx
+++ b/src/ui/panels/expectin/expectintab.tsx
@@ -36,12 +36,12 @@ const ExpectinTab = () => {
   }
 
   return (
-    <div className="flex-column-gap debug-section">
+    <div className="flex-column-gap debug-section desktop-code-workspace">
       <CodeMirrorEditor value={expectinText} setValue={setExpectinText} />
-      <div className="flex-row-gap">
+      <div className="flex-row-gap desktop-code-controls">
         {expectinError === "" ?
           <button
-            className="dbg-expect-button"
+            className="push-button"
             title={expectinObject?.IsRunning() ? t("expectin.stopScript") : t("expectin.runScript")}
             onClick={handleExpectButtonClick}>{expectinObject?.IsRunning() ?
               <FontAwesomeIcon icon={faStop} /> :

--- a/src/ui/panels/help/defaulthelpcontent.test.tsx
+++ b/src/ui/panels/help/defaulthelpcontent.test.tsx
@@ -8,12 +8,14 @@ describe("DefaultHelpContent", () => {
       key === "help.exampleLinks.totalReplayDebugging" ? maliciousTranslation : key
     ))
 
-    const html = renderToStaticMarkup(<DefaultHelpContent t={t} />)
+    const html = renderToStaticMarkup(<DefaultHelpContent t={t} isTouchDevice={false} />)
 
     expect(html).toContain("&lt;a href=&quot;javascript:alert(1)&quot;&gt;owned&lt;/a&gt;")
     expect(html).not.toContain("href=\"javascript:")
     expect(html).toContain("href=\"https://apple2ts.com/?debug=on#Replay\"")
     expect(html).toContain("rel=\"noopener noreferrer\"")
+    expect(html).toContain("<strong>help.keyboardShortcuts</strong>")
+    expect(html).not.toContain("<b>")
   })
 
   it("explains unavailable shortcuts while the modifier controls Open Apple", () => {

--- a/src/ui/panels/help/defaulthelpcontent.tsx
+++ b/src/ui/panels/help/defaulthelpcontent.tsx
@@ -107,30 +107,32 @@ export const DefaultHelpContent = ({
     </HelpLink>
     {isTouchDevice ? "\n\n\n" : "\n\n"}
     {isTouchDevice ? <>
-      <b>{t("help.mobileInstructions")}</b>{"\n"}
+      <strong>{t("help.mobileInstructions")}</strong>{"\n"}
       {t("help.tapScreen")}{"\n"}
       {t("help.arrowKeys")}{"\n"}
       {t("help.ctrlKey")}{"\n"}
       {t("help.ctrlLock")}{"\n"}
       {t("help.appleKeys")}{"\n"}
     </> : <>
-      <b>{t("help.keyboardShortcuts")}</b>{"\n"}
+      <strong>{t("help.keyboardShortcuts")}</strong>{"\n"}
       {useOpenAppleKey
-        ? t("help.shortcutsUnavailable", { keyMod: shortcutKeyName })
-        : <>
+        ? <span key="shortcuts-unavailable" className="help-shortcuts-unavailable">
+          {t("help.shortcutsUnavailable", { keyMod: shortcutKeyName })}
+        </span>
+        : <span key="shortcuts-available" className="help-shortcuts-available">
           <ShortcutTable rows={shortcutRows} />
           {"\n"}{t("help.openAppleKey")}
           {"\n"}{t("help.closedAppleKey")}
           {"\n"}{t("help.joystickKeys")}
           {"\n\n"}{t("help.onScreenKeyboard")}
-        </>}{"\n"}
+        </span>}{"\n"}
     </>}
-    {"\n"}<b>{t("help.diskImages")}</b>{" "}hdv, 2mg, dsk, woz, po, do, bin, bas
-    {"\n\n"}<b>{t("help.urlParameters")}</b>{"\n"}
+    {"\n"}<strong>{t("help.diskImages")}</strong>{" "}hdv, 2mg, dsk, woz, po, do, bin, bas
+    {"\n\n"}<strong>{t("help.urlParameters")}</strong>{"\n"}
     {t("help.urlParametersBody")}
-    {"\n\n"}<b>{t("help.examples")}</b>{"\n"}
+    {"\n\n"}<strong>{t("help.examples")}</strong>{"\n"}
     <LinkList links={helpExamples} />
-    {"\n\n"}<b>{t("help.links")}</b>{"\n"}
+    {"\n\n"}<strong>{t("help.links")}</strong>{"\n"}
     <LinkList links={helpResources} />
   </>
 }

--- a/src/ui/panels/help/helppanel.css
+++ b/src/ui/panels/help/helppanel.css
@@ -104,9 +104,3 @@
   padding: 5px;
   color: #00FF00;
 }
-
-@media (max-width: 600px) {
-  .help-text {
-    font-size: 0.5em;
-  }
-}

--- a/src/ui/panels/help/helppanel.minimal.css
+++ b/src/ui/panels/help/helppanel.minimal.css
@@ -6,7 +6,7 @@
   box-sizing: content-box;
   margin: 0;
   padding: 0;
-  height: auto;
+  height: max-content;
   max-width: min(70vw, 687px);
   max-height: 70vh;
   overflow-x: hidden !important;
@@ -16,7 +16,10 @@
 .help-paper {
   position: relative;
   width: 100%;
-  height: 100%;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  height: max-content;
+  min-height: 100%;
   background-color: #f0f0f0;
   background-image:
     repeating-linear-gradient(to bottom,
@@ -50,12 +53,12 @@
 }
 
 .help-text-light {
-  margin-left: 0;
+  margin-left: 40px;
   margin-top: 0px;
   margin-bottom: 0px;
   padding-top: 10px;
   padding-bottom: 10px;
-  padding-left: 10px;
+  padding-left: 20px;
   border-left: 1px solid #d8e6e1;
   color: var(--text-color);
 }

--- a/src/ui/panels/help/helptab.test.tsx
+++ b/src/ui/panels/help/helptab.test.tsx
@@ -1,0 +1,146 @@
+import { act } from "react"
+import { createRoot, Root } from "react-dom/client"
+import { UI_THEME } from "../../../common/utility"
+import HelpTab from "./helptab"
+
+jest.mock("./helppanel.css", () => ({}))
+
+jest.mock("../../../i18n/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock("../../ui_settings", () => ({
+  isMinimalTheme: () => false,
+}))
+
+const setViewport = (width: number, height: number) => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width })
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: height })
+}
+
+const reactEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean,
+}
+
+describe("HelpTab", () => {
+  let container: HTMLDivElement
+  let root: Root
+  let touchStartOwner: object | null
+  let touchStartDescriptor: PropertyDescriptor | undefined
+  let innerWidthDescriptor: PropertyDescriptor | undefined
+  let innerHeightDescriptor: PropertyDescriptor | undefined
+  let rectSpy: jest.SpyInstance
+  let previousActEnvironment: boolean | undefined
+
+  beforeEach(() => {
+    previousActEnvironment = reactEnvironment.IS_REACT_ACT_ENVIRONMENT
+    reactEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    touchStartOwner = document.documentElement
+    while (touchStartOwner && !Object.prototype.hasOwnProperty.call(touchStartOwner, "ontouchstart")) {
+      touchStartOwner = Object.getPrototypeOf(touchStartOwner) as object | null
+    }
+    touchStartDescriptor = touchStartOwner
+      ? Object.getOwnPropertyDescriptor(touchStartOwner, "ontouchstart")
+      : undefined
+    if (touchStartOwner && touchStartDescriptor?.configurable) {
+      delete (touchStartOwner as { ontouchstart?: unknown }).ontouchstart
+    }
+    innerWidthDescriptor = Object.getOwnPropertyDescriptor(window, "innerWidth")
+    innerHeightDescriptor = Object.getOwnPropertyDescriptor(window, "innerHeight")
+    rectSpy = jest.spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        const isHelp = this.classList.contains("help-parent")
+        const top = isHelp ? (this.style.height ? 80 : 900) : 0
+        const height = this.classList.contains("flyout-button") ? 30 : 0
+        return {
+          x: 0, y: top, top, left: 0, right: 0,
+          bottom: top + height, width: 0, height,
+          toJSON: () => ({}),
+        }
+      })
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    if (touchStartOwner && touchStartDescriptor) {
+      Object.defineProperty(touchStartOwner, "ontouchstart", touchStartDescriptor)
+    }
+    if (innerWidthDescriptor) {
+      Object.defineProperty(window, "innerWidth", innerWidthDescriptor)
+    }
+    if (innerHeightDescriptor) {
+      Object.defineProperty(window, "innerHeight", innerHeightDescriptor)
+    }
+    rectSpy.mockRestore()
+    reactEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
+  })
+
+  const renderHelp = (useOpenAppleKey: boolean, narrow = false) => {
+    root.render(
+      <div className="flyout">
+        <HelpTab
+          helptext="<Default>"
+          narrow={narrow}
+          theme={UI_THEME.CLASSIC}
+          useOpenAppleKey={useOpenAppleKey}
+        />
+        <div className="flyout-button" />
+      </div>
+    )
+  }
+
+  it("updates its layout when the viewport changes", () => {
+    setViewport(1200, 800)
+    act(() => {
+      renderHelp(false)
+    })
+
+    const help = container.querySelector<HTMLElement>(".help-parent")
+    expect(help?.style.width).toBe("500px")
+    expect(help?.style.height).toBe("686px")
+    expect(help?.style.overflow).toBe("auto")
+
+    setViewport(700, 900)
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+      renderHelp(false, true)
+    })
+
+    expect(help?.style.width).toBe("500px")
+    expect(help?.style.height).toBe("")
+    expect(help?.style.overflow).toBe("visible")
+
+    setViewport(1200, 800)
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+      renderHelp(false)
+    })
+
+    expect(help?.style.width).toBe("500px")
+    expect(help?.style.height).toBe("686px")
+    expect(help?.style.overflow).toBe("auto")
+  })
+
+  it("replaces the complete shortcut mode when the Open Apple setting changes", () => {
+    setViewport(1200, 800)
+    act(() => {
+      renderHelp(true)
+    })
+
+    const unavailable = container.querySelector(".help-shortcuts-unavailable")
+    unavailable?.append(document.createTextNode("stale translated text"))
+
+    act(() => {
+      renderHelp(false)
+    })
+
+    expect(container.textContent).not.toContain("stale translated text")
+    expect(container.querySelector(".help-shortcuts-unavailable")).toBeNull()
+    expect(container.querySelector(".help-shortcuts-available")).not.toBeNull()
+    expect(container.querySelector(".help-parent")?.getAttribute("translate")).toBe("no")
+  })
+})

--- a/src/ui/panels/help/helptab.test.tsx
+++ b/src/ui/panels/help/helptab.test.tsx
@@ -79,10 +79,11 @@ describe("HelpTab", () => {
     reactEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
   })
 
-  const renderHelp = (useOpenAppleKey: boolean, narrow = false) => {
+  const renderHelp = (useOpenAppleKey: boolean, narrow = false, desktop = false) => {
     root.render(
       <div className="flyout">
         <HelpTab
+          desktop={desktop}
           helptext="<Default>"
           narrow={narrow}
           theme={UI_THEME.CLASSIC}
@@ -92,6 +93,18 @@ describe("HelpTab", () => {
       </div>
     )
   }
+
+  it("lets the desktop shell own its width and vertical flow", () => {
+    setViewport(1200, 800)
+    act(() => {
+      renderHelp(false, false, true)
+    })
+
+    const help = container.querySelector<HTMLElement>(".help-parent")
+    expect(help?.style.width).toBe("100%")
+    expect(help?.style.height).toBe("")
+    expect(help?.style.overflow).toBe("visible")
+  })
 
   it("updates its layout when the viewport changes", () => {
     setViewport(1200, 800)

--- a/src/ui/panels/help/helptab.tsx
+++ b/src/ui/panels/help/helptab.tsx
@@ -8,32 +8,50 @@ import { isDefaultHelp } from "./helpselection"
 
 type HelpPanelProps = {
   helptext: string,
+  narrow: boolean,
   theme: UI_THEME,
   useOpenAppleKey: boolean,
 }
 
+const getViewportHeight = () => window.innerHeight || window.outerHeight - 120
+
+const getPaperHeight = (help: HTMLElement | null, viewportHeight: number) => {
+  const helpTop = help?.getBoundingClientRect().top ?? 0
+  const flyoutButton = help?.closest(".flyout")?.querySelector<HTMLElement>(".flyout-button")
+  const buttonHeight = flyoutButton?.getBoundingClientRect().height ?? 0
+  return Math.max(0, Math.floor(viewportHeight - helpTop - buttonHeight - 4))
+}
+
 const HelpTab = React.memo((props: HelpPanelProps) => {
   const { t } = useTranslation()
-  const paperheight = window.innerHeight ? window.innerHeight - 170 : (window.outerHeight - 170)
+  const [paperHeight, setPaperHeight] = React.useState(() => getViewportHeight() - 170)
+  const helpRef = React.useRef<HTMLDivElement>(null)
   const isDarkMode = props.theme == UI_THEME.DARK
+  const minimalTheme = isMinimalTheme()
 
-  if (isMinimalTheme()) {
+  if (minimalTheme) {
     import("./helppanel.minimal.css")
   }
 
+  React.useLayoutEffect(() => {
+    const handleResize = () => {
+      setPaperHeight(getPaperHeight(helpRef.current, getViewportHeight()))
+    }
+    handleResize()
+    window.addEventListener("resize", handleResize)
+    return () => window.removeEventListener("resize", handleResize)
+  }, [props.narrow])
+
   const isTouchDevice = "ontouchstart" in document.documentElement
-  const height = window.innerHeight ? window.innerHeight : (window.outerHeight - 120)
-  const width = window.innerWidth ? window.innerWidth : (window.outerWidth - 20)
-  const narrow = isTouchDevice || (width < height)
   const helpClassName = "help-text " + (isDarkMode ? "help-text-dark" : "help-text-light")
   const showDefaultHelp = isDefaultHelp(props.helptext)
 
   return (
-    <div className="help-parent"
+    <div ref={helpRef} className="help-parent" translate="no"
       style={{
-        width: narrow || isMinimalTheme() ? "687px" : 500,
-        height: narrow || isMinimalTheme() ? "" : paperheight,
-        overflow: (narrow ? "visible" : "auto")
+        width: minimalTheme ? "687px" : 500,
+        height: props.narrow || minimalTheme ? "" : paperHeight,
+        overflow: (props.narrow ? "visible" : "auto")
       }}>
       <div className={isDarkMode ? "" : "help-paper"}>
         {showDefaultHelp
@@ -51,6 +69,7 @@ const HelpTab = React.memo((props: HelpPanelProps) => {
 }, (prevProps, nextProps) => {
   return prevProps.helptext === nextProps.helptext
     && prevProps.theme === nextProps.theme
+    && prevProps.narrow === nextProps.narrow
     && prevProps.useOpenAppleKey === nextProps.useOpenAppleKey
 })
 

--- a/src/ui/panels/help/helptab.tsx
+++ b/src/ui/panels/help/helptab.tsx
@@ -7,6 +7,7 @@ import { DefaultHelpContent } from "./defaulthelpcontent"
 import { isDefaultHelp } from "./helpselection"
 
 type HelpPanelProps = {
+  desktop?: boolean,
   helptext: string,
   narrow: boolean,
   theme: UI_THEME,
@@ -34,13 +35,14 @@ const HelpTab = React.memo((props: HelpPanelProps) => {
   }
 
   React.useLayoutEffect(() => {
+    if (props.desktop) return
     const handleResize = () => {
       setPaperHeight(getPaperHeight(helpRef.current, getViewportHeight()))
     }
     handleResize()
     window.addEventListener("resize", handleResize)
     return () => window.removeEventListener("resize", handleResize)
-  }, [props.narrow])
+  }, [props.desktop, props.narrow])
 
   const isTouchDevice = "ontouchstart" in document.documentElement
   const helpClassName = "help-text " + (isDarkMode ? "help-text-dark" : "help-text-light")
@@ -49,9 +51,9 @@ const HelpTab = React.memo((props: HelpPanelProps) => {
   return (
     <div ref={helpRef} className="help-parent" translate="no"
       style={{
-        width: minimalTheme ? "687px" : 500,
-        height: props.narrow || minimalTheme ? "" : paperHeight,
-        overflow: (props.narrow ? "visible" : "auto")
+        width: props.desktop ? "100%" : (minimalTheme ? "687px" : 500),
+        height: props.desktop || props.narrow || minimalTheme ? "" : paperHeight,
+        overflow: (props.desktop || props.narrow ? "visible" : "auto")
       }}>
       <div className={isDarkMode ? "" : "help-paper"}>
         {showDefaultHelp
@@ -70,6 +72,7 @@ const HelpTab = React.memo((props: HelpPanelProps) => {
   return prevProps.helptext === nextProps.helptext
     && prevProps.theme === nextProps.theme
     && prevProps.narrow === nextProps.narrow
+    && prevProps.desktop === nextProps.desktop
     && prevProps.useOpenAppleKey === nextProps.useOpenAppleKey
 })
 

--- a/src/ui/panels/memory/memorydump.tsx
+++ b/src/ui/panels/memory/memorydump.tsx
@@ -38,6 +38,21 @@ const MemoryDump = () => {
   const [highAscii, setHighAscii] = useState(false)
   const previousMemLengthRef = useRef(0)
 
+  useEffect(() => {
+    switch (memoryRange) {
+      case MEMORY_RANGE.HGR1:
+        overrideHires(true, false)
+        break
+      case MEMORY_RANGE.HGR2:
+        overrideHires(true, true)
+        break
+      default:
+        overrideHires(false, false)
+        break
+    }
+    return () => overrideHires(false, false)
+  }, [memoryRange])
+
   const doSetScrollRow = (row: number) => {
     setScrollRow(row)
     // Turn off our new scroll position after a brief moment. Otherwise the
@@ -239,17 +254,6 @@ const MemoryDump = () => {
   const handleSetMemoryRange = (value: string) => {
     setAddress("")
     setMemoryRange(value)
-    switch (value) {
-      case MEMORY_RANGE.HGR1:
-        overrideHires(true, false)
-        break
-      case MEMORY_RANGE.HGR2:
-        overrideHires(true, true)
-        break
-      default:
-        overrideHires(false, false)
-        break
-    }
   }
 
   const doPickWatchpoint = (addr: number) => {

--- a/src/ui/panels/panels.css
+++ b/src/ui/panels/panels.css
@@ -279,6 +279,18 @@ body.dark-mode .droplist-edit:disabled {
   user-select: none;
 }
 
+.popup-item-main {
+  align-items: center;
+  display: flex;
+  min-width: 0;
+}
+
+.popup-selection-marker {
+  display: inline-flex;
+  flex: 0 0 1.25em;
+  justify-content: center;
+}
+
 body.dark-mode .droplist-option {
   background-color: var(--input-background-dark);
   color: var(--text-color-dark);

--- a/src/ui/panels/panels.css
+++ b/src/ui/panels/panels.css
@@ -608,7 +608,14 @@ body.dark-mode .icon-text {
 
 .dbg-tab-active {
   background-color: var(--button-active);
-  border-bottom-style: none;
+}
+
+.dbg-tab-horizontal.dbg-tab-active {
+  border-bottom-color: transparent;
+}
+
+.dbg-tab-vertical.dbg-tab-active {
+  border-right-color: transparent;
 }
 
 .dbg-tab-horizontal {
@@ -638,22 +645,6 @@ body.dark-mode .icon-text {
   white-space: nowrap;
 }
 
-.dbg-expect-button {
-  width: 96px;
-  height: 32px;
-  margin-top: 6px;
-  font-size: 12pt;
-  color: black;
-  padding: 4px;
-  border-radius: 8px;
-  border: 1px solid black;
-  cursor: pointer;
-}
-
-.dbg-expect-button:hover {
-  background-color: gray;
-}
-
 .cm-tooltip-autocomplete {
   border: 1px solid var(--background-color) !important;
 }
@@ -680,6 +671,38 @@ body.dark-mode .basic-vars-field {
   background-color: var(--input-background-dark);
   border-color: var(--text-color-dark);
   color: var(--text-color-dark);
+}
+
+.basic-editor {
+  height: 560px;
+  overflow: hidden;
+  width: min(687px, 100%);
+}
+
+.expectin-editor {
+  height: 760px;
+  overflow: hidden;
+  width: min(687px, 100%);
+}
+
+.basic-variables-pane {
+  max-height: none;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.basic-variables-toggle {
+  margin-left: auto;
+}
+
+.basic-variables-toggle-icon {
+  display: inline-block;
+  position: relative;
+}
+
+.basic-variables-toggle-slash {
+  inset: 0;
+  position: absolute;
 }
 
 .link-builder-textarea {

--- a/src/ui/panels/panels.tsx
+++ b/src/ui/panels/panels.tsx
@@ -16,7 +16,12 @@ import VeraTab from "./vera/veratab"
 import { setPreferenceBoolean } from "../localstorage"
 import { isDefaultHelp } from "./help/helpselection"
 
-const DebugSection = (props: { updateDisplay: UpdateDisplay, narrow: boolean }) => {
+const DebugSection = (props: {
+  desktop?: boolean,
+  horizontalTabs?: boolean,
+  narrow: boolean,
+  updateDisplay: UpdateDisplay,
+}) => {
 
   const [activeTab, setActiveTab] = useState<number>(getTabView())
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
@@ -41,7 +46,9 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay, narrow: boolean }) 
     }
     setActiveTab(tabIndex)
     event.stopPropagation()
-    forceRefresh()
+    if (!props.desktop) {
+      forceRefresh()
+    }
     if (tabIndex == 1) {
       setPreferenceBoolean("debugMode", true)
       passSetDebug(true)
@@ -61,10 +68,39 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay, narrow: boolean }) 
   }
 
   useEffect(() => {
-    forceRefresh()
-  }, [isFlyoutOpen])
+    if (!props.desktop) {
+      forceRefresh()
+    }
+  }, [isFlyoutOpen, props.desktop])
 
-  const tabClass = props.narrow ? "dbg-tab-horizontal" : "dbg-tab-vertical"
+  const horizontalTabs = props.narrow || props.horizontalTabs
+  const tabClass = horizontalTabs ? "dbg-tab-horizontal" : "dbg-tab-vertical"
+
+  const panelContent = <>
+    {(activeTab == 1 && !isSmall) &&
+      <DebugTab updateDisplay={props.updateDisplay} />
+    }
+    {(activeTab == 2 && !isSmall) &&
+      <BasicTab updateDisplay={props.updateDisplay} />
+    }
+    {(activeTab == 3 && !isSmall) &&
+      <ExpectinTab />
+    }
+    {(activeTab == 4 && !isSmall) &&
+      <VeraTab />
+    }
+    {(activeTab == 5 && !isSmall) &&
+      <AgentTab />
+    }
+  </>
+
+  const helpPanel = <HelpTab
+    desktop={props.desktop}
+    helptext={getHelpText()}
+    narrow={props.narrow}
+    theme={getTheme()}
+    useOpenAppleKey={getUIStateBoolean("useOpenAppleKey")}
+  />
 
   return (
     <Flyout
@@ -77,8 +113,8 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay, narrow: boolean }) 
         setIsFlyoutOpen(!isFlyoutOpen)
         props.updateDisplay()
       }}>
-      <div id="debug-section" className={`${props.narrow ? "flex-column" : "flex-row"}`}>
-        {!isSmall && <div className={`${props.narrow ? "flex-row" : "flex-column"} dbg-tab-row`}>
+      <div id="debug-section" className={`${horizontalTabs ? "flex-column" : "flex-row"}`}>
+        {!isSmall && <div className={`${horizontalTabs ? "flex-row" : "flex-column"} dbg-tab-row`}>
           <div
             className={`dbg-tab ${tabClass} ${activeTab == 0 ? " dbg-tab-active" : ""}`}
             title={t("debug.helpTab")}
@@ -118,29 +154,12 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay, narrow: boolean }) 
           </div>
         </div>
         }
-        {(activeTab == 0 || isSmall) &&
-          <HelpTab
-            helptext={getHelpText()}
-            narrow={props.narrow}
-            theme={getTheme()}
-            useOpenAppleKey={getUIStateBoolean("useOpenAppleKey")}
-          />
-        }
-        {(activeTab == 1 && !isSmall) &&
-          <DebugTab updateDisplay={props.updateDisplay} />
-        }
-        {(activeTab == 2 && !isSmall) && 
-          <BasicTab updateDisplay={props.updateDisplay} />
-        }
-        {(activeTab == 3 && !isSmall) && 
-          <ExpectinTab />
-        }
-        {(activeTab == 4 && !isSmall) && 
-          <VeraTab />
-        }
-        {(activeTab == 5 && !isSmall) && 
-          <AgentTab />
-        }
+        {(activeTab == 0 || isSmall) && (props.desktop
+          ? <div className="desktop-panel-content">{helpPanel}</div>
+          : helpPanel)}
+        {activeTab > 0 && (props.desktop
+          ? <div className={`desktop-panel-content${activeTab == 1 ? " desktop-panel-content-debug" : ""}`}>{panelContent}</div>
+          : panelContent)}
       </div>
     </Flyout>
   )

--- a/src/ui/panels/panels.tsx
+++ b/src/ui/panels/panels.tsx
@@ -113,7 +113,7 @@ const DebugSection = (props: {
         setIsFlyoutOpen(!isFlyoutOpen)
         props.updateDisplay()
       }}>
-      <div id="debug-section" className={`${horizontalTabs ? "flex-column" : "flex-row"}`}>
+      <div id="debug-section" className={`${horizontalTabs ? "flex-column debug-section-horizontal" : "flex-row"}`}>
         {!isSmall && <div className={`${horizontalTabs ? "flex-row" : "flex-column"} dbg-tab-row`}>
           <div
             className={`dbg-tab ${tabClass} ${activeTab == 0 ? " dbg-tab-active" : ""}`}

--- a/src/ui/panels/panels.tsx
+++ b/src/ui/panels/panels.tsx
@@ -121,6 +121,7 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay, narrow: boolean }) 
         {(activeTab == 0 || isSmall) &&
           <HelpTab
             helptext={getHelpText()}
+            narrow={props.narrow}
             theme={getTheme()}
             useOpenAppleKey={getUIStateBoolean("useOpenAppleKey")}
           />

--- a/src/ui/panels/state6502controls.tsx
+++ b/src/ui/panels/state6502controls.tsx
@@ -80,16 +80,6 @@ const State6502Controls = () => {
       </div>
       <div className="flex-row" style={{ alignItems: "center" }}>
         <div className="flex-row">
-          {createCheckbox("N", 7, s6502.PStatus, runMode)}
-          {createCheckbox("V", 6, s6502.PStatus, runMode)}
-          {createCheckbox("B", 4, s6502.PStatus, runMode)}
-          {createCheckbox("D", 3, s6502.PStatus, runMode)}
-          {createCheckbox("I", 2, s6502.PStatus, runMode)}
-          {createCheckbox("Z", 1, s6502.PStatus, runMode)}
-          {createCheckbox("C", 0, s6502.PStatus, runMode)}
-          {createCheckbox("NMI", 0, s6502.flagNMI ? 1 : 0, runMode)}
-        </div>
-        <div className="flex-row" style={{ marginLeft: "1em" }}>
           <span className="bigger-font">Cycles:</span>
           <span className="bigger-monospace"
             style={{ marginLeft: "2pt", marginRight: "2pt", marginTop: "1pt" }}> {s6502.cycleCount}</span>
@@ -98,6 +88,16 @@ const State6502Controls = () => {
             onClick={() => { passSetCycleCount(0) }}>
             <FontAwesomeIcon icon={faSync} style={{ fontSize: "0.7em" }}/>
           </button>
+        </div>
+        <div className="flex-row" style={{ marginLeft: "1em" }}>
+          {createCheckbox("N", 7, s6502.PStatus, runMode)}
+          {createCheckbox("V", 6, s6502.PStatus, runMode)}
+          {createCheckbox("B", 4, s6502.PStatus, runMode)}
+          {createCheckbox("D", 3, s6502.PStatus, runMode)}
+          {createCheckbox("I", 2, s6502.PStatus, runMode)}
+          {createCheckbox("Z", 1, s6502.PStatus, runMode)}
+          {createCheckbox("C", 0, s6502.PStatus, runMode)}
+          {createCheckbox("NMI", 0, s6502.flagNMI ? 1 : 0, runMode)}
         </div>
       </div>
     </div>

--- a/src/ui/panels/vera/veratab.tsx
+++ b/src/ui/panels/vera/veratab.tsx
@@ -36,13 +36,14 @@ const VeraTab = () => {
   }, [])
 
   return (
-    <div className="flex-column-gap debug-section" style={{ display: "flex", height: "100%", width: "calc(50vw - 40px)" }}>
+    <div className="flex-column-gap debug-section vera-panel">
       <div style={{ flex: 1, display: "flex", justifyContent: "flex-start", alignItems: "flex-start", paddingTop: "20px" }}>
         <canvas 
           ref={canvasRef} 
           width={640} 
           height={480} 
           style={{ 
+            boxSizing: "border-box",
             width: "100%", 
             objectFit: "contain",
             backgroundColor: "#000",

--- a/src/ui/viewport.test.ts
+++ b/src/ui/viewport.test.ts
@@ -1,0 +1,32 @@
+import { subscribeViewportResize } from "./viewport"
+
+describe("subscribeViewportResize", () => {
+  const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+
+  afterEach(() => {
+    if (originalVisualViewport) {
+      Object.defineProperty(window, "visualViewport", originalVisualViewport)
+    } else {
+      delete (window as { visualViewport?: VisualViewport }).visualViewport
+    }
+  })
+
+  it("observes and cleans up window and visual viewport resizes", () => {
+    const visualViewport = new EventTarget()
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    })
+    const listener = jest.fn()
+    const unsubscribe = subscribeViewportResize(listener)
+
+    window.dispatchEvent(new Event("resize"))
+    visualViewport.dispatchEvent(new Event("resize"))
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    unsubscribe()
+    window.dispatchEvent(new Event("resize"))
+    visualViewport.dispatchEvent(new Event("resize"))
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/ui/viewport.ts
+++ b/src/ui/viewport.ts
@@ -1,0 +1,9 @@
+export const subscribeViewportResize = (listener: () => void) => {
+  window.addEventListener("resize", listener)
+  window.visualViewport?.addEventListener("resize", listener)
+
+  return () => {
+    window.removeEventListener("resize", listener)
+    window.visualViewport?.removeEventListener("resize", listener)
+  }
+}

--- a/tests/ui-layout/desktop-layout.spec.ts
+++ b/tests/ui-layout/desktop-layout.spec.ts
@@ -1,0 +1,1049 @@
+import { expect, test as base } from "@playwright/test"
+import type { Locator, Page, TestInfo } from "@playwright/test"
+
+type Rectangle = {
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  right: number,
+  bottom: number,
+}
+
+type LayoutFixtures = {
+  browserFailures: string[],
+}
+
+const test = base.extend<LayoutFixtures>({
+  browserFailures: [async ({ page }, provideFixture) => {
+    const failures: string[] = []
+    page.on("console", message => {
+      if (message.type() === "error") failures.push(`console: ${message.text()}`)
+    })
+    page.on("pageerror", error => failures.push(`page: ${error.message}`))
+    await provideFixture(failures)
+  }, { auto: true }],
+})
+
+test.afterEach(async ({ browserFailures }, testInfo) => {
+  await testInfo.attach("browser-failures.json", {
+    body: Buffer.from(JSON.stringify(browserFailures, null, 2)),
+    contentType: "application/json",
+  })
+  expect(browserFailures).toEqual([])
+})
+
+const rectangle = async (locator: Locator): Promise<Rectangle> => {
+  const box = await locator.boundingBox()
+  expect(box).not.toBeNull()
+  return {
+    ...box!,
+    right: box!.x + box!.width,
+    bottom: box!.y + box!.height,
+  }
+}
+
+const descendantBottomOffset = async (container: Locator, selector: string) => (
+  container.evaluate((element, childSelector) => {
+    const child = element.querySelector(childSelector)
+    if (!(child instanceof HTMLElement)) {
+      throw new Error(`Missing descendant ${childSelector}`)
+    }
+    const containerBox = element.getBoundingClientRect()
+    return child.getBoundingClientRect().bottom - containerBox.top
+  }, selector)
+)
+
+const exposedPoint = async (locator: Locator) => locator.evaluate(element => {
+  const box = element.getBoundingClientRect()
+  const inset = Math.min(4, box.width / 4, box.height / 4)
+  const candidates = [
+    [box.left + box.width / 2, box.top + box.height / 2],
+    [box.left + inset, box.top + inset],
+    [box.right - inset, box.top + inset],
+    [box.left + inset, box.bottom - inset],
+    [box.right - inset, box.bottom - inset],
+  ]
+  const point = candidates.find(([x, y]) => {
+    const target = document.elementFromPoint(x, y)
+    return target === element || (target !== null && element.contains(target))
+  })
+  if (!point) throw new Error("Control has no exposed pointer target")
+  return { x: point[0], y: point[1] }
+})
+
+const attachGeometry = async (testInfo: TestInfo, value: unknown) => {
+  await testInfo.attach("geometry.json", {
+    body: Buffer.from(JSON.stringify(value, null, 2)),
+    contentType: "application/json",
+  })
+}
+
+const expectAligned = (actual: number, expected: number, message?: string) => {
+  expect(Math.abs(actual - expected), message).toBeLessThanOrEqual(1)
+}
+
+const settleLayout = async (page: Page) => {
+  await page.evaluate(async () => {
+    await document.fonts.ready
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+  })
+}
+
+const openDesktop = async (
+  page: Page,
+  viewport = { width: 1800, height: 800 },
+) => {
+  await page.setViewportSize(viewport)
+  await page.goto("/?color=white")
+  await expect(page.locator(".desktop-emulator-layout")).toBeVisible()
+  await expect(page.locator("html")).toHaveAttribute("lang", "en")
+  await expect(page.locator(".desktop-panel-orientation-toggle"))
+    .toHaveAttribute("aria-pressed", "false")
+  await expect(page.locator(".desktop-panel-collapse-toggle"))
+    .toHaveAttribute("aria-expanded", "true")
+  await expect(page.locator(".desktop-panel-width-toggle"))
+    .toHaveAttribute("aria-pressed", "false")
+  await settleLayout(page)
+}
+
+const selectTab = async (page: Page, title: string) => {
+  const tab = page.locator(`.dbg-tab[title="${title}"]`)
+  await tab.click()
+  await expect(tab).toHaveClass(/dbg-tab-active/)
+}
+
+const selectTouchTabAndWaitForResize = async (page: Page, title: string) => {
+  await page.evaluate(() => {
+    const testWindow = window as Window & { touchTabResizeObserved?: boolean }
+    testWindow.touchTabResizeObserved = false
+    window.addEventListener("resize", () => {
+      testWindow.touchTabResizeObserved = true
+    }, { once: true })
+  })
+  await selectTab(page, title)
+  await expect.poll(() => page.evaluate(() => (
+    (window as Window & { touchTabResizeObserved?: boolean }).touchTabResizeObserved
+  ))).toBe(true)
+  await settleLayout(page)
+}
+
+test("pins the monitor while Debugger tabs and layout controls scroll together", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 608 })
+  await selectTab(page, "Debugging")
+
+  const monitor = page.locator(".desktop-primary-sticky")
+  const tabs = page.locator(".dbg-tab-row")
+  const controls = page.locator(".desktop-panel-controls")
+  const before = {
+    monitor: await rectangle(monitor),
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+  }
+
+  await page.locator(".desktop-panel-content-debug").hover()
+  await page.mouse.wheel(0, 2_000)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+
+  const after = {
+    scrollY: await page.evaluate(() => window.scrollY),
+    monitor: await rectangle(monitor),
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+  }
+  expectAligned(after.monitor.y, before.monitor.y)
+  expect(after.tabs.y).toBeLessThan(before.tabs.y)
+  expect(after.controls.y).toBeLessThan(before.controls.y)
+  expect(await page.evaluate(() => document.documentElement.scrollWidth))
+    .toBeLessThanOrEqual(await page.evaluate(() => window.innerWidth))
+  await page.locator(".desktop-panel-collapse-toggle").click()
+  const collapsedBefore = await rectangle(page.locator(".desktop-panel-collapse-toggle"))
+  await page.mouse.wheel(0, 2_000)
+  await settleLayout(page)
+  const collapsedAfter = await rectangle(page.locator(".desktop-panel-collapse-toggle"))
+  expectAligned(collapsedAfter.y, collapsedBefore.y)
+  await attachGeometry(testInfo, { before, after, collapsedBefore, collapsedAfter })
+})
+
+test("keeps ordinary wide panels pinned without making their content scroll", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 608 })
+  await page.locator(".desktop-panel-width-toggle").click()
+  const shell = page.locator(".desktop-panel-shell")
+  const tabs = page.locator(".dbg-tab-row")
+  const before = {
+    shell: await rectangle(shell),
+    tabs: await rectangle(tabs),
+  }
+
+  await page.locator(".desktop-panel-content").hover()
+  await page.mouse.wheel(0, 2_000)
+  await settleLayout(page)
+  const after = {
+    scrollY: await page.evaluate(() => window.scrollY),
+    shell: await rectangle(shell),
+    tabs: await rectangle(tabs),
+  }
+  expect(after.scrollY).toBe(0)
+  expectAligned(after.shell.y, before.shell.y)
+  expectAligned(after.tabs.y, before.tabs.y)
+  await attachGeometry(testInfo, { before, after })
+})
+
+test("keeps status and device controls usable beside the emulator controls", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 608 })
+  const layoutToggles = page.locator(".desktop-panel-toggle")
+  await expect(layoutToggles).toHaveCount(3)
+  const toggleBoxes = await layoutToggles.evaluateAll(elements => elements.map(element => {
+    const rect = element.getBoundingClientRect()
+    return { height: rect.height, width: rect.width }
+  }))
+  expect(new Set(toggleBoxes.map(box => `${box.width}x${box.height}`)).size).toBe(1)
+  const controlStrip = await rectangle(page.locator(".desktop-control-strip").first())
+  const controls = await rectangle(page.locator(".control-panel-two-rows"))
+  const deviceStrip = await rectangle(page.locator(".desktop-device-strip"))
+  const diskStrip = await rectangle(page.locator(".desktop-disk-strip"))
+  const disks = await rectangle(page.locator(".disk-interface-single-row"))
+  const status = await rectangle(page.locator(".desktop-status-strip"))
+  const diskOverflow = await page.locator(".desktop-disk-strip").evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }))
+  const statusOverflow = await page.locator(".desktop-status-strip").evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }))
+  expectAligned(status.y, controlStrip.y)
+  expectAligned(deviceStrip.y, controlStrip.bottom)
+  expectAligned(
+    deviceStrip.bottom,
+    await page.evaluate(() => window.innerHeight - 10),
+  )
+  expectAligned(
+    disks.bottom,
+    await page.evaluate(() => window.innerHeight - 10),
+  )
+  expect(disks.y - controls.bottom).toBeGreaterThanOrEqual(0)
+  const statusLines = page.locator(".desktop-status-strip .footer-item > div")
+  expect(await statusLines.count()).toBeGreaterThan(0)
+  const statusLineRectangles = await statusLines.evaluateAll(elements => elements.map(element => {
+    const rect = element.getBoundingClientRect()
+    return { bottom: rect.bottom, left: rect.left, right: rect.right, top: rect.top }
+  }))
+  for (const line of statusLineRectangles) {
+    expect(line.left).toBeGreaterThanOrEqual(status.x)
+    expect(line.right).toBeLessThanOrEqual(status.right)
+    expect(line.top).toBeGreaterThanOrEqual(status.y)
+    expect(line.bottom).toBeLessThanOrEqual(status.bottom)
+  }
+  expect(
+    diskOverflow.scrollWidth,
+    `device row requires ${diskOverflow.scrollWidth}px but has ${diskOverflow.clientWidth}px`,
+  ).toBeLessThanOrEqual(diskOverflow.clientWidth)
+  expect(statusOverflow.scrollWidth).toBeLessThanOrEqual(statusOverflow.clientWidth)
+  const pageHeight = await page.evaluate(() => ({
+    body: document.body.getBoundingClientRect().height,
+    canvas: document.querySelector("#apple2canvas")?.getBoundingClientRect().height,
+    controls: document.querySelector(".desktop-controls-and-status")?.getBoundingClientRect().height,
+    devices: document.querySelector(".desktop-device-strip")?.getBoundingClientRect().height,
+    document: document.documentElement.scrollHeight,
+    layout: document.querySelector(".desktop-emulator-layout")?.getBoundingClientRect().height,
+    primary: document.querySelector(".desktop-primary-sticky")?.getBoundingClientRect().height,
+    viewport: window.innerHeight,
+  }))
+  expect(pageHeight.document, JSON.stringify(pageHeight))
+    .toBeLessThanOrEqual(pageHeight.viewport)
+  await page.mouse.wheel(0, 2_000)
+  expect(await page.evaluate(() => window.scrollY)).toBe(0)
+
+  await openDesktop(page, { width: 900, height: 800 })
+  const narrowDiskOverflow = await page.locator(".desktop-disk-strip").evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }))
+  expect(
+    narrowDiskOverflow.scrollWidth,
+    `narrow device row requires ${narrowDiskOverflow.scrollWidth}px but has ${narrowDiskOverflow.clientWidth}px`,
+  ).toBeLessThanOrEqual(narrowDiskOverflow.clientWidth)
+  await page.locator(".desktop-disk-strip img[alt=disks]").click()
+  const overlay = await rectangle(page.locator(".desktop-disk-strip .modal-overlay"))
+  const dialog = await rectangle(page.locator(".desktop-disk-strip .floating-dialog"))
+  const narrowViewport = await page.evaluate(() => ({
+    height: window.visualViewport?.height ?? document.documentElement.clientHeight,
+    width: window.visualViewport?.width ?? document.documentElement.clientWidth,
+  }))
+  expectAligned(overlay.x, 0)
+  expectAligned(overlay.y, 0)
+  expect(overlay.width).toBeGreaterThanOrEqual(narrowViewport.width - 15)
+  expect(overlay.height).toBeGreaterThanOrEqual(narrowViewport.height - 15)
+  expect(dialog.x).toBeGreaterThanOrEqual(overlay.x)
+  expect(dialog.y).toBeGreaterThanOrEqual(overlay.y)
+  expect(dialog.right).toBeLessThanOrEqual(overlay.right)
+  expect(dialog.bottom).toBeLessThanOrEqual(overlay.bottom)
+  expect(dialog.width).toBeGreaterThan(0)
+  expect(dialog.height).toBeGreaterThan(0)
+  await expect(page.locator(".desktop-disk-strip .floating-dialog .dcp-tab-active"))
+    .toBeVisible()
+  await attachGeometry(testInfo, {
+    deviceStrip,
+    controlStrip,
+    controls,
+    disks,
+    diskStrip,
+    status,
+    diskOverflow,
+    statusOverflow,
+    pageHeight,
+    narrowDiskOverflow,
+    narrowDialog: { dialog, overlay, viewport: narrowViewport },
+  })
+})
+
+test("keeps Minimal Help text inside the lined paper", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 1200, height: 800 })
+  await page.goto("/?color=white&theme=minimal")
+  await page.locator(".flyout-top-right .flyout-button").click()
+  const paper = page.locator(".help-paper")
+  const text = page.locator(".help-text-light")
+  await expect(paper).toBeVisible()
+  await settleLayout(page)
+  const geometry = {
+    paper: await rectangle(paper),
+    text: await rectangle(text),
+  }
+  expect(geometry.text.x).toBeGreaterThanOrEqual(geometry.paper.x + 40)
+  expect(geometry.text.bottom).toBeLessThanOrEqual(geometry.paper.bottom + 1)
+  await attachGeometry(testInfo, geometry)
+})
+
+test("keeps viewport anchors aligned across tabs and BASIC variables", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 608 })
+  const tabs = page.locator(".dbg-tab-row")
+  const controls = page.locator(".desktop-panel-controls")
+  const keyboard = page.locator(".keyboard-toggle-button")
+  const monitor = page.locator(".desktop-primary-sticky")
+  const baseline = {
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+    keyboard: await rectangle(keyboard),
+    monitor: await rectangle(monitor),
+  }
+  const observations = []
+
+  // Help is initially active. Clicking an active tab closes it, so use its
+  // initial geometry as the baseline and visit only the other tabs here.
+  for (const title of [
+    "Debugging",
+    "Applesoft BASIC",
+    "Apple exPectin",
+    "VERA Monitor",
+    "Agent",
+  ]) {
+    await selectTab(page, title)
+    await settleLayout(page)
+    const current = {
+      title,
+      scrollY: await page.evaluate(() => window.scrollY),
+      tabs: await rectangle(tabs),
+      controls: await rectangle(controls),
+      keyboard: await rectangle(keyboard),
+      monitor: await rectangle(monitor),
+    }
+    expectAligned(
+      current.tabs.y,
+      baseline.tabs.y,
+      `${title}: tab rail moved at scrollY=${current.scrollY} (${current.tabs.y} vs ${baseline.tabs.y})`,
+    )
+    expectAligned(current.controls.y, baseline.controls.y, `${title}: layout controls moved`)
+    expectAligned(current.keyboard.y, baseline.keyboard.y, `${title}: keyboard control moved`)
+    expectAligned(current.monitor.y, baseline.monitor.y, `${title}: monitor moved`)
+    observations.push(current)
+  }
+
+  await selectTab(page, "Applesoft BASIC")
+  await page.locator(".basic-variables-toggle").click()
+  await expect(page.locator(".desktop-basic-workspace"))
+    .toHaveClass(/desktop-basic-variables-visible/)
+  await settleLayout(page)
+  const variables = {
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+    keyboard: await rectangle(keyboard),
+    monitor: await rectangle(monitor),
+  }
+  expectAligned(variables.tabs.y, baseline.tabs.y)
+  expectAligned(variables.controls.y, baseline.controls.y)
+  expectAligned(variables.keyboard.y, baseline.keyboard.y)
+  expectAligned(variables.monitor.y, baseline.monitor.y)
+  await page.locator(".desktop-basic-variables-visible").hover()
+  await page.mouse.wheel(0, 2_000)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  const variablesScrolled = {
+    scrollY: await page.evaluate(() => window.scrollY),
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+    monitor: await rectangle(monitor),
+  }
+  expect(variablesScrolled.tabs.y).toBeLessThan(baseline.tabs.y)
+  expect(variablesScrolled.controls.y).toBeLessThan(baseline.controls.y)
+  expectAligned(variablesScrolled.monitor.y, baseline.monitor.y)
+  await attachGeometry(testInfo, { baseline, observations, variables, variablesScrolled })
+})
+
+test("aligns BASIC, exPectin, and Agent actions without moving BASIC for variables", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 608 })
+
+  await selectTab(page, "Applesoft BASIC")
+  const basicControls = page.locator(".desktop-code-controls")
+  const basicPrimary = page.locator(".desktop-basic-primary")
+  const monitor = page.locator(".desktop-primary-sticky")
+  const tabs = page.locator(".dbg-tab-row")
+  const layoutControls = page.locator(".desktop-panel-controls")
+  const basicBefore = {
+    controls: await rectangle(basicControls),
+    primary: await rectangle(basicPrimary),
+  }
+  await page.locator(".basic-variables-toggle").click()
+  await expect(page.locator(".desktop-basic-workspace"))
+    .toHaveClass(/desktop-basic-variables-visible/)
+  await settleLayout(page)
+  const basicAfter = {
+    controls: await rectangle(basicControls),
+    primary: await rectangle(basicPrimary),
+    variables: await rectangle(page.locator(".basic-debug-view")),
+  }
+  expectAligned(basicAfter.controls.bottom, basicBefore.controls.bottom)
+  expectAligned(basicAfter.primary.y, basicBefore.primary.y)
+  expectAligned(basicAfter.primary.height, basicBefore.primary.height)
+
+  const anchoredBeforeScroll = {
+    monitor: await rectangle(monitor),
+    tabs: await rectangle(tabs),
+    controls: await rectangle(layoutControls),
+  }
+  await page.locator(".basic-debug-view").hover()
+  await page.mouse.wheel(0, 2_000)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  const anchoredAfterScroll = {
+    monitor: await rectangle(monitor),
+    tabs: await rectangle(tabs),
+    controls: await rectangle(layoutControls),
+  }
+  expectAligned(anchoredAfterScroll.monitor.y, anchoredBeforeScroll.monitor.y)
+  expect(anchoredAfterScroll.tabs.y).toBeLessThan(anchoredBeforeScroll.tabs.y)
+  expect(anchoredAfterScroll.controls.y).toBeLessThan(anchoredBeforeScroll.controls.y)
+
+  await page.locator(".desktop-panel-orientation-toggle").click()
+  await expect(page.locator(".desktop-panel-shell")).toHaveClass(/desktop-panel-below/)
+  await settleLayout(page)
+  const belowWithVariables = {
+    controls: await rectangle(basicControls),
+    contentOverflow: await page.locator(".desktop-panel-content").evaluate(element => ({
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+    })),
+    panel: await rectangle(page.locator(".desktop-panel-shell")),
+    primary: await rectangle(basicPrimary),
+    controlBottomOffset: await descendantBottomOffset(
+      basicPrimary,
+      ".desktop-code-controls",
+    ),
+  }
+  await page.locator(".basic-variables-toggle").click()
+  await expect(page.locator(".desktop-basic-workspace"))
+    .not.toHaveClass(/desktop-basic-variables-visible/)
+  await settleLayout(page)
+  const belowWithoutVariables = {
+    controls: await rectangle(basicControls),
+    panel: await rectangle(page.locator(".desktop-panel-shell")),
+    primary: await rectangle(basicPrimary),
+    controlBottomOffset: await descendantBottomOffset(
+      basicPrimary,
+      ".desktop-code-controls",
+    ),
+  }
+  await attachGeometry(testInfo, { belowWithVariables, belowWithoutVariables })
+  expectAligned(belowWithoutVariables.primary.height, belowWithVariables.primary.height)
+  expect(belowWithVariables.contentOverflow.scrollHeight)
+    .toBeLessThanOrEqual(belowWithVariables.contentOverflow.clientHeight)
+  expectAligned(
+    belowWithoutVariables.controlBottomOffset,
+    belowWithVariables.controlBottomOffset,
+    `below BASIC control offset changed (${belowWithVariables.controlBottomOffset} -> ${belowWithoutVariables.controlBottomOffset})`,
+  )
+
+  await selectTab(page, "Apple exPectin")
+  const expectin = await rectangle(page.locator(".desktop-code-controls"))
+  const expectinWorkspace = await rectangle(page.locator(".desktop-code-workspace"))
+  await selectTab(page, "Agent")
+  const agent = await rectangle(page.locator(".agent-controls"))
+  const agentWorkspace = await rectangle(page.locator(".agent-container"))
+
+  const basicControlBottom = belowWithoutVariables.controls.bottom
+    - belowWithoutVariables.primary.y
+  expectAligned(expectin.bottom - expectinWorkspace.y, basicControlBottom)
+  expectAligned(agent.bottom - agentWorkspace.y, basicControlBottom)
+  await attachGeometry(testInfo, {
+    basicBefore,
+    basicAfter,
+    anchoredBeforeScroll,
+    anchoredAfterScroll,
+    belowWithVariables,
+    belowWithoutVariables,
+    expectin,
+    expectinWorkspace,
+    agent,
+    agentWorkspace,
+  })
+})
+
+test("moves the panel below and immediately reveals its new location", async ({ page }, testInfo) => {
+  await openDesktop(page)
+  const shell = page.locator(".desktop-panel-shell")
+  await page.locator(".desktop-panel-orientation-toggle").click()
+
+  await expect(page.locator(".desktop-emulator-layout"))
+    .toHaveClass(/desktop-panel-layout-below/)
+  await expect(shell).toHaveClass(/desktop-panel-below/)
+
+  const footer = await rectangle(page.locator(".desktop-status-strip"))
+  const panel = await rectangle(shell)
+  const tabs = await rectangle(shell.locator(".dbg-tab-row"))
+  const activeTab = await rectangle(shell.locator(".dbg-tab-active"))
+  const panelContent = await rectangle(shell.locator(".desktop-panel-content"))
+  expectAligned(panelContent.y, activeTab.bottom)
+  const belowToggleRectangles = await page.locator(".desktop-panel-toggle")
+    .evaluateAll(elements => elements.map(element => {
+      const rect = element.getBoundingClientRect()
+      return { bottom: rect.bottom, height: rect.height }
+    }))
+  for (const toggle of belowToggleRectangles) {
+    expectAligned(toggle.bottom, panelContent.y)
+    expectAligned(toggle.height, tabs.height)
+  }
+  expect(panel.y).toBeGreaterThan(footer.bottom)
+  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  expect(tabs.y).toBeGreaterThanOrEqual(0)
+  expect(tabs.bottom).toBeLessThanOrEqual(await page.evaluate(() => window.innerHeight + 1))
+  expect(panel.y).toBeGreaterThan(0)
+  await expect(page.locator(".dbg-tab-horizontal").first()).toBeVisible()
+  const revealedScrollY = await page.evaluate(() => window.scrollY)
+  const canvas = page.locator("#apple2canvas")
+  const canvasBox = await canvas.boundingBox()
+  if (!canvasBox) throw new Error("Apple II canvas has no browser geometry")
+  await page.mouse.move(
+    canvasBox.x + canvasBox.width / 2,
+    canvasBox.y + canvasBox.height / 2,
+  )
+  await expect(canvas).toBeFocused()
+  expect(await page.evaluate(() => window.scrollY)).toBe(revealedScrollY)
+  await attachGeometry(testInfo, { footer, panel, tabs })
+})
+
+test("keeps wide code-tab action rows and the BASIC variable header visible", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 608 })
+  await page.locator(".desktop-panel-width-toggle").click()
+  await expect(page.locator(".desktop-panel-shell")).toHaveClass(/desktop-panel-wide/)
+  const viewportBottom = await page.evaluate(() => window.innerHeight)
+  const helpOverflow = await page.locator(".desktop-panel-content").evaluate(element => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }))
+  expect(helpOverflow.scrollHeight).toBeLessThanOrEqual(helpOverflow.clientHeight)
+
+  await selectTab(page, "Applesoft BASIC")
+  await settleLayout(page)
+  const basicControls = await rectangle(page.locator(".desktop-code-controls"))
+  const scrollBeforeVariables = await page.evaluate(() => window.scrollY)
+  expect(basicControls.bottom).toBeLessThanOrEqual(viewportBottom)
+  const variablesToggle = page.locator(".basic-variables-toggle")
+  const variablesTogglePoint = await exposedPoint(variablesToggle)
+  await page.mouse.click(variablesTogglePoint.x, variablesTogglePoint.y)
+  await expect(page.locator(".desktop-basic-workspace"))
+    .toHaveClass(/desktop-basic-variables-visible/)
+  await settleLayout(page)
+  const basicWithVariables = {
+    controls: await rectangle(page.locator(".desktop-code-controls")),
+    variables: await rectangle(page.locator(".basic-debug-view")),
+    scrollY: await page.evaluate(() => window.scrollY),
+  }
+  expectAligned(
+    basicWithVariables.controls.bottom,
+    basicControls.bottom,
+    `BASIC controls moved after showing variables (scroll ${scrollBeforeVariables} -> ${basicWithVariables.scrollY})`,
+  )
+  expect(basicWithVariables.variables.y).toBeLessThan(viewportBottom)
+
+  await selectTab(page, "Apple exPectin")
+  const expectin = await rectangle(page.locator(".desktop-code-controls"))
+  expect(expectin.bottom).toBeLessThanOrEqual(viewportBottom)
+  await selectTab(page, "Agent")
+  const agent = await rectangle(page.locator(".agent-controls"))
+  expect(agent.bottom).toBeLessThanOrEqual(viewportBottom)
+  expectAligned(expectin.bottom, basicControls.bottom)
+  expectAligned(agent.bottom, basicControls.bottom)
+  await attachGeometry(testInfo, {
+    helpOverflow,
+    basicControls,
+    basicWithVariables,
+    expectin,
+    agent,
+  })
+})
+
+test("bounds wide ordinary tabs and gives VERA a stable internal viewport", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 800 })
+  const shell = page.locator(".desktop-panel-shell")
+  const tabs = page.locator(".dbg-tab-row")
+  const controls = page.locator(".desktop-panel-controls")
+  const widthToggle = page.locator(".desktop-panel-width-toggle")
+
+  await widthToggle.click()
+  await expect(widthToggle).toHaveAttribute("aria-pressed", "true")
+  const info = {
+    shell: await rectangle(shell),
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+    documentWidth: await page.evaluate(() => document.documentElement.scrollWidth),
+    viewportWidth: await page.evaluate(() => window.innerWidth),
+  }
+  expect(info.shell.right).toBeLessThanOrEqual(info.viewportWidth)
+  expect(info.documentWidth).toBeLessThanOrEqual(info.viewportWidth)
+
+  await selectTab(page, "VERA Monitor")
+  await settleLayout(page)
+  const veraContent = page.locator(".desktop-panel-content")
+  const before = {
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+    documentHeight: await page.evaluate(() => document.documentElement.scrollHeight),
+    viewportHeight: await page.evaluate(() => window.innerHeight),
+  }
+  await veraContent.hover()
+  await page.mouse.wheel(0, 2_000)
+  const after = {
+    tabs: await rectangle(tabs),
+    controls: await rectangle(controls),
+    scrollY: await page.evaluate(() => window.scrollY),
+  }
+  expectAligned(after.tabs.y, before.tabs.y)
+  expectAligned(after.controls.y, before.controls.y)
+  expect(after.scrollY).toBe(0)
+  expect(before.documentHeight).toBeLessThanOrEqual(before.viewportHeight)
+  await attachGeometry(testInfo, { info, before, after })
+})
+
+test("keeps HGR magnifier geometry independent of the panel underneath it", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1404, height: 800 })
+  await page.locator("button[title=\"Boot\"]").click()
+  await expect(page.locator("button[title=\"Pause\"]")).toBeEnabled()
+  await page.locator("button[title=\"Pause\"]").click()
+  await settleLayout(page)
+  const debugTab = page.locator(".dbg-tab[title=\"Debugging\"]")
+  if (!(await debugTab.getAttribute("class"))?.includes("dbg-tab-active")) {
+    await selectTab(page, "Debugging")
+  }
+  await page.locator("#tour-debug-memorydump select").selectOption({
+    label: "HGR page 1 (screen order)",
+  })
+
+  const monitor = await rectangle(page.locator(".main-canvas"))
+  const magnifier = page.locator(".hgr-view")
+  const sourceBox = page.locator(".hgr-view-box")
+  const pixelCanvas = page.locator("#hgr-info-canvas")
+  const sample = async (xRatio: number) => {
+    await page.mouse.move(
+      monitor.x + monitor.width * xRatio,
+      monitor.y + monitor.height / 2,
+    )
+    await expect(magnifier).toBeVisible()
+    await settleLayout(page)
+    return {
+      canvas: await rectangle(pixelCanvas),
+      source: await rectangle(sourceBox),
+    }
+  }
+
+  const overMonitor = await sample(0.25)
+  const overPanel = await sample(0.75)
+  expectAligned(overPanel.canvas.width, overMonitor.canvas.width)
+  expectAligned(overPanel.canvas.height, overMonitor.canvas.height)
+  expectAligned(overPanel.source.width, overMonitor.source.width)
+  expectAligned(overPanel.source.height, overMonitor.source.height)
+  expect(await magnifier.evaluate(element => element.parentElement === document.body)).toBe(true)
+  expect(await magnifier.evaluate(element => getComputedStyle(element).position)).toBe("fixed")
+  const placeMagnifierOver = async (target: Locator) => page.evaluate(
+    ([magnifierElement, targetElement]) => {
+      const magnifier = magnifierElement as HTMLElement
+      const targetRect = (targetElement as HTMLElement).getBoundingClientRect()
+      const previous = {
+        left: magnifier.style.left,
+        top: magnifier.style.top,
+        pointerEvents: magnifier.style.pointerEvents,
+      }
+      magnifier.style.left = `${targetRect.left}px`
+      magnifier.style.top = `${targetRect.top}px`
+      magnifier.style.pointerEvents = "auto"
+      const point = {
+        x: targetRect.left + Math.min(10, targetRect.width / 2),
+        y: targetRect.top + Math.min(10, targetRect.height / 2),
+      }
+      const topElement = document.elementFromPoint(point.x, point.y)
+      magnifier.style.left = previous.left
+      magnifier.style.top = previous.top
+      magnifier.style.pointerEvents = previous.pointerEvents
+      return {
+        magnifierIsTop: topElement !== null && magnifier.contains(topElement),
+        targetIsTop: topElement !== null && (targetElement as HTMLElement).contains(topElement),
+      }
+    },
+    [await magnifier.elementHandle(), await target.elementHandle()],
+  )
+  const panelStacking = await placeMagnifierOver(page.locator(".desktop-panel-shell"))
+  expect(panelStacking.magnifierIsTop).toBe(true)
+  await page.locator(".control-panel-two-rows button[title=\"Display Settings\"]").click()
+  const floatingDialog = page.locator(".desktop-primary-column .floating-dialog")
+  await expect(floatingDialog).toBeVisible()
+  const dialogStacking = await placeMagnifierOver(floatingDialog)
+  expect(dialogStacking.targetIsTop).toBe(true)
+  await page.mouse.click(1, 1)
+  await expect(floatingDialog).toHaveCount(0)
+
+  await page.locator(".desktop-panel-orientation-toggle").click()
+  await expect(page.locator(".desktop-emulator-layout"))
+    .toHaveClass(/desktop-panel-layout-below/)
+  await page.evaluate(() => window.scrollTo(0, 0))
+  await settleLayout(page)
+  const belowMonitor = await rectangle(page.locator(".main-canvas"))
+  await page.mouse.move(
+    belowMonitor.x + belowMonitor.width * 0.25,
+    belowMonitor.y + belowMonitor.height / 2,
+  )
+  await page.mouse.down()
+  await page.mouse.up()
+  await settleLayout(page)
+  const beforeScroll = {
+    monitor: await rectangle(page.locator(".main-canvas")),
+    magnifier: await rectangle(magnifier),
+  }
+  await page.evaluate(() => window.scrollBy(0, 100))
+  await settleLayout(page)
+  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  const afterScroll = {
+    monitor: await rectangle(page.locator(".main-canvas")),
+    magnifier: await rectangle(magnifier),
+  }
+  expectAligned(
+    afterScroll.magnifier.y - afterScroll.monitor.y,
+    beforeScroll.magnifier.y - beforeScroll.monitor.y,
+  )
+
+  await page.locator("#tour-debug-memorydump select").selectOption({
+    label: "Current memory",
+  })
+  await expect(magnifier).toHaveCount(0)
+  await page.locator("#tour-debug-memorydump select").selectOption({
+    label: "HGR page 1 (screen order)",
+  })
+  await page.mouse.move(monitor.x + monitor.width * 0.75, monitor.y + monitor.height / 2)
+  await expect(magnifier).toBeVisible()
+  await selectTab(page, "Help")
+  await expect(magnifier).toHaveCount(0)
+  await attachGeometry(testInfo, {
+    monitor,
+    overMonitor,
+    overPanel,
+    stacking: { panel: panelStacking, dialog: dialogStacking },
+  })
+})
+
+test("collapse reclaims the grid track and restore preserves tab and width", async ({ page }, testInfo) => {
+  await openDesktop(page)
+  await selectTab(page, "Agent")
+  const monitor = page.locator(".main-canvas")
+  const shell = page.locator(".desktop-panel-shell")
+  const widthToggle = page.locator(".desktop-panel-width-toggle")
+  const collapseToggle = page.locator(".desktop-panel-collapse-toggle")
+
+  await widthToggle.click()
+  await expect(widthToggle).toHaveAttribute("aria-pressed", "true")
+  const expanded = {
+    monitor: await rectangle(monitor),
+    panel: await rectangle(shell),
+    layout: await rectangle(page.locator(".desktop-emulator-layout")),
+    collapse: await rectangle(collapseToggle),
+  }
+
+  await collapseToggle.click()
+  await expect(shell).toHaveClass(/desktop-panel-collapsed/)
+  await expect(collapseToggle).toHaveAttribute("aria-expanded", "false")
+  const collapsed = {
+    monitor: await rectangle(monitor),
+    panel: await rectangle(shell),
+    layout: await rectangle(page.locator(".desktop-emulator-layout")),
+    collapse: await rectangle(collapseToggle),
+  }
+  expect(collapsed.panel.width).toBeLessThan(expanded.panel.width)
+  expect(collapsed.layout.width).toBeLessThan(expanded.layout.width)
+  expectAligned(collapsed.monitor.width, expanded.monitor.width)
+  expectAligned(collapsed.collapse.y, expanded.collapse.y)
+
+  await collapseToggle.click()
+  await expect(shell).not.toHaveClass(/desktop-panel-collapsed/)
+  await expect(page.locator(".dbg-tab[title=\"Agent\"]")).toHaveClass(/dbg-tab-active/)
+  await expect(widthToggle).toHaveAttribute("aria-pressed", "true")
+  const restored = {
+    monitor: await rectangle(monitor),
+    panel: await rectangle(shell),
+  }
+  expectAligned(restored.panel.width, expanded.panel.width)
+  await attachGeometry(testInfo, { expanded, collapsed, restored })
+})
+
+test("wide Debugger uses meaningful root scrolling without phantom width", async ({ page }, testInfo) => {
+  await openDesktop(page, { width: 1024, height: 700 })
+  await page.locator(".desktop-panel-width-toggle").click()
+  await selectTab(page, "Debugging")
+
+  const layout = page.locator(".desktop-emulator-layout")
+  const panel = page.locator(".desktop-panel-shell")
+  const before = {
+    documentWidth: await page.evaluate(() => document.documentElement.scrollWidth),
+    viewportWidth: await page.evaluate(() => window.innerWidth),
+    layout: await rectangle(layout),
+    panel: await rectangle(panel),
+  }
+  expect(Math.abs(before.documentWidth - before.layout.right))
+    .toBeLessThanOrEqual(2)
+  expect(before.documentWidth).toBeGreaterThan(before.viewportWidth)
+
+  await page.mouse.wheel(2_000, 0)
+  await expect.poll(() => page.evaluate(() => window.scrollX)).toBeGreaterThan(0)
+  const afterHorizontal = {
+    scrollX: await page.evaluate(() => window.scrollX),
+    panel: await rectangle(panel),
+  }
+  expect(afterHorizontal.panel.right).toBeLessThanOrEqual(before.viewportWidth + 1)
+
+  await page.locator(".desktop-panel-content-debug").hover()
+  await page.mouse.wheel(0, 2_000)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  await attachGeometry(testInfo, {
+    before,
+    afterHorizontal,
+    scrollY: await page.evaluate(() => window.scrollY),
+  })
+})
+
+const expectOverlayAbovePoint = async (
+  overlay: Locator,
+  target: Locator,
+) => {
+  const targetBox = await rectangle(target)
+  expect(await overlay.evaluate((element, point) => {
+    const top = document.elementFromPoint(point.x, point.y)
+    return top !== null && element.contains(top)
+  }, {
+    x: targetBox.x + targetBox.width / 2,
+    y: Math.min(100, targetBox.y + targetBox.height / 2),
+  })).toBe(true)
+}
+
+test("primary configuration dialogs appear above the side panel", async ({ page }) => {
+  await openDesktop(page)
+  await page.locator(".control-panel-two-rows button[title=\"Display Settings\"]").click()
+  const overlay = page.locator(".desktop-primary-column .modal-overlay")
+  await expect(overlay).toBeVisible()
+  await expectOverlayAbovePoint(overlay, page.locator(".desktop-panel-shell"))
+})
+
+test("Agent configuration dialogs center over the Agent panel", async ({ page }, testInfo) => {
+  await openDesktop(page)
+  await selectTab(page, "Agent")
+  await page.locator(".agent-controls button[title=\"Change configuration\"]").click()
+  const overlay = page.locator(".desktop-panel-shell .modal-overlay")
+  const shell = page.locator(".desktop-panel-shell")
+  const dialog = page.locator(".agent-config-dialog")
+  await expect(overlay).toBeVisible()
+  const panelBox = await rectangle(shell)
+  const dialogBox = await rectangle(dialog)
+  expectAligned(dialogBox.x + dialogBox.width / 2, panelBox.x + panelBox.width / 2)
+  expectAligned(dialogBox.y + dialogBox.height / 2, panelBox.y + panelBox.height / 2)
+  expect(Number(await shell.evaluate(element => getComputedStyle(element).zIndex)))
+    .toBeGreaterThan(Number(await page.locator(".desktop-primary-column")
+      .evaluate(element => getComputedStyle(element).zIndex)))
+  await attachGeometry(testInfo, { panelBox, dialogBox })
+})
+
+test("collects browser errors before page interaction", async ({ page, browserFailures }) => {
+  const probe = "layout-acceptance-error-probe"
+  await page.goto("/?color=white")
+  await page.evaluate(message => console.error(message), probe)
+  await expect.poll(() => browserFailures.includes(`console: ${probe}`)).toBe(true)
+  browserFailures.splice(browserFailures.indexOf(`console: ${probe}`), 1)
+})
+
+for (const viewport of [
+  { name: "normal", width: 1200, height: 800 },
+  { name: "short", width: 1200, height: 600 },
+  { name: "narrow", width: 900, height: 700 },
+]) {
+  test(`${viewport.name} desktop viewport retains usable panel controls`, async ({ page }, testInfo) => {
+    await openDesktop(page, viewport)
+    const shell = page.locator(".desktop-panel-shell")
+    const collapseToggle = page.locator(".desktop-panel-collapse-toggle")
+    const before = {
+      panel: await rectangle(shell),
+      monitor: await rectangle(page.locator(".main-canvas")),
+      document: await page.evaluate(() => ({
+        width: document.documentElement.scrollWidth,
+        height: document.documentElement.scrollHeight,
+      })),
+    }
+    expect(before.panel.width).toBeGreaterThan(100)
+    expect(before.panel.height).toBeGreaterThan(100)
+
+    await collapseToggle.click()
+    await expect(collapseToggle).toHaveAttribute("aria-expanded", "false")
+    await collapseToggle.click()
+    await expect(collapseToggle).toHaveAttribute("aria-expanded", "true")
+    await attachGeometry(testInfo, { viewport, before })
+  })
+}
+
+test("keeps the touch monitor stable across horizontal debug tabs", async ({ page }, testInfo) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(HTMLElement.prototype, "ontouchstart", {
+      configurable: true,
+      value: null,
+    })
+  })
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto("/?color=white")
+  await expect(page.locator(".desktop-emulator-layout")).toHaveCount(0)
+  await settleLayout(page)
+
+  const viewportWidth = await page.evaluate(() => document.documentElement.clientWidth)
+  const canvasBefore = await rectangle(page.locator("#apple2canvas"))
+  expectAligned(canvasBefore.width, viewportWidth)
+
+  const language = await rectangle(page.locator("button[title*=\"Language\"]"))
+  const secondRow = await rectangle(page.locator(".control-panel-row").nth(1))
+  expect(language.y).toBeGreaterThanOrEqual(secondRow.y)
+  expect(language.bottom).toBeLessThanOrEqual(secondRow.bottom + 1)
+  await page.locator("button[title*=\"Language\"]").click()
+  const languageLabelPositions = await page.locator(
+    ".modal-overlay > .floating-dialog > .droplist-option .popup-item-label",
+  ).evaluateAll(elements => elements.map(element => element.getBoundingClientRect().x))
+  expect(languageLabelPositions).toHaveLength(14)
+  expect(Math.max(...languageLabelPositions) - Math.min(...languageLabelPositions))
+    .toBeLessThanOrEqual(1)
+  await page.locator(".modal-overlay").click({ position: { x: 1, y: 1 } })
+  await expect(page.locator(".modal-overlay")).toHaveCount(0)
+  const deviceRow = await rectangle(page.locator(".mobile-device-row"))
+  const divider = await rectangle(page.locator(".mobile-divider"))
+  expect(divider.y - deviceRow.bottom).toBeGreaterThanOrEqual(0)
+  const mobileStatus = page.locator(".mobile-status")
+  const status = await rectangle(mobileStatus)
+  const panel = await rectangle(page.locator("#debug-section"))
+  expect(status.y).toBeGreaterThanOrEqual(panel.bottom)
+  expect(status.right).toBeLessThanOrEqual(viewportWidth)
+
+  await selectTouchTabAndWaitForResize(page, "Debugging")
+  const canvasDebug = await rectangle(page.locator("#apple2canvas"))
+  const debugScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+  await selectTouchTabAndWaitForResize(page, "Help")
+  const canvasInfo = await rectangle(page.locator("#apple2canvas"))
+  expectAligned(canvasDebug.width, canvasBefore.width)
+  expectAligned(canvasInfo.width, canvasBefore.width)
+  expect(debugScrollWidth).toBeLessThanOrEqual(viewportWidth)
+  expect(await page.evaluate(() => document.documentElement.scrollWidth))
+    .toBeLessThanOrEqual(viewportWidth)
+
+  await selectTouchTabAndWaitForResize(page, "Agent")
+  await page.locator("button[title=\"Change configuration\"]").click()
+  const agentDialog = page.locator(".agent-config-dialog")
+  await expect(agentDialog).toBeVisible()
+  await expect(page.locator(".agent-config-overlay-mobile")).toHaveCSS("position", "fixed")
+  const agentDialogBox = await rectangle(agentDialog)
+  const portraitAgentDialogContent = await agentDialog.evaluate(element => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }))
+  expect(portraitAgentDialogContent.scrollHeight)
+    .toBeLessThanOrEqual(portraitAgentDialogContent.clientHeight + 1)
+  expect(agentDialogBox.y).toBeGreaterThanOrEqual(0)
+  expect(agentDialogBox.bottom).toBeLessThanOrEqual(
+    await page.evaluate(() => window.innerHeight),
+  )
+  await agentDialog.locator("button").first().click()
+  await expect(agentDialog).toHaveCount(0)
+
+  await page.setViewportSize({ width: 844, height: 390 })
+  await settleLayout(page)
+  const landscapeViewportWidth = await page.evaluate(() => document.documentElement.clientWidth)
+  const landscapeCanvas = await rectangle(page.locator("#apple2canvas"))
+  const landscapeSidebar = await rectangle(page.locator(".mobile-landscape-sidebar"))
+  const landscapePanel = await rectangle(page.locator("#debug-section"))
+  const landscapeStatus = await rectangle(mobileStatus)
+  expect(landscapeCanvas.width + landscapeSidebar.width).toBeLessThanOrEqual(landscapeViewportWidth)
+  expect(landscapeSidebar.right).toBeLessThanOrEqual(landscapeViewportWidth)
+  expect(landscapeStatus.y).toBeGreaterThanOrEqual(landscapePanel.bottom)
+  expect(await page.evaluate(() => document.documentElement.scrollWidth))
+    .toBeLessThanOrEqual(landscapeViewportWidth)
+
+  await page.locator("button[title=\"Change configuration\"]").click()
+  const landscapeAgentDialogLocator = page.locator(".agent-config-dialog")
+  const landscapeAgentDialog = await rectangle(landscapeAgentDialogLocator)
+  const landscapeAgentDialogContent = await landscapeAgentDialogLocator.evaluate(element => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }))
+  expect(landscapeAgentDialogContent.scrollHeight)
+    .toBeLessThanOrEqual(landscapeAgentDialogContent.clientHeight + 1)
+  await page.locator(".agent-config-dialog button").first().click()
+
+  await page.setViewportSize({ width: 844, height: 330 })
+  await settleLayout(page)
+  const browserChromeCanvas = await rectangle(page.locator("#apple2canvas"))
+  expectAligned(browserChromeCanvas.width, landscapeCanvas.width)
+  expectAligned(browserChromeCanvas.height, landscapeCanvas.height)
+
+  // A page initially opened while browser chrome consumes viewport height must
+  // still grow when that space becomes visible. Reload to clear the remembered
+  // landscape maximum before exercising the inverse transition.
+  await page.reload()
+  await settleLayout(page)
+  const initiallyContractedCanvas = await rectangle(page.locator("#apple2canvas"))
+  await page.setViewportSize({ width: 844, height: 390 })
+  await settleLayout(page)
+  const expandedCanvas = await rectangle(page.locator("#apple2canvas"))
+  expect(expandedCanvas.height).toBeGreaterThan(initiallyContractedCanvas.height)
+  expect(expandedCanvas.width).toBeGreaterThan(initiallyContractedCanvas.width)
+  await attachGeometry(testInfo, {
+    canvasBefore,
+    canvasDebug,
+    canvasInfo,
+    browserChromeCanvas,
+    initiallyContractedCanvas,
+    expandedCanvas,
+    deviceRow,
+    divider,
+    debugScrollWidth,
+    language,
+    languageLabelPositions,
+    agentDialogBox,
+    landscapeCanvas,
+    landscapeAgentDialog,
+    landscapeAgentDialogContent,
+    landscapePanel,
+    landscapeSidebar,
+    landscapeStatus,
+    landscapeViewportWidth,
+    panel,
+    secondRow,
+    status,
+    portraitAgentDialogContent,
+    viewportWidth,
+  })
+})


### PR DESCRIPTION
## GitHub merge style: Rebase and merge

This PR is structured as four reviewable commits. Please preserve the commit boundaries.

This stabilizes the emulator GUI across changing window sizes, panel contents, translations, and mobile browser controls.

- Refine responsive Help content and translated shortcut labels.
- Establish an adaptive desktop layout with controls for moving, collapsing, and widening the tab panel.
- Keep the emulator screen fitted to the phone without shrinking when mobile browser controls appear.
- Add repeatable browser checks for the layout behaviors established in this PR.

Tests:
- `npm test -- --runInBand` — 37 suites and 597 tests passed
- PO catalog tests — 57 passed
- `npm run test:ui-layout` — 19 passed
- `npm run lint`
- `npm run build`
