### PR TITLE
fix(cpu): defer IRQ recognition after CLI

### DIFF
--- a/src/worker/cpu6502.ts
+++ b/src/worker/cpu6502.ts
@@ -333,6 +333,10 @@ export const processInstruction = (updateTrace: ((str: string) => void) | null =
   const PC1 = s6502.PC
   // Do not trigger watchpoints. Those should only trigger on true read/writes.
   const instr = memGet(s6502.PC, false)
+  // The 6502 samples the interrupt-disable flag before CLI clears it, so a
+  // pending IRQ is not serviced until the following instruction completes.
+  const cliDefersIRQ =
+    instr === 0x58 && (s6502.PStatus & 0x04) !== 0
   const code =  pcodes[instr]
   // Make sure we only get these instruction bytes if necessary.
   // Do not trigger watchpoints. Those should only trigger on true read/writes.
@@ -398,7 +402,7 @@ export const processInstruction = (updateTrace: ((str: string) => void) | null =
     cycles = doNonMaskableInterrupt()
     setCycleCount(s6502.cycleCount + cycles)
   }
-  if (s6502.flagIRQ) {
+  if (s6502.flagIRQ && !cliDefersIRQ) {
     const intcycles = doInterruptRequest()
     if (intcycles > 0) {
       setCycleCount(s6502.cycleCount + intcycles)

--- a/src/worker/devices/mockingboard.test.ts
+++ b/src/worker/devices/mockingboard.test.ts
@@ -159,6 +159,46 @@ for (let chip = 0; chip <= 1; chip++) {
   }
 }
 
+test("Timer 1 IRQ is visible between adjacent stores", () => {
+  // mb-audit uses this boundary to distinguish a real 6522 from MegaAudio.
+  // A real 6522 interrupts after STA $00 and before STX $00, so the handler
+  // observes $02 rather than $01.
+  memory[ROMmemoryStart + 0x3FFE] = 0x03
+  memory[ROMmemoryStart + 0x3FFF] = 0x20
+  runAssemblyTest(`
+      JMP START
+IRQ   LDA $00
+      STA $10
+      BIT $C404
+      RTI
+START SEI
+      LDA #$00
+      STA $FE
+      LDA #$C4
+      STA $FF
+      STA $10
+      LDA #$01
+      STA $00
+      LDA #$00
+      STA $C40B
+      LDA #$C0
+      STA $C40E
+      LDA #$06
+      LDY #$04
+      STA ($FE),Y
+      LDA #$00
+      LDY #$05
+      STA ($FE),Y
+      LDA #$02
+      LDX #$01
+      CLI
+      STA $00
+      STX $00
+      SEI
+      LDA $10
+  `.split("\n"), 2, 0x04)
+})
+
 const interrupt = (chip: number, timer: number) => {
   const X = chip ? "8" : "0"
   const L = timer ? "8" : "4"


### PR DESCRIPTION
Addresses part of #364.

mb-audit v1.60 can mistake the Apple2TS Mockingboard for MegaAudio because Apple2TS services a pending IRQ immediately after CLI. A real 6502 lets the following instruction finish first.

- Defer a pending IRQ until the instruction after CLI completes.
- Add a focused Timer 1 regression for the boundary mb-audit checks.