### PR TITLE
fix(remote-control): wait for emulator worker results

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -23,6 +23,11 @@ declare module "*.hdv" {
 
 type MessagePayload = object | number | string | boolean | EmuGamepad[] | null
 
+type WorkerOperationResult = {
+  operationId: number,
+  error?: string,
+}
+
 type KeyboardState = {
   key: number,
   isDown: boolean,

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -49,6 +49,7 @@ export enum MSG_WORKER {
   VERA_FRAME,
   VERA_PCM_WRITE,
   VERA_PSG_WRITE,
+  OPERATION_RESULT,
 }
 
 export enum MSG_MAIN {

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -31,7 +31,6 @@ import {
   passSetBinaryBlock,
   passSetState6502,
   passSetMemory,
-  passSetRunMode,
   passSetSoftSwitches,
   passStepInto,
   passStepOut,
@@ -39,6 +38,7 @@ import {
   passTimeTravelIndex,
   passTimeTravelSnapshot,
   passSetShowDebugTab,
+  requestSetRunMode,
 } from "../main2worker"
 import { getBinaryLoadError, loadBinary, runBinary } from "../binaryload"
 import {
@@ -46,7 +46,7 @@ import {
   setPreferenceColorMode,
   setPreferenceMachineName,
   setPreferenceRamWorks,
-  setPreferenceSpeedMode,
+  requestPreferenceSpeedMode,
 } from "../localstorage"
 import { RestoreSaveState } from "../savestate"
 import { getUIState } from "../ui_settings"
@@ -399,13 +399,17 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
     case "getMemory":
       return collectMemory()
 
-    case "setRunMode":
-      passSetRunMode(Number(payload.runMode))
+    case "setRunMode": {
+      const runMode = Number(payload.runMode) as RUN_MODE
+      await requestSetRunMode(runMode)
       return collectStatus()
+    }
 
-    case "setSpeedMode":
-      setPreferenceSpeedMode(Number(payload.speedMode))
+    case "setSpeedMode": {
+      const speedMode = Number(payload.speedMode)
+      await requestPreferenceSpeedMode(speedMode)
       return collectStatus()
+    }
 
     case "setColorMode":
       setPreferenceColorMode(Number(payload.colorMode))

--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -2,7 +2,7 @@ import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
 import { TraceSettingsDefault } from "../common/util_disassemble"
 import { COLOR_MODE, DEFAULT_SLOT_CONFIG, UI_THEME, UI_THEMES } from "../common/utility"
 import { changeMockingboardMode } from "./devices/audio/mockingboard_audio"
-import { passBreakpoints, passReverseYAxis, passSetMachineName, passSetProdosFloppy, passSetRamWorks, passSetShowDebugTab, passSetSlotConfig, passSetTraceSettings, passSetVeraSlot, passSiriusJoyport, passSpeedMode, } from "./main2worker"
+import { passBreakpoints, passReverseYAxis, passSetMachineName, passSetProdosFloppy, passSetRamWorks, passSetShowDebugTab, passSetSlotConfig, passSetTraceSettings, passSetVeraSlot, passSiriusJoyport, passSpeedMode, requestSpeedMode, } from "./main2worker"
 import { getTheme, getUIState, setColorMode, setTheme, setTouchJoystickMode, setTouchJoystickSensitivity, setUIStateBoolean, BooleanKeyOf } from "./ui_settings"
 
 const booleanUIKeys: BooleanKeyOf<UIState>[] = ["arrowKeysAsJoystick",
@@ -229,13 +229,22 @@ export const setPreferenceSlotConfig = (config: SlotConfig) => {
   passSetSlotConfig(config)
 }
 
-export const setPreferenceSpeedMode = (mode = 0) => {
+const savePreferenceSpeedMode = (mode: number) => {
   if (mode === 0) {
     localStorage.removeItem("speedMode")
   } else {
     localStorage.setItem("speedMode", JSON.stringify(mode))
   }
+}
+
+export const setPreferenceSpeedMode = (mode = 0) => {
+  savePreferenceSpeedMode(mode)
   passSpeedMode(mode)
+}
+
+export const requestPreferenceSpeedMode = async (mode: number) => {
+  await requestSpeedMode(mode)
+  savePreferenceSpeedMode(mode)
 }
 
 export const setPreferenceNewReleasesChecked = (lastChecked = -1) => {

--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -274,10 +274,7 @@ export const setPreferenceSlotConfig = (
   notifySettingsChanged([1, 2, 3, 4, 5, 6, 7].map(slot => `slots.${slot}`), origin)
 }
 
-export const setPreferenceSpeedMode = (
-  mode = 0,
-  origin: SettingsChangeOrigin = "external",
-) => {
+const savePreferenceSpeedMode = (mode: number) => {
   if (mode === 0) {
     localStorage.removeItem("speedMode")
   } else {
@@ -285,7 +282,10 @@ export const setPreferenceSpeedMode = (
   }
 }
 
-export const setPreferenceSpeedMode = (mode = 0) => {
+export const setPreferenceSpeedMode = (
+  mode = 0,
+  origin: SettingsChangeOrigin = "external",
+) => {
   savePreferenceSpeedMode(mode)
   passSpeedMode(mode)
   notifySettingsChanged(["options.speed"], origin)

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -1,0 +1,90 @@
+import { MSG_WORKER, RUN_MODE } from "../common/utility"
+import {
+  doOnMessage,
+  requestSetRunMode,
+  requestSpeedMode,
+  setMain2Worker,
+} from "./main2worker"
+
+jest.mock("./panels/disassembly/disassembly_utilities", () => ({
+  set6502Instructions: jest.fn(),
+  setDisassemblyVisibleMode: jest.fn(),
+}))
+jest.mock("./devices/audio/speaker", () => ({
+  emulatorSoundEnable: jest.fn(),
+  clickSpeaker: jest.fn(),
+}))
+jest.mock("./devices/disk/driveprops", () => ({ doSetUIDriveProps: jest.fn() }))
+jest.mock("./ui_settings", () => ({ getHelpText: () => "" }))
+
+const worker = { postMessage: jest.fn() }
+
+const sendMachineState = (runMode: RUN_MODE) => {
+  doOnMessage({
+    data: {
+      msg: MSG_WORKER.MACHINE_STATE,
+      payload: { runMode, speedMode: 0, cpuSpeed: 0 } as MachineState,
+    },
+  } as MessageEvent)
+}
+
+const sendOperationResult = (operationId: number, error?: string) => {
+  doOnMessage({
+    data: {
+      msg: MSG_WORKER.OPERATION_RESULT,
+      payload: { operationId, error },
+    },
+  } as MessageEvent)
+}
+
+const lastOperationId = () => worker.postMessage.mock.calls.at(-1)[0].operationId as number
+
+describe("worker operations", () => {
+  beforeAll(() => setMain2Worker(worker as unknown as Worker))
+  beforeEach(() => worker.postMessage.mockClear())
+
+  test("resolves only the operation named by the worker result", async () => {
+    const operation = requestSpeedMode(4)
+    const operationId = lastOperationId()
+
+    sendOperationResult(operationId)
+
+    await expect(operation).resolves.toBeUndefined()
+  })
+
+  test("does not resolve an operation with another result", async () => {
+    let resolved = false
+    const operation = requestSetRunMode(RUN_MODE.PAUSED).then(() => {
+      resolved = true
+    })
+    const operationId = lastOperationId()
+
+    sendOperationResult(operationId + 1)
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    sendMachineState(RUN_MODE.PAUSED)
+    sendOperationResult(operationId)
+    await expect(operation).resolves.toBeUndefined()
+  })
+
+  test("reports a worker error", async () => {
+    const operation = requestSetRunMode(RUN_MODE.NEED_RESET)
+    sendOperationResult(lastOperationId(), "Worker operation was superseded")
+
+    await expect(operation).rejects.toThrow("Worker operation was superseded")
+  })
+
+  test("reports an operation timeout", async () => {
+    jest.useFakeTimers()
+    try {
+      const operation = expect(requestSpeedMode(4, 25)).rejects.toThrow(
+        "Timed out waiting for worker operation",
+      )
+      jest.advanceTimersByTime(25)
+      await operation
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -23,6 +23,42 @@ let saveStateCallback: (sState: EmulatorSaveState) => void
 let bootCallback: (() => void) | null = null
 let serialConfigCallback: ((config: SerialConfig) => void) | null = null
 let captureBootStateResolve: ((result: CaptureBootResult | null) => void) | null = null
+let nextWorkerOperationId = 0
+const pendingWorkerOperations = new Map<number, {
+  resolve: () => void,
+  reject: (error: Error) => void,
+  timeout: ReturnType<typeof setTimeout>,
+}>()
+
+const requestWorkerOperation = (
+  msg: MSG_MAIN,
+  payload: MessagePayload,
+  timeoutMs = 5000,
+): Promise<void> => new Promise((resolve, reject) => {
+  const operationId = ++nextWorkerOperationId
+  const operation = {
+    resolve,
+    reject,
+    timeout: setTimeout(() => {
+      pendingWorkerOperations.delete(operationId)
+      reject(new Error("Timed out waiting for worker operation"))
+    }, timeoutMs),
+  }
+  pendingWorkerOperations.set(operationId, operation)
+  doPostMessage(msg, payload, operationId)
+})
+
+const resolveWorkerOperation = ({ operationId, error }: WorkerOperationResult) => {
+  const operation = pendingWorkerOperations.get(operationId)
+  if (!operation) return
+  clearTimeout(operation.timeout)
+  pendingWorkerOperations.delete(operationId)
+  if (error) {
+    operation.reject(new Error(error))
+  } else {
+    operation.resolve()
+  }
+}
 
 export const setMain2Worker = (workerIn: Worker) => {
   worker = workerIn
@@ -36,8 +72,9 @@ export const setSerialConfigCallback = (callback: (config: SerialConfig) => void
   serialConfigCallback = callback
 }
 
-const doPostMessage = (msg: MSG_MAIN, payload: MessagePayload) => {
-  if (worker) worker.postMessage({msg, payload})
+const doPostMessage = (msg: MSG_MAIN, payload: MessagePayload, operationId?: number) => {
+  if (!worker) return
+  worker.postMessage(operationId === undefined ? {msg, payload} : {msg, payload, operationId})
 }
 
 export const passSetRunMode = (runMode: RUN_MODE) => {
@@ -46,6 +83,14 @@ export const passSetRunMode = (runMode: RUN_MODE) => {
   }
   doPostMessage(MSG_MAIN.RUN_MODE, runMode)
   machineState.runMode = runMode
+}
+
+export const requestSetRunMode = (runMode: RUN_MODE, timeoutMs = 5000) => {
+  if (runMode === RUN_MODE.NEED_BOOT && bootCallback) {
+    bootCallback()
+  }
+  machineState.runMode = runMode
+  return requestWorkerOperation(MSG_MAIN.RUN_MODE, runMode, timeoutMs)
 }
 
 export const passSetCyclesToRun = (cycles: number) => {
@@ -98,6 +143,11 @@ export const passSpeedMode = (mode: number) => {
   doPostMessage(MSG_MAIN.SPEED, mode)
   // Force the state right away, so the UI can update.
   machineState.speedMode = mode
+}
+
+export const requestSpeedMode = (mode: number, timeoutMs = 5000) => {
+  machineState.speedMode = mode
+  return requestWorkerOperation(MSG_MAIN.SPEED, mode, timeoutMs)
 }
 
 export const passGoForwardInTime = () => {
@@ -358,6 +408,9 @@ export const doOnMessage = (e: MessageEvent): {speed: number, helptext: string} 
       const helpText = getHelpText()
       return {speed: machineState.cpuSpeed, helptext: helpText}
     }
+    case MSG_WORKER.OPERATION_RESULT:
+      resolveWorkerOperation(e.data.payload as WorkerOperationResult)
+      break
     case MSG_WORKER.SAVE_STATE: {
       const sState = e.data.payload as EmulatorSaveState
       if (saveStateCallback) saveStateCallback(sState)

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -8,6 +8,7 @@ import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
 import { getCurrentDriveState } from "./devices/drivestate"
+import * as worker2main from "./worker2main"
 
 // Make sure we don't accidentally leave debug mode on.
 test("debugMode", () => {
@@ -158,6 +159,45 @@ test("slow CPU refresh reaches the bottom HGR scanline", () => {
     SWITCHES.PAGE2.isSet = oldPage2
     jest.clearAllTimers()
     jest.useRealTimers()
+  }
+})
+
+test("speed operations complete after applying their mode", () => {
+  setIsTesting()
+  const previousState = getExternalMachineState()
+  doSetRunMode(RUN_MODE.PAUSED)
+  const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
+
+  try {
+    doSetSpeedMode(4, 7)
+
+    expect(getExternalMachineState().speedMode).toEqual(4)
+    expect(passOperationResult).toHaveBeenCalledWith(7)
+  } finally {
+    passOperationResult.mockRestore()
+    doSetSpeedMode(previousState.speedMode)
+    doSetRunMode(previousState.runMode)
+  }
+})
+
+test("run changes complete after publishing their state", () => {
+  const previousState = getExternalMachineState()
+  const passMachineState = jest.spyOn(worker2main, "passMachineState")
+  const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
+
+  try {
+    doSetRunMode(RUN_MODE.PAUSED, true, 7)
+    expect(passMachineState).toHaveBeenCalledWith(expect.objectContaining({
+      runMode: RUN_MODE.PAUSED,
+    }))
+    expect(passOperationResult).toHaveBeenCalledWith(7)
+    expect(passMachineState.mock.invocationCallOrder[0]).toBeLessThan(
+      passOperationResult.mock.invocationCallOrder[0],
+    )
+  } finally {
+    passMachineState.mockRestore()
+    passOperationResult.mockRestore()
+    doSetRunMode(previousState.runMode)
   }
 })
 

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -1,5 +1,5 @@
 // Chris Torrence, 2022
-import { passMachineState, passSoftSwitchDescriptions } from "./worker2main"
+import { passMachineState, passSoftSwitchDescriptions, passWorkerOperationResult } from "./worker2main"
 import { s6502, setState6502, reset6502, setCycleCount, setPC, getStackString, get6502Instructions } from "./instructions"
 import { hiresAddressToLine, RUN_MODE, TEST_DEBUG, DEFAULT_SLOT_CONFIG } from "../common/utility"
 import { resetFloppyDrives, doPauseDrive, getHardDriveState, doSetEmuDriveNewData, getProdosFloppy } from "./devices/drivestate"
@@ -57,6 +57,7 @@ let showDebugTab = false
 let refreshTime = 16.6881 // = 17030 / 1020.488
 let cpuCyclesPerRefresh = 17030
 let cpuRunMode = RUN_MODE.IDLE
+let pendingRunModeOperation: number | undefined
 let cyclesToRun = 0
 let nextFrameTime = 0
 let machineName: MACHINE_NAME = "APPLE2EE"
@@ -370,13 +371,14 @@ export const doReset = () => {
 // Note that making the cyclesPerRefresh too large can cause games to be
 // less responsive to keyboard input, since we're checking the keyboard
 // less often.
-export const doSetSpeedMode = (speedModeIn: number) => {
+export const doSetSpeedMode = (speedModeIn: number, operationId?: number) => {
   speedMode = speedModeIn
   // speedMode = -2 is slowest, but add 2 to it to make the arrays be zero based.
   // speedMode = 0 is still 1 MHz, so no risk of backwards compatibility issues.
   refreshTime = (speedMode === 4) ? 0 : 16.6881
   cpuCyclesPerRefresh = 17030 * ([0.1, 0.5, 1, 2, 3, 4, 24])[speedMode + 2]
   resetRefreshCounter()
+  if (operationId !== undefined) passWorkerOperationResult(operationId)
 }
 
 // Boot a floppy disk image, run at ludicrous speed until the given entry
@@ -661,7 +663,16 @@ const resetRefreshCounter = () => {
   nextFrameTime = performance.now()
 }
 
-export const doSetRunMode = (cpuRunModeIn: RUN_MODE, doShowDebugTab = true) => {
+export const doSetRunMode = (
+  cpuRunModeIn: RUN_MODE,
+  doShowDebugTab = true,
+  operationId?: number,
+) => {
+  if (pendingRunModeOperation !== undefined && pendingRunModeOperation !== operationId) {
+    passWorkerOperationResult(pendingRunModeOperation, "Worker operation was superseded")
+  }
+  const isTransitional = cpuRunModeIn === RUN_MODE.NEED_BOOT || cpuRunModeIn === RUN_MODE.NEED_RESET
+  pendingRunModeOperation = isTransitional ? operationId : undefined
   configureMachine()
   if (doShowDebugTab && cpuRunMode === RUN_MODE.RUNNING && cpuRunModeIn === RUN_MODE.PAUSED) {
     showDebugTab = true
@@ -722,6 +733,7 @@ export const doSetRunMode = (cpuRunModeIn: RUN_MODE, doShowDebugTab = true) => {
     cpuSpeed = 1
     doAdvance6502Timer()
   }
+  if (operationId !== undefined && !isTransitional) passWorkerOperationResult(operationId)
 }
 
 export const doSetCyclesToRun = (cycles: number) => {
@@ -908,11 +920,17 @@ const doAdvance6502 = () => {
     return
   }
   if (cpuRunMode === RUN_MODE.NEED_BOOT) {
+    const operationId = pendingRunModeOperation
+    pendingRunModeOperation = undefined
     doBoot()
     doSetRunMode(RUN_MODE.RUNNING)
+    if (operationId !== undefined) passWorkerOperationResult(operationId)
   } else if (cpuRunMode === RUN_MODE.NEED_RESET) {
+    const operationId = pendingRunModeOperation
+    pendingRunModeOperation = undefined
     doReset()
     doSetRunMode(RUN_MODE.RUNNING)
+    if (operationId !== undefined) passWorkerOperationResult(operationId)
   }
   let cycleTotal = 0
   let currentLine = -1

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -136,6 +136,10 @@ export const passCaptureBootStateResponse = (result: CaptureBootResult | null) =
   doPostMessage(MSG_WORKER.CAPTURE_BOOT_STATE_RESPONSE, result)
 }
 
+export const passWorkerOperationResult = (operationId: number, error?: string) => {
+  doPostMessage(MSG_WORKER.OPERATION_RESULT, { operationId, error })
+}
+
 // We do this weird check so we can safely run this code from the node.js
 // command line where self will be undefined.
 if (typeof self !== "undefined") {
@@ -147,7 +151,7 @@ if (typeof self !== "undefined") {
     if (!("msg" in e.data)) return
     switch (e.data.msg as MSG_MAIN) {
       case MSG_MAIN.RUN_MODE:
-        doSetRunMode(e.data.payload as RUN_MODE)
+        doSetRunMode(e.data.payload as RUN_MODE, true, e.data.operationId)
         break
       case MSG_MAIN.CYCLES_TO_RUN:
         doSetCyclesToRun(e.data.payload as number)
@@ -180,7 +184,7 @@ if (typeof self !== "undefined") {
         doSetBasicStep()
         break
       case MSG_MAIN.SPEED:
-        doSetSpeedMode(e.data.payload as number)
+        doSetSpeedMode(e.data.payload as number, e.data.operationId)
         break
       case MSG_MAIN.TIME_TRAVEL_STEP:
         if (e.data.payload === "FORWARD") {


### PR DESCRIPTION
## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator.

Before this fix, the browser control bridge could report “done” to MCP or
another remote-control client while the emulator worker was still processing
the command. The client could then inspect stale state or send its next command
too early.

This slice makes the bridge report completion only after the emulator worker
applies the operation.

## What was implemented in this slice

- Added one shared operation/result path between the browser UI and emulator
  worker.
- Confirmed pause and resume after the worker publishes their state, and boot
  and reset after the emulator returns to running.
- Confirmed speed changes after application and saved remote speed preferences
  after confirmation.
- Matched failures, superseded operations, and timeouts to the caller that
  initiated them.

## Verification

- A browser session paused and accepted speed mode 4 while paused.
- Reset returned after the emulator reported running.
- Delayed, mismatched, superseded, and timed-out operations settled the correct
  caller.
