### PR TITLE
chore: ignore nested worktrees during checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ node_modules
 .github
 .vscode
 *.md
+/.worktrees/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ export default [
   },
   {
     // this needs to be outside of the curly braces above, so it acts as "global" ignores
-    ignores: ["**/dist", "**/.eslintrc.cjs", "**/public", "src/i18n/**/*.cjs"],
+    ignores: ["**/dist", "**/.eslintrc.cjs", "**/public", ".worktrees/**", "src/i18n/**/*.cjs"],
   },
   // Custom rules for src/ui and src/worker, to prevent imports between them
   {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,7 +3,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
-  testPathIgnorePatterns: ["/node_modules/", "/tools/"],
+  testPathIgnorePatterns: ["/node_modules/", "/tools/", "<rootDir>/\\.worktrees/"],
   moduleNameMapper: {
     "\\.(css)$": "<rootDir>/src/test/stylemock.cjs",
   },


### PR DESCRIPTION
Keep repository-wide Jest, ESLint, and Prettier checks from traversing linked checkouts stored under .worktrees.