### PR TITLE
fix(debugger): preserve HGR selection across tabs

### DIFF
--- a/src/ui/panels/memory/memorydump.test.tsx
+++ b/src/ui/panels/memory/memorydump.test.tsx
@@ -1,0 +1,46 @@
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { overrideHires } from "../../graphics"
+import MemoryDump from "./memorydump"
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true
+Object.defineProperty(globalThis, "TextDecoder", {
+  configurable: true,
+  value: class { decode() { return "" } },
+})
+
+jest.mock("../../main2worker", () => ({
+  handleGetAddressGetTable: () => new Uint32Array(),
+  handleGetBreakpoints: () => new Map(),
+  handleGetMemoryDump: () => new Uint8Array(),
+  handleGetRunMode: () => 0,
+  passSetMemory: jest.fn(),
+}))
+jest.mock("../../graphics", () => ({ overrideHires: jest.fn() }))
+jest.mock("./memorytable", () => () => null)
+jest.mock("../droplist", () => ({
+  Droplist: ({ setValue, value }: { setValue: (value: string) => void, value: string }) =>
+    <button onClick={() => setValue("HGR page 1 (screen order)")}>{value}</button>,
+}))
+
+it("restores the selected HGR override when the memory view remounts", () => {
+  const container = document.createElement("div")
+  const firstRoot = createRoot(container)
+  act(() => firstRoot.render(<MemoryDump />))
+  expect(overrideHires).not.toHaveBeenCalled()
+
+  act(() => container.querySelector("button")?.click())
+  expect(overrideHires).toHaveBeenLastCalledWith(true, false)
+
+  act(() => firstRoot.unmount())
+  expect(overrideHires).toHaveBeenLastCalledWith(false, false)
+
+  const secondRoot = createRoot(container)
+  act(() => secondRoot.render(<MemoryDump />))
+  expect(container.querySelector("button")?.textContent)
+    .toBe("HGR page 1 (screen order)")
+  expect(overrideHires).toHaveBeenLastCalledWith(true, false)
+
+  act(() => secondRoot.unmount())
+})

--- a/src/ui/panels/memory/memorydump.tsx
+++ b/src/ui/panels/memory/memorydump.tsx
@@ -23,11 +23,13 @@ enum MEMORY_RANGE {
   HGR2 = "HGR page 2 (screen order)",
 }
 
+let lastMemoryRange = `${MEMORY_RANGE.CURRENT}`
+
 const MemoryDump = () => {
   const { updateBreakpoint, setUpdateBreakpoint } = useGlobalContext()
   const memoryDumpRef = useRef(null)
   const [address, setAddress] = useState("")
-  const [memoryRange, setMemoryRange] = useState(`${MEMORY_RANGE.CURRENT}`)
+  const [memoryRange, setMemoryRange] = useState(lastMemoryRange)
   const [scrollRow, setScrollRow] = useState(-1)
   const [pickWatchpoint, setPickWatchpoint] = useState(false)
   const [ascii, setAscii] = useState("")
@@ -37,6 +39,17 @@ const MemoryDump = () => {
   const [matchIndex, setMatchIndex] = useState(0)
   const [highAscii, setHighAscii] = useState(false)
   const previousMemLengthRef = useRef(0)
+
+  useEffect(() => {
+    switch (memoryRange) {
+      case MEMORY_RANGE.HGR1:
+        overrideHires(true, false)
+        return () => overrideHires(false, false)
+      case MEMORY_RANGE.HGR2:
+        overrideHires(true, true)
+        return () => overrideHires(false, false)
+    }
+  }, [memoryRange])
 
   const doSetScrollRow = (row: number) => {
     setScrollRow(row)
@@ -238,18 +251,8 @@ const MemoryDump = () => {
 
   const handleSetMemoryRange = (value: string) => {
     setAddress("")
+    lastMemoryRange = value
     setMemoryRange(value)
-    switch (value) {
-      case MEMORY_RANGE.HGR1:
-        overrideHires(true, false)
-        break
-      case MEMORY_RANGE.HGR2:
-        overrideHires(true, true)
-        break
-      default:
-        overrideHires(false, false)
-        break
-    }
   }
 
   const doPickWatchpoint = (addr: number) => {


### PR DESCRIPTION
Keep the selected HGR memory range when leaving Debugger, while releasing its display override outside the tab. Returning restores the same range and reacquires the override.