### PR TITLE
Change Slot 2 default to None and remove asterisks from card labels

### DIFF
--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -106,7 +106,7 @@ export enum MSG_MAIN {
 
 export const DEFAULT_SLOT_CONFIG: SlotConfig = {
   1: "ssc",
-  2: "softcard",
+  2: "none",
   3: "aux",
   4: "mockingboard",
   5: "mouse",

--- a/src/ui/devices/machineconfig.tsx
+++ b/src/ui/devices/machineconfig.tsx
@@ -266,7 +266,7 @@ export const MachineConfig = (props: DisplayProps) => {
             onClick: () => handleSelectSlotCard(3, "none"),
           },
           {
-            label: "*Videx VideoTerm 80-Col Card",
+            label: "Videx VideoTerm 80-Col Card",
             isSelected: () => slotConfig[3] === "videoterm",
             onClick: () => handleSelectSlotCard(3, "videoterm"),
           },
@@ -280,7 +280,7 @@ export const MachineConfig = (props: DisplayProps) => {
 
       // Apple IIe options
       const auxOptions = RAM_OPTIONS.map(sizeKb => ({
-        label: `${sizeKb === 64 ? "*" : ""}${getAuxCardLabel(sizeKb)}`,
+        label: `${getAuxCardLabel(sizeKb)}`,
         sizeKb,
       }))
 


### PR DESCRIPTION
# Change Slot 2 default to None (Opt-in SoftCard)

### Description
This PR addresses the issue raised in #363 regarding the Z-80 SoftCard being active by default in Slot 2.

As noted by @3amcinnamonroll, the Z-80 SoftCard's hardware behavior causes it to activate and transfer execution to the Z80 when its address space is probed (e.g., writing `$00` to `$C20E`). While this is accurate emulation, having it enabled by default causes unintended crashes or hangs in standard 6502 software that scans expansion slots—such as the Mockingboard detection routine.

### Changes Made
1. **Updated Default Configuration**: Changed `DEFAULT_SLOT_CONFIG` for Slot 2 from `"softcard"` to `"none"`. This makes the Z-80 SoftCard opt-in via the Machine Configuration menu, providing a much safer general-purpose default for Apple II/IIe software.
2. **UI Cleanup**: Removed the hardcoded `*` markers from the card labels in `machineconfig.tsx` to keep the dropdown menu clean.

Closes #363 
