### PR TITLE
fix(l10n): refine Help and menu wording

### DIFF
--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -21,12 +21,12 @@ msgstr "Starten"
 #, fuzzy
 msgctxt "controls.reset"
 msgid "Reset"
-msgstr "Zurücksetzen"
+msgstr "Reset"
 
 #, fuzzy
 msgctxt "controls.copyScreen"
 msgid "Copy Screen"
-msgstr "Bildschirm Kopieren"
+msgstr "Bildkopie"
 
 #, fuzzy
 msgctxt "controls.copyText"
@@ -36,17 +36,17 @@ msgstr "Text Kopieren"
 #, fuzzy
 msgctxt "controls.pasteText"
 msgid "Paste Text"
-msgstr "Text Einfügen"
+msgstr "Einfügen"
 
 #, fuzzy
 msgctxt "controls.saveState"
 msgid "Save State"
-msgstr "Zustand Speichern"
+msgstr "Speichern"
 
 #, fuzzy
 msgctxt "controls.restoreState"
 msgid "Restore State"
-msgstr "Zustand Wiederherstellen"
+msgstr "Laden"
 
 #, fuzzy
 msgctxt "controls.toggleSound"
@@ -1815,7 +1815,7 @@ msgstr "Exportproblem melden"
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
-msgstr "In der Zeit zurückgehen"
+msgstr "Zurückspulen"
 
 #, fuzzy
 msgctxt "debugControls.takeSnapshot"
@@ -1825,7 +1825,7 @@ msgstr "Schnappschuss erstellen"
 #, fuzzy
 msgctxt "debugControls.goForwardInTime"
 msgid "Go Forward in Time"
-msgstr "In der Zeit vorwärts gehen"
+msgstr "Vorspulen"
 
 #, fuzzy
 msgctxt "debugControls.saveStateWithSnapshots"

--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -209,8 +209,9 @@ msgstr "Schnell (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Lächerlich/Warp-Geschwindigkeit"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "Wahnsinnige Geschwindigkeit"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2301,9 +2302,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Wahnsinnig"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -177,8 +177,10 @@ msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Full Sail (4 MHz)"
 
+#, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
 msgstr "Kraken Speed"
 
 msgctxt "colors.color"
@@ -2099,8 +2101,10 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr "4 MHz (Full sail)"
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr "Kraken!"
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -201,8 +201,10 @@ msgctxt "speed.fast"
 msgid "Fast Speed (4 MHz)"
 msgstr "Velocidad rápida (4 MHz)"
 
+#, fuzzy
+#| msgid "Ludicrous/Warp Speed"
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
 msgstr "Velocidad absurda"
 
 msgctxt "colors.color"
@@ -2284,9 +2286,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Absurda"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -209,8 +209,9 @@ msgstr "Rapide (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Vitesse Ridicule/Warp"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "Vitesse ridicule"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2300,9 +2301,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Ridicule"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -201,8 +201,9 @@ msgstr "Veloce (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Velocità Ridicola/Warp"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "Velocità ridicola"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2281,9 +2282,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Ridicola"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -174,7 +174,7 @@ msgstr ""
 #, fuzzy
 msgctxt "speed.snail"
 msgid "Snail Speed (0.1 MHz)"
-msgstr "Velocità Lumaca (0.1 MHz)"
+msgstr "Lumaca (0.1 MHz)"
 
 #, fuzzy
 msgctxt "speed.slow"
@@ -1796,7 +1796,7 @@ msgstr "Segnala un problema di esportazione"
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
-msgstr "Torna Indietro nel Tempo"
+msgstr "Riavvolgi"
 
 #, fuzzy
 msgctxt "debugControls.takeSnapshot"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -200,8 +200,9 @@ msgstr "高速 (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "ばかげた/ワープ速度"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "ばかげた速度"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2230,9 +2231,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "ばかげた速度"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -200,8 +200,9 @@ msgstr "빠른 속도 (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "터무니없는/워프 속도"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "터무니없는 속도"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2239,9 +2240,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "터무니없는 속도"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -170,7 +170,7 @@ msgid "Fast Speed (4 MHz)"
 msgstr ""
 
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
 msgstr ""
 
 msgctxt "colors.color"
@@ -1946,7 +1946,7 @@ msgid "4 MHz"
 msgstr ""
 
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
+msgid "Ludicrous"
 msgstr ""
 
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -199,8 +199,9 @@ msgstr "Snel (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Belachelijk/Warp Snelheid"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "Belachelijke snelheid"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2264,9 +2265,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Belachelijk"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -200,8 +200,9 @@ msgstr "Rápida (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Velocidade Ridícula/Warp"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "Velocidade ridícula"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2270,9 +2271,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Ridícula"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -2273,13 +2273,15 @@ msgctxt "linkBuilder.speedNames.normal"
 msgid "1 MHz (default)"
 msgstr ""
 
+#, fuzzy
 msgctxt "linkBuilder.speedNames.two"
 msgid "2 MHz"
-msgstr ""
+msgstr "2 МГц"
 
+#, fuzzy
 msgctxt "linkBuilder.speedNames.three"
 msgid "3 MHz"
-msgstr ""
+msgstr "3 МГц"
 
 msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -202,8 +202,9 @@ msgstr "Быстрая (4 МГц)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Безумная/Варп скорость"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "Безумная скорость"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2284,9 +2285,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Безумная"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -199,8 +199,9 @@ msgstr "Snabb (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "Löjlig/Warp Hastighet"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "Löjlig hastighet"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2275,9 +2276,11 @@ msgctxt "linkBuilder.speedNames.four"
 msgid "4 MHz"
 msgstr ""
 
+#, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr ""
+msgid "Ludicrous"
+msgstr "Löjlig"
 
 msgctxt "linkBuilder.machines.enhanced"
 msgid "Apple IIe enhanced"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -201,8 +201,9 @@ msgstr "快速 (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "极速/曲速"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "极速"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2268,9 +2269,10 @@ msgid "4 MHz"
 msgstr ""
 
 #, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr "极速/曲速"
+msgid "Ludicrous"
+msgstr "极速"
 
 #, fuzzy
 msgctxt "linkBuilder.machines.enhanced"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -202,8 +202,9 @@ msgstr "快速 (4 MHz)"
 
 #, fuzzy
 msgctxt "speed.warp"
-msgid "Ludicrous/Warp Speed"
-msgstr "極速/曲速"
+#| msgid "Ludicrous/Warp Speed"
+msgid "Ludicrous Speed"
+msgstr "極速"
 
 #, fuzzy
 msgctxt "colors.color"
@@ -2276,9 +2277,10 @@ msgid "4 MHz"
 msgstr ""
 
 #, fuzzy
+#| msgid "Warp"
 msgctxt "linkBuilder.speedNames.warp"
-msgid "Warp"
-msgstr "極速/曲速"
+msgid "Ludicrous"
+msgstr "極速"
 
 #, fuzzy
 msgctxt "linkBuilder.machines.enhanced"


### PR DESCRIPTION
- Refine German and Italian Help labels.
- Standardize maximum-speed wording.
- Localize Russian MHz labels.