### PR TITLE
Implement hardware-accurate handling for instructions that mutate the I flag

### DIFF
--- a/src/worker/cpu6502.ts
+++ b/src/worker/cpu6502.ts
@@ -1,4 +1,4 @@
-import { doInterruptRequest, doNonMaskableInterrupt, getLastJSR, getProcessorStatus, incrementPC, pcodes, s6502, setCycleCount } from "./instructions"
+import { clearInterruptEntry, doInterruptRequest, doNonMaskableInterrupt, getLastJSR, getProcessorStatus, incrementPC, isInterruptDisabled, pcodes, s6502, setCycleCount } from "./instructions"
 import { memGet, memGetRaw, specialJumpTable } from "./memory"
 import { doSetRunMode, doTakeSnapshot, runOnlyMode } from "./motherboard"
 import { SWITCHES } from "./softswitches"
@@ -366,7 +366,13 @@ export const processInstruction = (updateTrace: ((str: string) => void) | null =
   }
 
   // *** EXECUTE A SINGLE INSTRUCTION ***
+  // Instructions that mutate the I flag need special handling:
+  // CLI, SEI, and PLP use the pre-instruction value for the next IRQ decision.
+  // RTI uses the value restored from the stack.
+  let interruptDisabled = isInterruptDisabled()
+  clearInterruptEntry()
   cycles = code.execute(vLo, vHi)
