### PR TITLE
fix(i18n): improve localized UI presentation

### DIFF
--- a/src/ui/controls/popupmenu.test.tsx
+++ b/src/ui/controls/popupmenu.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import PopupMenu from "./popupmenu"
+
+describe("PopupMenu", () => {
+  it("reserves the same selection-marker column for every option", () => {
+    const menuItems: PopupMenuItem[] = [
+      { label: "Selected", isSelected: () => true },
+      { label: "Unselected", isSelected: () => false },
+    ]
+
+    const html = renderToStaticMarkup(
+      <PopupMenu
+        location={[0, 0]}
+        menuItems={[menuItems]}
+        onClose={jest.fn()}
+      />
+    )
+
+    expect(html.match(/class="popup-selection-marker"/g)).toHaveLength(2)
+    expect(html).toContain("class=\"popup-selection-marker\">✔</span>")
+    expect(html).toContain("class=\"popup-selection-marker\"></span>")
+  })
+})

--- a/src/ui/controls/popupmenu.tsx
+++ b/src/ui/controls/popupmenu.tsx
@@ -14,7 +14,6 @@ type PopupMenuProps = {
 
 const PopupMenu = (props: PopupMenuProps) => {
 
-  const isTouchDevice = "ontouchstart" in document.documentElement
   const menuRef = useRef<HTMLDivElement>(null)
   const [posStyle, setPosStyle] = useState<{ left: number, top: number } | undefined>(undefined)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
@@ -126,13 +125,15 @@ const PopupMenu = (props: PopupMenuProps) => {
               }
               props.onClose()
             }}>
-            <span>
-              {menuItem.isSelected != undefined && menuItem.isSelected()
-                ? "\u2714\u2009"
-                : `${isTouchDevice ? "\u2003" : "\u2004"}\u2007`}
-              {menuItem.icon && <FontAwesomeIcon icon={menuItem.icon} style={{ width: "24px" }} />}
-              {menuItem.svg && menuItem.svg}
-              {`${menuItem.label}\u2004`}
+            <span className="popup-item-main">
+              <span className="popup-selection-marker">
+                {menuItem.isSelected?.() ? "\u2714" : ""}
+              </span>
+              <span className="popup-item-label">
+                {menuItem.icon && <FontAwesomeIcon icon={menuItem.icon} style={{ width: "24px" }} />}
+                {menuItem.svg && menuItem.svg}
+                {`${menuItem.label}\u2004`}
+              </span>
             </span>
             {menuItem.subMenu && menuItem.subMenu.length > 0 && (
               <FontAwesomeIcon icon={faCaretRight} style={{ marginLeft: "12px", opacity: 0.7 }} />

--- a/src/ui/panels/help/defaulthelpcontent.test.tsx
+++ b/src/ui/panels/help/defaulthelpcontent.test.tsx
@@ -1,4 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
 import { DefaultHelpContent } from "./defaulthelpcontent"
 
 describe("DefaultHelpContent", () => {
@@ -23,6 +25,30 @@ describe("DefaultHelpContent", () => {
 
     expect(t).toHaveBeenCalledWith("help.shortcutsUnavailable", { keyMod: "Alt" })
     expect(t).not.toHaveBeenCalledWith("help.shortcutsTable", expect.anything())
+  })
+
+  it("replaces shortcut guidance when the Open Apple modifier changes", () => {
+    const t = jest.fn((key: string) => key)
+    const container = document.createElement("div")
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(<DefaultHelpContent t={t} useOpenAppleKey isTouchDevice={false} />)
+    })
+    const unavailableGuidance = container.querySelector(".help-shortcuts-unavailable")
+    expect(unavailableGuidance).not.toBeNull()
+    expect(container.querySelector(".help-shortcuts-available")).toBeNull()
+
+    act(() => {
+      root.render(<DefaultHelpContent t={t} useOpenAppleKey={false} isTouchDevice={false} />)
+    })
+    const availableGuidance = container.querySelector(".help-shortcuts-available")
+    expect(container.querySelector(".help-shortcuts-unavailable")).toBeNull()
+    expect(availableGuidance).not.toBeNull()
+    expect(availableGuidance).not.toBe(unavailableGuidance)
+    expect(container.contains(unavailableGuidance)).toBe(false)
+
+    act(() => root.unmount())
   })
 
   it("renders shortcut keys and translated labels in aligned table cells", () => {

--- a/src/ui/panels/help/defaulthelpcontent.tsx
+++ b/src/ui/panels/help/defaulthelpcontent.tsx
@@ -116,14 +116,16 @@ export const DefaultHelpContent = ({
     </> : <>
       <b>{t("help.keyboardShortcuts")}</b>{"\n"}
       {useOpenAppleKey
-        ? t("help.shortcutsUnavailable", { keyMod: shortcutKeyName })
-        : <>
+        ? <span key="shortcuts-unavailable" className="help-shortcuts-unavailable">
+          {t("help.shortcutsUnavailable", { keyMod: shortcutKeyName })}
+        </span>
+        : <span key="shortcuts-available" className="help-shortcuts-available">
           <ShortcutTable rows={shortcutRows} />
           {"\n"}{t("help.openAppleKey")}
           {"\n"}{t("help.closedAppleKey")}
           {"\n"}{t("help.joystickKeys")}
           {"\n\n"}{t("help.onScreenKeyboard")}
-        </>}{"\n"}
+        </span>}{"\n"}
     </>}
     {"\n"}<b>{t("help.diskImages")}</b>{" "}hdv, 2mg, dsk, woz, po, do, bin, bas
     {"\n\n"}<b>{t("help.urlParameters")}</b>{"\n"}

--- a/src/ui/panels/help/helptab.tsx
+++ b/src/ui/panels/help/helptab.tsx
@@ -29,7 +29,7 @@ const HelpTab = React.memo((props: HelpPanelProps) => {
   const showDefaultHelp = isDefaultHelp(props.helptext)
 
   return (
-    <div className="help-parent"
+    <div className="help-parent" translate="no"
       style={{
         width: narrow || isMinimalTheme() ? "687px" : 500,
         height: narrow || isMinimalTheme() ? "" : paperheight,

--- a/src/ui/panels/panels.css
+++ b/src/ui/panels/panels.css
@@ -279,6 +279,18 @@ body.dark-mode .droplist-edit:disabled {
   user-select: none;
 }
 
+.popup-item-main {
+  align-items: center;
+  display: flex;
+  min-width: 0;
+}
+
+.popup-selection-marker {
+  display: inline-flex;
+  flex: 0 0 1.25em;
+  justify-content: center;
+}
+
 body.dark-mode .droplist-option {
   background-color: var(--input-background-dark);
   color: var(--text-color-dark);


### PR DESCRIPTION
- Protect localized Help content from browser translation.
- Refresh shortcut guidance cleanly when the Open Apple setting changes.
- Align popup-menu selections.