### PR TITLE
feat(update)/Update Pitch Dark disk image to R6 with VidHD SHR Support

### DIFF
--- a/src/ui/devices/disk/diskimages.ts
+++ b/src/ui/devices/disk/diskimages.ts
@@ -110,11 +110,11 @@ export const diskImages: DiskCollectionItem[] = [
   },
   {
     title: "Pitch Dark",
-    diskUrl: "https://ct6502.org/wp-content/uploads/2026/01/PitchDark.hdv_.zip",
+    diskUrl: "https://github.com/anomixer/pitch-dark/releases/download/R6/Pitch_Dark.hdv.zip",
     helpFile: "PitchDark.txt",
     // diskUrl: "https://archive.org/download/PitchDark/00playable.hdv",
     imageUrl: "disks/Pitch%20Dark.png",
-    detailsUrl: "https://archive.org/details/PitchDark",
+    detailsUrl: "https://github.com/anomixer/pitch-dark/releases",
     type: undefined,
     lastUpdated: new Date(0),
     fileSize: 33553920

--- a/src/ui/mcp/mcp_resources.ts
+++ b/src/ui/mcp/mcp_resources.ts
@@ -33,7 +33,7 @@ const DISK_CATALOG = [
     description: "Frontend for 8 classic RPG scenarios with integrated character editor and save management. Navigate by typing the first 3-4 characters of a game name and pressing Enter.",
     games: "Classic RPGs: Wizardry: Proving Grounds of the Mad Overlord and other Wizardry series games with WizPlus character editor integration"
   },
-  { name: "Pitch Dark", filename: "https://ct6502.org/wp-content/uploads/2026/01/PitchDark.hdv_.zip", path: "https://ct6502.org/wp-content/uploads/2026/01/PitchDark.hdv_.zip", type: "game", description: "Interactive fiction adventure" },
+  { name: "Pitch Dark", filename: "https://github.com/anomixer/pitch-dark/releases/download/R6/Pitch_Dark.hdv.zip", path: "https://github.com/anomixer/pitch-dark/releases/download/R6/Pitch_Dark.hdv.zip", type: "game", description: "Interactive fiction adventure" },
   { name: "Aztec", filename: "Aztec.po", path: "disks/Aztec.po", type: "game", description: "Adventure game exploring Aztec pyramid" },
   { name: "Eamon", filename: "Eamon%201.po", path: "disks/Eamon%201.po", type: "game", description: "Text adventure RPG system" },
   { name: "MECC Inspector", filename: "MECC-Inspector.woz", path: "disks/MECC-Inspector.woz", type: "educational", description: "Educational detective game" },


### PR DESCRIPTION
### Description
This PR updates the built-in Pitch Dark disk image in the disk collection to the latest **Revision 6**. 

The main highlight of R6 is full support for **Apple //e Enhanced with VidHD**, allowing users to experience the stunning 4096-color Super High-Res (SHR) box artwork directly on an Apple //e emulator.

### Tested Emulators
The R6 HDV has been successfully tested to properly display the 4096-color SHR artwork on the following Apple //e emulators with VidHD support:
* `Apple2TS` (This project!)
* `AppleWin`
* `izapple`
* `microM8`
* `emu6502` (with my custom patch)

### Note to Maintainer (Chris) @ct6502 
This PR is mainly intended as a demonstration. Feel free to merge it directly, or if you prefer to host the image yourself, you can manually grab the new R6 `Pitch_Dark.hdv` or `Pitch_Dark.hdv.zip` from my releases page and update your collection accordingly:
📥 [Pitch Dark R6 Release Download](https://github.com/anomixer/pitch-dark/releases)

***
**P.S.** The original Pitch Dark repository (R5) was archived on July 17th, and the original Apple //e SHR implementation was only half-finished. That's why I had to create a separate fork to finish the job! ;)

### Screenshots
Here is a comparison showing the standard Apple //e display vs. the Apple //e enhanced with VidHD:

## Apple //e Standard
<img width="790" height="772" alt="image" src="https://github.com/user-attachments/assets/9c50f623-94f0-4355-a617-e82118e4c15a" />

## Apple //e with VidHD (4096 Colors)
<img width="792" height="778" alt="Screenshot 2026-08-26 183214" src="https://github.com/user-attachments/assets/2fb7c261-1224-4b7e-9e0f-d0bf278488e7" />
