### PR TITLE
feat(video): add VidHD card emulation with Super Hi-Res graphics & Slot Configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 **Implemented enhancements:**
 
+- Add VidHD video expansion card emulation in Slot 3 for Apple IIe and Apple II+, providing Apple IIGS-compatible Super Hi-Res (SHR) 320x200 (16 colors per line from 16 12-bit RGB palettes / 4096 colors) and 640x200 dithered graphics modes.
+- Support `$C029` (`NEWVIDEO`) softswitch control, enabling seamless SHR activation and automatic Super Hi-Res box art rendering in modern software such as Total Replay.
+- Implement accurate Slot 3 ROM signature routing with `SLOTC3ROM` softswitch support, allowing VidHD hardware detection while preserving full compatibility with Apple IIe internal 80-column firmware and applications.
 - Add Applied Engineering (AE) RamWorks III auxiliary memory expansion card emulation on Apple IIe, supporting 512KB, 1MB, 4MB, and up to 8MB RAM bank switching with auxiliary 80-column and dHGR support.
 - Add Videx VideoTerm 80-Column Display Card emulation in Slot 3 for Apple II/II+ (MC6845 CRTC, 2KB static VRAM, bank switching, and official Videx 2.4 firmware ROM).
 - Implement Videx Soft Video Switch auto-switching: automatic display handover between 80-column text, 40-column text, and Apple II graphics (`GR`, `HGR`, `HGR2`). Note: In accordance with authentic Videx hardware behavior, `PR#0` resets character vectors to 40-column without resetting the display; returning the display to 40-column can be done via `Ctrl-Reset`.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This project was originally create using [Create React App](https://github.com/f
 
 Note: The integrated server and CLI were moved out of this repository into `apple2ts-server`.
 
-## Dynamic Slot Manager
+## Dynamic Slot Configurator
 
-Apple2TS features a flexible **Slot Manager** system allowing real-time configuration of expansion cards across Slots 1 through 7 via the Machine Settings menu:
+Apple2TS features a flexible **Slot Configurator** system allowing real-time configuration of expansion cards across Slots 1 through 7 via the Machine Settings menu:
 
 - **Slot 1**: *Super Serial Card (Printer / Serial Communications)
 - **Slot 2**: *Microsoft Z-80 SoftCard (CP/M), VERA Graphics Card, Passport MIDI Card
-- **Slot 3**: *Aux Card (Apple 64KB Extended 80-Col Card or Applied Engineering RamWorks III 512KB–8MB RAM / 80-Col / dHGR) on Apple IIe; *Videx VideoTerm 80-Col Card on Apple II+
+- **Slot 3**: *Aux Card (Apple 64KB Extended 80-Col Card or Applied Engineering RamWorks III 512KB–8MB RAM / 80-Col / dHGR) on Apple IIe; VidHD Video Card (Super Hi-Res 320/640x200 4096-color graphics, supports Total Replay SHR artwork); *Videx VideoTerm 80-Col Card on Apple II+
 - **Slot 4**: *Mockingboard Sound Card, Apple II Mouse Card, VERA Graphics Card, Microsoft Z-80 SoftCard
 - **Slot 5**: *Apple II Mouse Card, Microsoft Z-80 SoftCard, Mockingboard Sound Card (Dual Mockingboards supported for Ultima V!)
 - **Slot 6**: *Disk II Floppy Controller (140KB 5.25" floppies)

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -115,7 +115,7 @@ type Video7Override = {
 
 type TOUCH_JOYSTICK_MODE = "off" | "left" | "right"
 
-type SLOT_CARD_ID = "none" | "ssc" | "softcard" | "aux" | "videoterm" | "mockingboard" | "mouse" | "vera" | "passport" | "disk2" | "smartport"
+type SLOT_CARD_ID = "none" | "ssc" | "softcard" | "aux" | "videoterm" | "mockingboard" | "mouse" | "vera" | "passport" | "disk2" | "smartport" | "vidhd"
 
 type SlotConfig = {
   1: SLOT_CARD_ID,
@@ -153,6 +153,7 @@ type MachineState = {
   runMode: number,
   s6502: STATE6502,
   showDebugTab: boolean,
+  shr?: Uint8Array,
   slotConfig: SlotConfig,
   softSwitches: {[name: string]: boolean},
   speedMode: number,
@@ -161,6 +162,7 @@ type MachineState = {
   timeTravelThumbnails: Array<TimeTravelThumbnail>,
   tracelog: Array<string>,
   veraSlot: VERA_SLOT,
+  vidhdActive?: boolean,
   zeroPage: Uint8Array
 }
 

--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -151,9 +151,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr "Maschinenkonfiguration"
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Slot-Konfigurator"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -125,9 +125,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr "Machine Rigging"
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Ship's Hold Configurator"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -149,9 +149,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Configurador de ranuras"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -151,9 +151,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Configurateur de slots"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -143,9 +143,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Configuratore slot"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -142,9 +142,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "スロット設定"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -142,9 +142,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "슬롯 구성기"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -117,8 +117,8 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
 msgstr ""
 
 msgctxt "machine.models.apple2p"

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -141,9 +141,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Slotconfigurator"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -142,9 +142,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Configurador de Slots"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -142,9 +142,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Конфигуратор слотов"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -141,9 +141,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr ""
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "Kortplatskonfigurator"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -146,9 +146,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr "机器配置"
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "插槽配置器"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -144,9 +144,9 @@ msgctxt "machine.configuration"
 msgid "Machine Configuration"
 msgstr "機器配置"
 
-msgctxt "machine.slotManager"
-msgid "Slot Manager"
-msgstr ""
+msgctxt "machine.slotConfigurator"
+msgid "Slot Configurator"
+msgstr "插槽配置器"
 
 msgctxt "machine.models.apple2p"
 msgid "Apple II+"

--- a/src/ui/devices/machineconfig.tsx
+++ b/src/ui/devices/machineconfig.tsx
@@ -23,7 +23,7 @@ const retroSlotOptions = (slot: SlotNumber, machine: MACHINE_NAME): SLOT_CARD_ID
   const options: Record<SlotNumber, SLOT_CARD_ID[]> = {
     1: ["none", "ssc"],
     2: ["none", "vera", "passport", "softcard"],
-    3: machine === "APPLE2P" ? ["none", "videoterm"] : ["none", "aux"],
+    3: machine === "APPLE2P" ? ["none", "videoterm", "vidhd"] : ["none", "aux", "vidhd"],
     4: ["none", "mouse", "mockingboard", "vera", "softcard"],
     5: ["none", "mouse", "mockingboard", "softcard"],
     6: ["none", "disk2"],
@@ -38,6 +38,7 @@ const retroCardLabels = (context: RetroMenuContext): Record<SLOT_CARD_ID, string
   softcard: context.t("retroControl.card.softcard"),
   aux: context.t("retroControl.card.aux"),
   videoterm: context.t("retroControl.card.videoterm"),
+  vidhd: "VidHD (64KB / 80-Col / SHR)",
   mockingboard: context.t("retroControl.card.mockingboard"),
   mouse: context.t("retroControl.card.mouse"),
   vera: context.t("retroControl.card.vera"),
@@ -217,6 +218,7 @@ export const MachineConfig = (props: DisplayProps) => {
     softcard: "Microsoft Z-80 SoftCard",
     aux: getAuxCardLabel(extraMemSize),
     videoterm: "Videx VideoTerm 80-Col Card",
+    vidhd: "VidHD (64KB / 80-Col / SHR)",
     mockingboard: "Mockingboard Sound Card",
     mouse: "Apple II Mouse Card",
     vera: "VERA Graphics Card",
@@ -269,6 +271,11 @@ export const MachineConfig = (props: DisplayProps) => {
             isSelected: () => slotConfig[3] === "videoterm",
             onClick: () => handleSelectSlotCard(3, "videoterm"),
           },
+          {
+            label: "VidHD (64KB / 80-Col / SHR)",
+            isSelected: () => slotConfig[3] === "vidhd",
+            onClick: () => handleSelectSlotCard(3, "vidhd"),
+          },
         ]
       }
 
@@ -289,6 +296,11 @@ export const MachineConfig = (props: DisplayProps) => {
           isSelected: () => slotConfig[3] === "aux" && (opt.sizeKb === 64 ? extraMemSize <= 64 : extraMemSize === opt.sizeKb),
           onClick: () => handleSelectSlotCard(3, "aux", opt.sizeKb),
         })),
+        {
+          label: "VidHD (64KB / 80-Col / SHR)",
+          isSelected: () => slotConfig[3] === "vidhd",
+          onClick: () => handleSelectSlotCard(3, "vidhd"),
+        },
       ]
     }
     const control = sharedSlotControls.find(item => item.id === `slots.${slot}`)
@@ -329,7 +341,7 @@ export const MachineConfig = (props: DisplayProps) => {
               setPreferenceBoolean("prodosFloppy", newValue)
             }},
           { label: "-" },