+  if (code.pcode === 0x40) interruptDisabled = isInterruptDisabled()
 
   if (updateTrace) {
     // Do not output during the Apple II's WAIT subroutine
@@ -399,7 +405,7 @@ export const processInstruction = (updateTrace: ((str: string) => void) | null =
     setCycleCount(s6502.cycleCount + cycles)
   }
   if (s6502.flagIRQ) {
-    const intcycles = doInterruptRequest()
+    const intcycles = doInterruptRequest(interruptDisabled)
     if (intcycles > 0) {
       setCycleCount(s6502.cycleCount + intcycles)
       cycles = intcycles

--- a/src/worker/instructions.test.ts
+++ b/src/worker/instructions.test.ts
@@ -54,8 +54,10 @@ test("doBranch", () => {
   @param accumExpect The expected value for the Accumulator after the run.
   @param pstat The expected value for the Processor Status after the run.
   @param debug (Optional) Print the program counter during execution.
+  @param interruptDisabled (Optional) Initial interrupt-disable state.
 */
-export const runAssemblyTest = (instr: string[], accumExpect: number, pstat: number, debug=false) => {
+export const runAssemblyTest = (instr: string[], accumExpect: number, pstat: number,
+  debug=false, interruptDisabled=false) => {
   const irqClear = 0x1FFF
   const start = 0x2000
   // Make sure reset6502 doesn't stomp on our flags for our interrupt tests.
@@ -67,7 +69,7 @@ export const runAssemblyTest = (instr: string[], accumExpect: number, pstat: num
   enableMockingboard(true, 4)
 //  resetMockingboard(4, true)
   updateAddressTables()
-  setInterruptDisabled(false)
+  setInterruptDisabled(interruptDisabled)
   if (instr.length === 1) {
     instr[0] = " " + instr[0]
   }
@@ -417,9 +419,9 @@ test("IRQ masked",   () => {
   // Force our fake ROM's BRK/IRQ vector to point to our handler
   memory[ROMmemoryStart + 0x3FFE] = 0x06
   memory[ROMmemoryStart + 0x3FFF] = 0x20
-  // This should interrupt right after our first instruction
+  // Start with IRQs masked; SEI should leave the pending request masked.
   interruptRequest()
-  runAssemblyTest(irqmasked.split("\n"), 0x33, I)
+  runAssemblyTest(irqmasked.split("\n"), 0x33, I, false, true)
 })
 
 const irqenabled =
@@ -455,6 +457,96 @@ test("IRQ with RTI",   () => {
   // This should interrupt right after our first instruction
   interruptRequest()
   runAssemblyTest(irq_rti.split("\n"), 0x33, 0)
+})
+
+type IrqBoundary = "current" | "next" | "masked"
+
+const pendingIrqCases: Array<[string, number, boolean, boolean, IrqBoundary]> = [
+  ["CLI with I clear", 0x58, false, false, "current"],
+  ["CLI clearing I", 0x58, true, false, "next"],
+  ["SEI setting I", 0x78, false, true, "current"],
+  ["SEI with I set", 0x78, true, true, "masked"],
+  ["PLP keeping I clear", 0x28, false, false, "current"],
+  ["PLP clearing I", 0x28, true, false, "next"],
+  ["PLP setting I", 0x28, false, true, "current"],
+  ["PLP keeping I set", 0x28, true, true, "masked"],
+  ["RTI keeping I clear", 0x40, false, false, "current"],
+  ["RTI clearing I", 0x40, true, false, "current"],
+  ["RTI setting I", 0x40, false, true, "masked"],
+  ["RTI keeping I set", 0x40, true, true, "masked"],
+]
+
+test.each(pendingIrqCases)("pending IRQ boundary: %s", (_name, opcode,
+  initiallyDisabled, finallyDisabled, boundary) => {
+  const start = 0x2000
+  const irqHandler = 0x3000
+  reset6502()
+  updateAddressTables()
+  memory[start] = opcode
+  memory[start + 1] = 0xEA // NOP at the following instruction boundary
+  memory[ROMmemoryStart + 0x3FFE] = irqHandler & 0xFF
+  memory[ROMmemoryStart + 0x3FFF] = irqHandler >> 8
+  setPC(start)
+  setInterruptDisabled(initiallyDisabled)
+
+  if (opcode === 0x28) {
+    s6502.StackPtr = 0xFE
+    memory[0x1FF] = finallyDisabled ? I : 0
+  } else if (opcode === 0x40) {
+    s6502.StackPtr = 0xFC
+    memory[0x1FD] = finallyDisabled ? I : 0
+    memory[0x1FE] = (start + 1) & 0xFF
+    memory[0x1FF] = (start + 1) >> 8
+  }
+
+  interruptRequest()
+  processInstruction()
+  expect(s6502.PC).toEqual(boundary === "current" ? irqHandler : start + 1)
+
+  if (boundary !== "current") {
+    processInstruction()
+    expect(s6502.PC).toEqual(boundary === "next" ? irqHandler : start + 2)
+  }
+})
+
+test("pending IRQ does not nest after BRK", () => {
+  const start = 0x2000
+  const irqHandler = 0x3000
+  reset6502()
+  updateAddressTables()
+  memory[start] = 0x00
+  memory[ROMmemoryStart + 0x3FFE] = irqHandler & 0xFF
+  memory[ROMmemoryStart + 0x3FFF] = irqHandler >> 8
+  setPC(start)
+  setInterruptDisabled(false)
+  interruptRequest()
+
+  processInstruction()
+
+  expect(s6502.PC).toEqual(irqHandler)
+  expect(s6502.StackPtr).toEqual(0xFC)
+})
+
+test("NMI prevents IRQ entry at the same boundary", () => {
+  const start = 0x2000
+  const nmiHandler = 0x3000
+  const irqHandler = 0x4000
+  reset6502()
+  updateAddressTables()
+  memory[start] = 0xEA
+  memory[ROMmemoryStart + 0x3FFA] = nmiHandler & 0xFF
+  memory[ROMmemoryStart + 0x3FFB] = nmiHandler >> 8
+  memory[ROMmemoryStart + 0x3FFE] = irqHandler & 0xFF
+  memory[ROMmemoryStart + 0x3FFF] = irqHandler >> 8
+  setPC(start)
+  setInterruptDisabled(false)
+  nonMaskableInterrupt()
+  interruptRequest()
+
+  processInstruction()
+
+  expect(s6502.PC).toEqual(nmiHandler)
+  expect(s6502.StackPtr).toEqual(0xFC)
 })
 
 const nmi =

--- a/src/worker/instructions.ts
+++ b/src/worker/instructions.ts
@@ -4,6 +4,9 @@ import { pass6502Instructions } from "./worker2main"
 // var startTime = performance.now()
 
 export const s6502: STATE6502 = default6502State()
+let interruptEntryStarted = false
+
+export const clearInterruptEntry = () => { interruptEntryStarted = false }
 
 export const setAccumulator = (value: number) => {
   s6502.Accum = value
@@ -36,6 +39,7 @@ export const reset6502 = () => {
   setPC(memGet(0xFFFD, false) * 256 + memGet(0xFFFC, false))
   s6502.flagIRQ = 0
   s6502.flagNMI = false
+  clearInterruptEntry()
 }
 
 export const incrementPC = (value: number) => {
@@ -145,7 +149,7 @@ const isZero = () => { return ((s6502.PStatus & 0x02) !== 0) }
 const setZero = (set = true) => s6502.PStatus = set ? s6502.PStatus | 2 :
   s6502.PStatus & 0b11111101
 
-const isInterruptDisabled = () => { return ((s6502.PStatus & 0x04) !== 0) }
+export const isInterruptDisabled = () => { return ((s6502.PStatus & 0x04) !== 0) }
 export const setInterruptDisabled = (set = true) => s6502.PStatus = set ? s6502.PStatus | 4 :
   s6502.PStatus & 0b11111011
 
@@ -345,6 +349,7 @@ PCODE("BIT", ADDR_MODE.ABS_X, 0x3C, 3,
   doBit(memGet(addr)); return 4 + pageBoundary(addr, address(vLo, vHi))}, is65C02)
 
 const doInterrupt = (name: string, addr: number, pcOffset = 0) => {
+  interruptEntryStarted = true
   // I don't think the real Apple IIe switches back to main ROM $C300
   // Comment these out and see if we run into problems
   // memSet(0xC006, 0)  // slot ROM $C100-$CFFF
@@ -369,8 +374,8 @@ const doBrk = () => {
 }
 PCODE("BRK", ADDR_MODE.IMPLIED, 0x00, 1, doBrk)
 
-export const doInterruptRequest = (): number => {
-  if (isInterruptDisabled()) return 0
+export const doInterruptRequest = (interruptDisabled: boolean): number => {
+  if (interruptDisabled || interruptEntryStarted) return 0
   setBreak(false)
   doInterrupt("IRQ", 0xFFFE)
   return 7


### PR DESCRIPTION
While testing mb-audit v1.60 for #364, Apple2TS was misidentified as a MegaAudio card. The test exposed that Apple2TS evaluated a pending IRQ using the I flag after CLI. Real 6502 hardware uses the value from before the instruction for that IRQ decision.

The same hardware rule applies to SEI and PLP. RTI instead uses the I flag restored from the stack.

Saving the pre-instruction I flag introduces one additional case to handle. BRK can begin interrupt entry while executing, and a pending NMI is serviced immediately after the instruction, before the IRQ check. Because that check now reuses the saved I value, it could otherwise begin a second interrupt at the same boundary. An `interruptEntryStarted` guard suppresses that duplicate IRQ.

Focused tests cover these I-flag transitions and interrupt-entry cases.

This corrects the IRQ timing behind the mb-audit misclassification without special-casing the audit.

Related to #364.
