### PR TITLE
fix(ui): prevent canvas focus from scrolling

### DIFF
--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -604,7 +604,7 @@ const Apple2Canvas = (props: DisplayProps) => {
 
   const setFocus = () => {
     if (mainCanvas) {
-      (mainCanvas as HTMLCanvasElement).focus()
+      (mainCanvas as HTMLCanvasElement).focus({ preventScroll: true })
     }
   }
 


### PR DESCRIPTION
The browser window can unexpectedly scroll to the monitor frame by passing through it with the mouse.  The focus will still follow the mouse to the monitor, but the window stays put. 