### PR TITLE
fix(i18n): localize footer text

### DIFF
--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -72,6 +72,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Ein Problem melden"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -72,9 +72,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Ein Problem melden"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Datenschutzrichtlinie"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1286,9 +1287,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "Apple IIe Emulator in TypeScript"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence und die Mitwirkenden von Apple2TS"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -61,6 +61,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Report Scurvy Trouble"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 msgctxt "config.speed"
 msgid "Emulator Speed"
 msgstr "Ship's Gait"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -61,9 +61,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Report Scurvy Trouble"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Privacy Articles"
 
 msgctxt "config.speed"
 msgid "Emulator Speed"
@@ -1192,9 +1193,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr ""
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence and the Apple2TS crew"
 
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -72,9 +72,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Reportar un problema"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Política de privacidad"
 
 msgctxt "config.speed"
 msgid "Emulator Speed"
@@ -1271,9 +1272,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "Emulador de Apple IIe en TypeScript"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence y los colaboradores de Apple2TS"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -72,6 +72,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Reportar un problema"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 msgctxt "config.speed"
 msgid "Emulator Speed"
 msgstr "Velocidad de emulación"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -73,9 +73,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Signaler un problème"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Politique de confidentialité"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1284,9 +1285,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "Émulateur Apple IIe en TypeScript"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence et les contributeurs d’Apple2TS"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -73,6 +73,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Signaler un problème"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -65,9 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Segnala un problema"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Informativa sulla privacy"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1269,9 +1270,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "Emulatore Apple IIe in TypeScript"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence e i collaboratori di Apple2TS"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -65,6 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Segnala un problema"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -65,6 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "問題を報告"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -65,9 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "問題を報告"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "プライバシーポリシー"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1230,9 +1231,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe エミュレータ"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence および Apple2TS コントリビューター"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -65,9 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "문제 보고"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "개인정보 처리방침"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1235,9 +1236,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe 에뮬레이터"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence 및 Apple2TS 기여자"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -65,6 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "문제 보고"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -53,6 +53,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr ""
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 msgctxt "config.speed"
 msgid "Emulator Speed"
 msgstr ""

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -64,9 +64,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Een probleem melden"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Privacybeleid"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1257,9 +1258,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr ""
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence en de Apple2TS-bijdragers"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -64,6 +64,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Een probleem melden"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -65,9 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Relatar um problema"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Política de privacidade"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1259,9 +1260,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "Emulador de Apple IIe em TypeScript"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence e os colaboradores do Apple2TS"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -65,6 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Relatar um problema"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -65,9 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Сообщить о проблеме"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Политика конфиденциальности"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1272,9 +1273,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "Эмулятор Apple IIe на TypeScript"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence и участники проекта Apple2TS"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -65,6 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Сообщить о проблеме"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -64,6 +64,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Rapportera ett problem"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -64,9 +64,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "Rapportera ett problem"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Integritetspolicy"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1261,9 +1262,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr ""
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence och Apple2TS-bidragsgivarna"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -70,6 +70,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "报告问题"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 msgctxt "config.speed"
 msgid "Emulator Speed"
 msgstr "模拟器速度"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -70,9 +70,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "报告问题"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "隐私政策"
 
 msgctxt "config.speed"
 msgid "Emulator Speed"
@@ -1221,9 +1222,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe 模拟器"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence 和 Apple2TS 贡献者"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -65,6 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "回報問題"
 
+msgctxt "controls.privacyPolicy"
+msgid "Privacy Policy"
+msgstr ""
+
 #, fuzzy
 msgctxt "config.speed"
 msgid "Emulator Speed"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -65,9 +65,10 @@ msgctxt "controls.reportIssue"
 msgid "Report an Issue"
 msgstr "回報問題"
 
+#, fuzzy
 msgctxt "controls.privacyPolicy"
 msgid "Privacy Policy"
-msgstr ""
+msgstr "隱私權政策"
 
 #, fuzzy
 msgctxt "config.speed"
@@ -1227,9 +1228,10 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe 模擬器"
 
+#, fuzzy
 msgctxt "help.credit"
 msgid "(c) {{year}} Chris Torrence and the Apple2TS contributors"
-msgstr ""
+msgstr "(c) {{year}} Chris Torrence 與 Apple2TS 貢獻者"
 
 #, fuzzy
 msgctxt "help.keyboardShortcuts"

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -186,12 +186,12 @@ const DisplayApple2 = () => {
   const hasAuxCard = !isApple2Plus && slotConfig[3] === "aux"
   const mem = isApple2Plus ? 64 : (hasAuxCard ? (handleGetMemSize() + 64) : 64)
   const memSize = (mem > 1100) ? ((mem / 1024).toFixed() + " MB") : (mem + " KB")
-  const status = <div className="default-font footer-item">
+  const status = <div className="default-font footer-item" translate="no">
   <>{currentSpeed} MHz, {memSize}, FPS: {avgFPS.toFixed(1)}</>
   <br />
-  <span>©{new Date().getFullYear()}&nbsp;Chris Torrence and the Apple2TS contributors<br/>
+  <span>{t("help.credit", { year: String(new Date().getFullYear()) })}<br/>
   <a id="reportIssue" href="https://github.com/ct6502/apple2ts/issues">{t("controls.reportIssue")}</a>&nbsp;&nbsp;
-  <a href="https://ct6502.org/privacy/">Privacy Policy</a>
+  <a href="https://ct6502.org/privacy/">{t("controls.privacyPolicy")}</a>
   </span>
   </div>
 


### PR DESCRIPTION
- Reuse the Help attribution translation in the footer.
- Localize the Privacy Policy label.
- Add fuzzy translations for both footer strings.