-          ...[{ label: t("machine.slotManager"), isHeading: true }],
+          ...[{ label: t("machine.slotConfigurator"), isHeading: true }],
           ...([1, 2, 3, 4, 5, 6, 7] as const).map((slot) => {
             const currentCard = slotConfig[slot]
             return {

--- a/src/ui/display.tsx
+++ b/src/ui/display.tsx
@@ -184,7 +184,7 @@ const DisplayApple2 = () => {
   const machineName = handleGetMachineName()
   const slotConfig = handleGetSlotConfig()
   const isApple2Plus = machineName === "APPLE2P"
-  const hasAuxCard = !isApple2Plus && slotConfig[3] === "aux"
+  const hasAuxCard = !isApple2Plus && (slotConfig[3] === "aux" || slotConfig[3] === "vidhd")
   const mem = isApple2Plus ? 64 : (hasAuxCard ? (handleGetMemSize() + 64) : 64)
   const memSize = (mem > 1100) ? ((mem / 1024).toFixed() + " MB") : (mem + " KB")
   const status = <div className="default-font footer-item" translate="no">

--- a/src/ui/graphics.ts
+++ b/src/ui/graphics.ts
@@ -1,6 +1,8 @@
 import { handleGetAltCharSet, handleGetTextPage,
   handleGetLores, handleGetHires, handleGetNoDelayMode, passSetSoftSwitches,
   handleGetMachineName,
+  handleGetShr,
+  handleGetVidhdActive,
   handleGetSoftSwitches } from "./main2worker"
 import { convertTextPageValueToASCII, COLOR_MODE, TEST_GRAPHICS, hiresLineToAddress, toHex } from "../common/utility"
 import { convertColorsToRGBA, getHiresColors, getHiresGreen } from "./graphicshgr"
@@ -573,6 +575,107 @@ const applyCrtDistortion = (ctx: CanvasRenderingContext2D,
     xmarginPx, ymarginPx, imgWidth, imgHeight)
 }
 
+const shrRgbaBuffer = new Uint8ClampedArray(560 * 384 * 4)
+
+const processSuperHiRes = (hiddenContext: CanvasRenderingContext2D, colorMode: COLOR_MODE): boolean => {
+  const shrData = handleGetShr()
+  if (shrData.length < 0x8000) return false
+
+  const outWidth = 560
+  const outHeight = 384
+
+  // Decode 16 palettes (each has 16 colors, 2 bytes 0x0RGB)
+  const palR = new Uint8Array(256)
+  const palG = new Uint8Array(256)
+  const palB = new Uint8Array(256)
+
+  const isColor = (colorMode === COLOR_MODE.COLOR || colorMode === COLOR_MODE.NOFRINGE)
+  const isGreen = colorMode === COLOR_MODE.GREEN
+  const isAmber = colorMode === COLOR_MODE.AMBER
+
+  for (let p = 0; p < 16; p++) {
+    const pOffset = 0x7E00 + p * 32
+    for (let c = 0; c < 16; c++) {
+      const idx = (p << 4) | c
+      const colorLo = shrData[pOffset + c * 2]
+      const colorHi = shrData[pOffset + c * 2 + 1]
+      const colorWord = colorLo | (colorHi << 8)
+
+      let r = ((colorWord >> 8) & 0x0F) * 17
+      let g = ((colorWord >> 4) & 0x0F) * 17
+      let b = (colorWord & 0x0F) * 17
+
+      if (!isColor) {
+        // Monochrome / Green / Amber / B&W conversion
+        const lum = Math.round(0.299 * r + 0.587 * g + 0.114 * b)
+        if (isGreen) {
+          r = 0
+          g = lum
+          b = 0
+        } else if (isAmber) {
+          r = lum
+          g = Math.round(lum * 0.7)
+          b = 0
+        } else {
+          r = lum
+          g = lum
+          b = lum
+        }
+      }
+
+      palR[idx] = r
+      palG[idx] = g
+      palB[idx] = b
+    }
+  }
+
+    // Destination-driven sampling for 560x384 canvas
+    for (let ty = 0; ty < outHeight; ty++) {
+      const srcY = Math.min(199, Math.floor((ty * 200) / outHeight))
+      const lineOffset = srcY * 160
+      const scb = shrData[0x7D00 + srcY]
+      const palIdx = (scb & 0x0F) << 4
+      const is640 = (scb & 0x80) !== 0
+      const rowOffset = ty * outWidth * 4
+
+      if (!is640) {
+        // 320 mode
+        for (let x = 0; x < outWidth; x++) {
+          const srcX = Math.min(319, Math.floor((x * 320) / outWidth))
+          const byteVal = shrData[lineOffset + (srcX >> 1)]
+          const color4Bit = (srcX & 1) ? (byteVal & 0x0F) : ((byteVal >> 4) & 0x0F)
+          const c = palIdx | color4Bit
+
+          const px = rowOffset + x * 4
+          shrRgbaBuffer[px] = palR[c]
+          shrRgbaBuffer[px + 1] = palG[c]
+          shrRgbaBuffer[px + 2] = palB[c]
+          shrRgbaBuffer[px + 3] = 255
+        }
+      } else {
+        // 640 mode
+        for (let x = 0; x < outWidth; x++) {
+          const srcX = Math.min(639, Math.floor((x * 640) / outWidth))
+          const byteVal = shrData[lineOffset + (srcX >> 2)]
+          const shift = (3 - (srcX & 3)) * 2
+          const color2Bit = (byteVal >> shift) & 0x03
+          const colorIndex = (srcX % 4) * 4 + color2Bit
+          const c = palIdx | colorIndex
+
+          const px = rowOffset + x * 4
+          shrRgbaBuffer[px] = palR[c]
+          shrRgbaBuffer[px + 1] = palG[c]
+          shrRgbaBuffer[px + 2] = palB[c]
+          shrRgbaBuffer[px + 3] = 255
+        }
+      }
+    }
+
+    const imageData = new ImageData(shrRgbaBuffer, outWidth, outHeight)
+    hiddenContext.putImageData(imageData, 0, 0)
+    return true
+}
+
 export const ProcessDisplay = (ctx: CanvasRenderingContext2D,
   hiddenContext: CanvasRenderingContext2D,
   width: number, height: number) => {
@@ -607,8 +710,17 @@ export const ProcessDisplay = (ctx: CanvasRenderingContext2D,
   hiddenContext.fillStyle = effectBackground ?? "#000000"
   hiddenContext.fillRect(0, 0, 560, 384)
   const colorMode = getColorMode()
-  let didDraw = processLoRes(hiddenContext, colorMode)
-  didDraw = processHiRes(hiddenContext, colorMode) || didDraw
+  const isVidhdActive = handleGetVidhdActive()
+  let didDraw = false
+
+  if (isVidhdActive) {
+    didDraw = processSuperHiRes(hiddenContext, colorMode)
+  }
+  if (!didDraw) {
+    didDraw = processLoRes(hiddenContext, colorMode)
+    didDraw = processHiRes(hiddenContext, colorMode) || didDraw
+  }
+
   if (getCrtDistortion()) {
     applyCrtDistortion(ctx, hiddenContext, colorMode, width, height, effectBackground)
   } else {
@@ -617,7 +729,9 @@ export const ProcessDisplay = (ctx: CanvasRenderingContext2D,
     }
     // The hidden canvas was causing overlay issues with the text page.
     // So instead, draw the graphics first and then overlay the text chars.
-    processTextPage(ctx, hiddenContext, colorMode, width, height, false)
+    if (!isVidhdActive) {
+      processTextPage(ctx, hiddenContext, colorMode, width, height, false)
+    }
   }
   // if (TEST_GRAPHICS) {
   //   const tile = [

--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -151,9 +151,9 @@ export const setPreferenceMachineName = (name: MACHINE_NAME = "APPLE2EE") => {
   const slotConfig = getPreferenceSlotConfig()
   let newSlot3 = slotConfig[3]
   if (name === "APPLE2P") {
-    if (newSlot3 !== "none" && newSlot3 !== "videoterm") newSlot3 = "videoterm"
+    if (newSlot3 !== "none" && newSlot3 !== "videoterm" && newSlot3 !== "vidhd") newSlot3 = "videoterm"
   } else {
-    if (newSlot3 !== "none" && newSlot3 !== "aux") newSlot3 = "aux"
+    if (newSlot3 !== "none" && newSlot3 !== "aux" && newSlot3 !== "vidhd") newSlot3 = "aux"
   }
   if (slotConfig[3] !== newSlot3) {
     slotConfig[3] = newSlot3

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -526,6 +526,14 @@ export const handleGetHires = () => {
   return machineState.hires
 }
 
+export const handleGetShr = () => {
+  return machineState.shr || new Uint8Array()
+}
+
+export const handleGetVidhdActive = () => {
+  return !!machineState.vidhdActive
+}
+
 export const handleGetNoDelayMode = () => {
   return machineState.noDelayMode
 }

--- a/src/worker/devices/vidhd.test.ts
+++ b/src/worker/devices/vidhd.test.ts
@@ -1,0 +1,116 @@
+import { VidHD } from "./vidhd"
+import { memGet, memSet } from "../memory"
+import { doBoot, enableVidHD, disableVidHD } from "../motherboard"
+
+describe("VidHD Expansion Card Emulation", () => {
+  let card: VidHD
+
+  beforeEach(() => {
+    card = new VidHD(3)
+  })
+
+  test("ROM detection signatures at $C080+slot*16 ($C0B0-$C0B4) match official VidHD firmware", () => {
+    expect(card.readIO(0xC0B0)).toBe(0x24) // BIT $EA
+    expect(card.readIO(0xC0B1)).toBe(0xEA)
+    expect(card.readIO(0xC0B2)).toBe(0x4C) // JMP $FF58
+    expect(card.readIO(0xC0B3)).toBe(0x58)
+    expect(card.readIO(0xC0B4)).toBe(0xFF)
+  })
+
+  test("$C029 NEWVIDEO softswitch activates and deactivates SHR mode", () => {
+    card.enabled = true
+    expect(card.active).toBe(false)
+
+    // Write $80 to $C029 (Enable SHR)
+    card.writeSoftSwitch(0x80)
+    expect(card.readSoftSwitch()).toBe(0x80)
+    expect(card.active).toBe(true)
+    expect(card.isMonochrome).toBe(false)
+    expect(card.isLinear).toBe(false)
+
+    // Write $A0 ($80 | $20 = SHR + Monochrome)
+    card.writeSoftSwitch(0xA0)
+    expect(card.active).toBe(true)
+    expect(card.isMonochrome).toBe(true)
+
+    // Reset disables SHR
+    card.reset()
+    expect(card.active).toBe(false)
+    expect(card.readSoftSwitch()).toBe(0x00)
+  })
+
+  test("decodes 320x200 SHR mode with 12-bit RGB palettes and SCBs", () => {
+    const shrData = new Uint8Array(0x8000)
+
+    // Setup Palette 0 ($9E00 in Aux RAM -> offset $7E00 in shrData)
+    // Color 1: Red (0x0F00 -> Low byte = 0x00, High byte = 0x0F)
+    shrData[0x7E00 + 2] = 0x00
+    shrData[0x7E00 + 3] = 0x0F
+
+    // Setup SCB for line 0 ($9D00 -> offset $7D00): Mode 320 (bit 7 = 0), Palette 0 (bits 0-3 = 0)
+    shrData[0x7D00] = 0x00
+
+    // Setup Line 0 pixel data: Byte 0 has pixel 0 = Color 1, pixel 1 = Color 0 (0x10)
+    shrData[0] = 0x10
+
+    const rgba = new Uint8ClampedArray(560 * 384 * 4)
+    card.decodeShrTo560x384(shrData, rgba)
+
+    // Check that decoded RGBA has red pixel (R=255, G=0, B=0, A=255) in top-left
+    expect(rgba[0]).toBe(255) // R
+    expect(rgba[1]).toBe(0)   // G
+    expect(rgba[2]).toBe(0)   // B
+    expect(rgba[3]).toBe(255) // Alpha
+  })
+
+  test("decodes 640x200 SHR mode with 2bpp dithered colors", () => {
+    const shrData = new Uint8Array(0x8000)
+
+    // Setup Palette 2 ($9E00 + 2*32 -> offset $7E00 + 64)
+    // Color 1: Green (0x00F0 -> Low byte = 0xF0, High byte = 0x00)
+    shrData[0x7E00 + 64 + 2] = 0xF0
+    shrData[0x7E00 + 64 + 3] = 0x00
+
+    // Setup SCB for line 0: Mode 640 (bit 7 = 1), Palette 2 (bits 0-3 = 2) -> 0x82
+    shrData[0x7D00] = 0x82
+
+    // Setup Line 0 pixel data: 4 pixels of 2-bit each.
+    // Pixel 0 (bits 7-6 = 01 -> Color 1): for pixelX=0, colorIndex = (0%4)*4 + 1 = 1 (Color 1 of Palette 2)
+    shrData[0] = 0x40 // 01 00 00 00
+
+    const rgba = new Uint8ClampedArray(560 * 384 * 4)
+    card.decodeShrTo560x384(shrData, rgba)
+
+    // Check that decoded RGBA has green pixel (R=0, G=255, B=0, A=255) in top-left
+    expect(rgba[0]).toBe(0)   // R
+    expect(rgba[1]).toBe(255) // G
+    expect(rgba[2]).toBe(0)   // B
+    expect(rgba[3]).toBe(255) // Alpha
+  })
+
+  test("Memory read and write integration with slot 3", () => {
+    doBoot()
+    enableVidHD(3)
+
+    // With SLOTC3ROM OFF ($C00A, default): reads genuine internal 80-col ROM ($C300 = $2C BIT $CE43)
+    memSet(0xC00A, 0) // CLRC3ROM
+    expect(memGet(0xC300, false)).toBe(0x2C)
+
+    // With SETC3ROM ON ($C00B, Total Replay HasVidHDCard routine): reads VidHD card ROM signatures
+    memSet(0xC00B, 0) // SETC3ROM
+    expect(memGet(0xC300, false)).toBe(0x24) // BIT $EA
+    expect(memGet(0xC301, false)).toBe(0xEA)
+    expect(memGet(0xC302, false)).toBe(0x4C) // JMP $FF58
+
+    // Read Slot 3 Device I/O signature ($C0B0-$C0B2)
+    expect(memGet(0xC0B0, false)).toBe(0x24)
+    expect(memGet(0xC0B1, false)).toBe(0xEA)
+    expect(memGet(0xC0B2, false)).toBe(0x4C)
+
+    // Write to $C029 softswitch
+    memSet(0xC029, 0x80)
+    expect(memGet(0xC029, false)).toBe(0x80)
+
+    disableVidHD()
+  })
+})

--- a/src/worker/devices/vidhd.ts
+++ b/src/worker/devices/vidhd.ts
@@ -1,0 +1,161 @@
+/**
+ * VidHD Video Card Emulation for Apple2TS
+ *
+ * Implements the VidHD (Blue Shift Inc / John Brooks) HDMI expansion card,
+ * providing Apple IIGS-compatible Super Hi-Res (SHR) video modes:
+ * - 320x200 16-color per line (from 16 palettes of 4096 colors)
+ * - 640x200 4/16-color dithered mode
+ * - Softswitch $C029 (NEWVIDEO) control
+ * - Slot detection signatures ($Cn00=$24, $Cn01=$EA, $Cn02=$4C)
+ */
+
+export class VidHD {
+  enabled = false
+  slot = 3
+  newVideo = 0 // Softswitch $C029
+
+  // ROM identification buffer (256 bytes for $Cn00-$CnFF)
+  rom = new Uint8Array(256)
+
+  constructor(slot = 3) {
+    this.slot = slot
+    this.initRom()
+    this.reset()
+  }
+
+  reset(): void {
+    this.newVideo = 0
+  }
+
+  get active(): boolean {
+    return this.enabled && (this.newVideo & 0x80) !== 0
+  }
+
+  get isMonochrome(): boolean {
+    return (this.newVideo & 0x20) !== 0
+  }
+
+  get isLinear(): boolean {
+    return (this.newVideo & 0x40) !== 0
+  }
+
+  /**
+   * Initializes the Slot ROM identification bytes for VidHD.
+   * Signature: $Cn00 = $24 (BIT $EA), $Cn01 = $EA, $Cn02 = $4C (JMP $FF58)
+   */
+  private initRom(): void {
+    this.rom.fill(0x60) // RTS default
+    this.rom[0x00] = 0x24 // BIT $EA
+    this.rom[0x01] = 0xEA
+    this.rom[0x02] = 0x4C // JMP $FF58 (RTS in Apple II ROM)
+    this.rom[0x03] = 0x58
+    this.rom[0x04] = 0xFF
+  }
+
+  readMemory(addr: number): number {
+    const offset = addr & 0xFF
+    return this.rom[offset]
+  }
+
+  /**
+   * Handles $C080 + slot*16 Device I/O reads ($C0B0-$C0BF for Slot 3).
+   * Returns official VidHD detection signatures.
+   */
+  readIO(addr: number): number {
+    const reg = addr & 0x0F
+    return this.rom[reg]
+  }
+
+  readSoftSwitch(): number {
+    return this.newVideo
+  }
+
+  writeSoftSwitch(value: number): void {
+    this.newVideo = value & 0xFF
+  }
+
+  /**
+   * Extracts the 32KB Super Hi-Res region ($2000-$9FFF) from Auxiliary RAM.
+   */
+  extractShrBuffer(memory: Uint8Array, auxMemoryStart: number): Uint8Array {
+    const start = auxMemoryStart + 0x2000
+    return memory.slice(start, start + 0x8000)
+  }
+
+  /**
+   * Decodes a 32KB SHR memory block ($2000-$9FFF) into a 560x384 RGBA image buffer
+   * matching Apple2TS's standard canvas dimensions.
+   */
+  decodeShrTo560x384(shrData: Uint8Array, outRgba: Uint8ClampedArray): void {
+    const outWidth = 560
+    const outHeight = 384
+    outRgba.fill(0)
+
+    if (shrData.length < 0x8000) return
+
+    // Pre-allocated palettes lookup table: 16 palettes x 16 colors x [R, G, B]
+    const palR = new Uint8Array(256)
+    const palG = new Uint8Array(256)
+    const palB = new Uint8Array(256)
+
+    // Decode 16 palettes located at offset $7E00 ($9E00 - $2000)
+    for (let p = 0; p < 16; p++) {
+      const pOffset = 0x7E00 + p * 32
+      for (let c = 0; c < 16; c++) {
+        const idx = (p << 4) | c
+        const colorLo = shrData[pOffset + c * 2]
+        const colorHi = shrData[pOffset + c * 2 + 1]
+        const colorWord = colorLo | (colorHi << 8)
+
+        // 12-bit RGB: 0x0RGB -> 0..15 scaled to 0..255 (multiply by 17)
+        palR[idx] = ((colorWord >> 8) & 0x0F) * 17
+        palG[idx] = ((colorWord >> 4) & 0x0F) * 17
+        palB[idx] = (colorWord & 0x0F) * 17
+      }
+    }
+
+    // Destination-driven sampling for 560x384 canvas
+    for (let ty = 0; ty < outHeight; ty++) {
+      const srcY = Math.min(199, Math.floor((ty * 200) / outHeight))
+      const lineOffset = srcY * 160
+      const scb = shrData[0x7D00 + srcY]
+      const palIdx = (scb & 0x0F) << 4
+      const is640 = (scb & 0x80) !== 0
+      const rowOffset = ty * outWidth * 4
+
+      if (!is640) {
+        // 320 mode
+        for (let x = 0; x < outWidth; x++) {
+          const srcX = Math.min(319, Math.floor((x * 320) / outWidth))
+          const byteVal = shrData[lineOffset + (srcX >> 1)]
+          const color4Bit = (srcX & 1) ? (byteVal & 0x0F) : ((byteVal >> 4) & 0x0F)
+          const c = palIdx | color4Bit
+
+          const px = rowOffset + x * 4
+          outRgba[px] = palR[c]
+          outRgba[px + 1] = palG[c]
+          outRgba[px + 2] = palB[c]
+          outRgba[px + 3] = 255
+        }
+      } else {
+        // 640 mode
+        for (let x = 0; x < outWidth; x++) {
+          const srcX = Math.min(639, Math.floor((x * 640) / outWidth))
+          const byteVal = shrData[lineOffset + (srcX >> 2)]
+          const shift = (3 - (srcX & 3)) * 2
+          const color2Bit = (byteVal >> shift) & 0x03
+          const colorIndex = (srcX % 4) * 4 + color2Bit
+          const c = palIdx | colorIndex
+
+          const px = rowOffset + x * 4
+          outRgba[px] = palR[c]
+          outRgba[px + 1] = palG[c]
+          outRgba[px + 2] = palB[c]
+          outRgba[px + 3] = 255
+        }
+      }
+    }
+  }
+}
+
+export const vidhd = new VidHD(3)

--- a/src/worker/memory.ts
+++ b/src/worker/memory.ts
@@ -10,6 +10,7 @@ import { RamWorksMemoryStart, RamWorksPage, ROMpage, ROMmemoryStart, hiresLineTo
 import { isWatchpoint, setWatchpointBreak } from "./cpu6502"
 import { noSlotClock } from "./nsc"
 import { videoTerm } from "./devices/videoterm"
+import { vidhd } from "./devices/vidhd"
 
 // 0x00000: main memory
 // 0x10000...13FFF: ROM (including page $C0 soft switches)
@@ -423,6 +424,12 @@ export const readWriteAuxMem = (addr: number, write = false) => {
 }
 
 const memGetSoftSwitch = (addr: number): number => {
+  if (addr === 0xC029 && vidhd.enabled) {
+    return vidhd.readSoftSwitch()
+  }
+  if (vidhd.enabled && ((addr >> 4) === (0xC08 + vidhd.slot))) {
+    return vidhd.readIO(addr)
+  }
   if (addr === 0xC058 && videoTerm.enabled) {
     // Videx Soft Video Switch: AN0 off -> switch to 40-col display
     videoTerm.active = false
@@ -476,6 +483,16 @@ export const memGet = (addr: number, checkWatchpoints = true): number => {
         // Also support No Slot Clock (NSC) serial bit-stream read at $C3xx for NS.CLOCK.SYSTEM.
         const nscVal = noSlotClock.read(addr)
         value = (nscVal >= 0) ? nscVal : videoTerm.readMemory(addr)
+      } else if (page === 0xC3 && vidhd.enabled) {
+        if (SWITCHES.SLOTC3ROM.isSet && !SWITCHES.INTCXROM.isSet) {
+          // SLOTC3ROM is ON ($C00B): return VidHD slot ROM bytes ($24, $EA, $4C...)
+          value = vidhd.readMemory(addr)
+        } else {
+          // SLOTC3ROM is OFF ($C00A) or INTCXROM is ON: return internal Apple IIe 80-col ROM or NSC
+          const nscVal = noSlotClock.read(addr)
+          value = (nscVal >= 0) ? nscVal : -1
+          checkSlotIO(addr)
+        }
       } else if (page == 0xC3 && (SWITCHES.INTCXROM.isSet || !SWITCHES.SLOTC3ROM.isSet)) {
         // NSC answers in slot C3 memory to be compatible with standard ProDOS driver and A2osX
         value = noSlotClock.read(addr)
@@ -515,6 +532,11 @@ export const memGetRaw = (addr: number): number => {
 }
 
 const memSetSoftSwitch = (addr: number, value: number) => {
+  if (addr === 0xC029 && vidhd.enabled) {
+    vidhd.writeSoftSwitch(value)
+    SWITCHES.NEWVIDEO.isSet = (value & 0x80) !== 0
+    return
+  }
   if (addr === 0xC058 && videoTerm.enabled) {
     // Videx Soft Video Switch: AN0 off -> switch to 40-col display
     videoTerm.active = false
@@ -762,4 +784,11 @@ export const getMemoryDump = () => {
     dump.set(memory.slice(offset, offset + 256), page * 256)
   }
   return dump
+}
+
+export const getShr = (): Uint8Array => {
+  if (!vidhd.enabled || !vidhd.active) {
+    return new Uint8Array()
+  }
+  return vidhd.extractShrBuffer(memory, RamWorksMemoryStart)
 }

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -19,9 +19,11 @@ import { memory, memGet, getTextPage, getHires, memoryReset,
   doSetRom,
   getZeroPage,
   getMemoryDump as getCpuMemoryDump,
+  getShr,
   memSet,
   exportMemoryToHiresLine,
   getDataBlock,
+  setSlotDriver,
   clearSlot} from "./memory"
 import { setButtonState, handleGamepads } from "./devices/joystick"
 import { handleGameSetup } from "./games/game_mappings"
@@ -31,6 +33,7 @@ import { enableMouseCard } from "./devices/mouse"
 import { enablePassportCard, resetPassport } from "./devices/passport/passport"
 import { enableVera, resetVera } from "./devices/vera/vera"
 import { videoTerm, enableVideoTerm, disableVideoTerm } from "./devices/videoterm"
+import { vidhd } from "./devices/vidhd"
 import { enableMockingboard, resetMockingboard } from "./devices/mockingboard"
 import { resetMouse, onMouseVBL } from "./devices/mouse"
 import { enableDiskDrive } from "./devices/diskdata"
@@ -166,13 +169,13 @@ export const configureMachine = () => {
     clearSlot(s)
   }
 
-  // Ensure Slot 3 is configured properly: on IIe default to 'aux' or 'none', on II+ allow 'videoterm' or 'none'
+  // Ensure Slot 3 is configured properly: on IIe default to 'aux', 'vidhd' or 'none', on II+ allow 'videoterm', 'vidhd' or 'none'
   if (machineName === "APPLE2P") {
-    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "videoterm") {
+    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "videoterm" && currentSlotConfig[3] !== "vidhd") {
       currentSlotConfig[3] = "videoterm"
     }
   } else {
-    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "aux") {
+    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "aux" && currentSlotConfig[3] !== "vidhd") {
       currentSlotConfig[3] = "aux"
     }
   }
@@ -217,7 +220,12 @@ export const configureMachine = () => {
   } else {
     disableVideoTerm()
   }
-  setAuxCardEnabled(currentSlotConfig[3] === "aux")
+  if (currentSlotConfig[3] === "vidhd") {
+    enableVidHD(3)
+  } else {
+    disableVidHD()
+  }
+  setAuxCardEnabled(currentSlotConfig[3] === "aux" || currentSlotConfig[3] === "vidhd")
 
   // Slot 4
   if (currentSlotConfig[4] === "mockingboard") {
@@ -255,9 +263,24 @@ export const configureMachine = () => {
   get6502Instructions()
 }
 
+export const enableVidHD = (slot = 3) => {
+  vidhd.enabled = true
+  vidhd.slot = slot
+  vidhd.reset()
+  setSlotDriver(slot, vidhd.rom)
+}
+
+export const disableVidHD = () => {
+  vidhd.enabled = false
+  vidhd.reset()
+}
+
 const resetMachine = () => {
   softCard.reset()
   videoTerm.reset()
+  if (vidhd.enabled) {
+    vidhd.reset()
+  }
   resetFloppyDrives()
   setButtonState()
   resetMouse()
@@ -518,11 +541,11 @@ export const doSetMemory = (addr: number, value: number) => {
 export const doSetMachineName = (name: MACHINE_NAME, reset = true) => {
   machineName = name
   if (name === "APPLE2P") {
-    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "videoterm") {
+    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "videoterm" && currentSlotConfig[3] !== "vidhd") {
       currentSlotConfig[3] = "videoterm"
     }
   } else {
-    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "aux") {
+    if (currentSlotConfig[3] !== "none" && currentSlotConfig[3] !== "aux" && currentSlotConfig[3] !== "vidhd") {
       currentSlotConfig[3] = "aux"
     }
   }
@@ -828,6 +851,7 @@ export const getExternalMachineState = () => {
     runMode: cpuRunMode,
     s6502: s6502,
     showDebugTab: showDebugTab,
+    shr: getShr(),
     slotConfig: currentSlotConfig,
     softSwitches: getSoftSwitches(),
     speedMode: speedMode,
@@ -836,6 +860,7 @@ export const getExternalMachineState = () => {
     timeTravelThumbnails: getTimeTravelThumbnails(),
     tracelog: cpuRunMode === RUN_MODE.PAUSED ? getTracelog() : [],
     veraSlot: veraSlot,
+    vidhdActive: vidhd.active,
     zeroPage: getZeroPage(),
   }
   return state

--- a/src/worker/save_restore.ts
+++ b/src/worker/save_restore.ts
@@ -6,6 +6,7 @@ import { s6502, getStackDump, setState6502, setStackDump } from "./instructions"
 import { memory, memoryReset, RamWorksMaxBank, setRamWorks, updateAddressTables } from "./memory"
 import { configureMachine, doReset, doSetMachineName, doSetRunMode, getMachineName, getSoftSwitches, updateExternalMachineState } from "./motherboard"
 import { SWITCHES } from "./softswitches"
+import { vidhd } from "./devices/vidhd"
 import { passRequestThumbnail } from "./worker2main"
 
 let iTempState = 0
@@ -83,6 +84,9 @@ export const setApple2State = (newState: Apple2SaveState, version: number) => {
     } catch {
       // do nothing
     }
+  }
+  if (vidhd.enabled && SWITCHES.NEWVIDEO) {
+    vidhd.writeSoftSwitch(SWITCHES.NEWVIDEO.isSet ? 0x80 : 0)
   }
   // If we have an old save file, we need to set the BSR_WRITE switch
   // based upon the old bank-switched RAM switches.

--- a/src/worker/softswitches.ts
+++ b/src/worker/softswitches.ts
@@ -113,6 +113,7 @@ export const SWITCHES = {
   BSRREADRAM: NewSwitch(0, 0, 0xC012),  // status location, not a switch
   VBLINV: NewSwitch(0, 0, 0xC019),  // vertical blanking status (inverse)
   CASSOUT: NewSwitch(0xC020, 0, 0),  // random value filled in checkSoftSwitches
+  NEWVIDEO: NewSwitch(0, 0, 0xC029), // VidHD / Apple IIGS Super Hi-Res control
   SPEAKER: NewSwitch(0xC030, 0, 0, false, (addr, cycleCount) => {
     memSetC000(0xC030, rand())
     passClickSpeaker(cycleCount)


### PR DESCRIPTION
### Summary of Changes

This PR introduces VidHD video expansion card emulation in Slot 3 for both Apple //e and Apple ][+ models, bringing Apple IIGS-compatible Super Hi-Res (SHR) graphics capabilities to 8-bit Apple II machines.

<img width="1154" height="940" alt="image" src="https://github.com/user-attachments/assets/e6c9a2c2-c2c9-4c39-a837-9de4df81fc76" />

#### 1. VidHD & Super Hi-Res Graphics Emulation
- **SHR Graphics Modes**: Implements 320x200 (16 colors per scanline from 16 12-bit RGB palettes / 4096 colors) and 640x200 dithered graphics decoding into the canvas rendering pipeline.
- **`$C029` (NEWVIDEO) Softswitch**: Implements softswitch tracking and register dispatch for runtime SHR video mode switching.
- **Hardware Signature & Routing**:
  - Implements VidHD hardware signature (`$24`, `$EA`, `$4C`) accessible via Slot 3 ROM (`$C300-$C302`) when `SLOTC3ROM` (`$C00B`) is active, as well as via Device I/O space (`$C0B0-$C0BF`).
  - Preserves 100% compatibility with Apple //e internal 80-column firmware (`INTC3ROM` / `$C00A`), ensuring standard 80-column applications (such as *Pitch Dark*, ProDOS 80-col driver) and CardCat identification continue to function seamlessly.
- **Game Compatibility**: Verified with *Total Replay*—enables automatic detection of the VidHD card and renders high-definition 4096-color SHR box artwork (`ARTWORK.SHR/`).

#### 2. Slot Configurator & UI Updates
- Renamed **Slot Manager** to **Slot Configurator** across the entire UI and 14 localized `.po` language catalogs.
- Updated Slot 3 dropdown option format to `VidHD (64KB / 80-Col / SHR)` for visual consistency with `Apple 699-0221` and `AE RamWorks III`.
- Integrated VidHD options into the newly introduced Retro Theme configuration.
- Added status bar memory size calculation (128KB) and save state serialization for the `NEWVIDEO` softswitch.

#### 3. Tests & Documentation
- Added unit tests covering VidHD initialization, palette & scanline decoding, softswitch read/write, and memory integration (`src/worker/devices/vidhd.test.ts`).
- Updated `README.md` and `CHANGELOG.md` with VidHD feature details.

---

### How to Test / Verification Workflow

1. **Configure VidHD**:
   - Open **Machine Settings** (Gear icon) -> **Slot Configurator** -> **Slot 3**, and select **`VidHD (64KB / 80-Col / SHR)`**.
2. **Select Total Replay from Built-in Disk Collection**:
   - Open the **Disk Collection** dialog from the toolbar (or press `#Replay` shortcut).
   - Choose and boot **Total Replay**.
3. **Verify VidHD Hardware Detection**:
   - During the startup sequence on the branding screen, Total Replay will detect the card in Slot 3 and confirm VidHD presence.
4. **View SHR Artwork & Demos**:
   - **Attract Mode**: Let the attract mode cycle automatically; Super Hi-Res graphical slideshows and game covers will be rendered in authentic 4096 colors.
   - **Game Launch**: Select and launch any game (e.g., *Prince of Persia*) from the list—the high-resolution Super Hi-Res box artwork will immediately display before the game starts.

---

### Automated Tests
- `npm test`: 42 test suites, 613 unit tests passed (0 failures).
- `npm run lint`: 0 errors, 0 warnings.
- `npm run build`: Production bundle built successfully.

---

Hi @ct6502, not just review it, now OWN it!!! ;D 
([Call-A.P.P.L.E. VidHD Feature Article](https://www.callapple.org/modern-apple-computing/apple-ii-in-1080p-the-vidhd/))
