### PR TITLE
fix(mockingboard): allow timer flags to latch independently of interrupt enable

### DIFF
--- a/src/worker/devices/mockingboard.test.ts
+++ b/src/worker/devices/mockingboard.test.ts
@@ -1,7 +1,9 @@
 import { runAssemblyTest } from "../instructions.test"
+import { interruptRequest } from "../cpu6502"
+import { s6502 } from "../instructions"
 import { memory } from "../memory"
 import { ROMmemoryStart } from "../../common/utility"
-import { disablePassRegisters } from "./mockingboard"
+import { disablePassRegisters, resetMockingboard } from "./mockingboard"
 
 test("temp", () => {})
 
@@ -11,7 +13,7 @@ const N = 0b10000000
 // const V = 0b01000000
 // const B = 0b00010000
 // const D = 0b00001000
-// const I = 0b00000100
+const I = 0b00000100
 const Z = 0b00000010
 const C = 0b00000001
 
@@ -158,6 +160,59 @@ for (let chip = 0; chip <= 1; chip++) {
     test(`lda04c-${chip}-T${timer + 1}`, () => runAssemblyTest(lda04c(chip, timer), 5, 0))
   }
 }
+
+const pollTimerWithInterruptDisabled = (timer: number) => {
+  const L = timer ? "8" : "4"
+  const H = timer ? "9" : "5"
+  return `
+      LDA #$7F
+      STA $C${slot}0E   ; disable all VIA interrupts
+      STA $C${slot}0D   ; clear all pending interrupt flags
+      LDA #$00
+      STA $C${slot}0B   ; use timed Timer 2 mode and one-shot Timer 1 mode
+      LDA #$08
+      STA $C${slot}0${L}
+      STZ $C${slot}0${H}   ; load and start the timer
+      LDY #$04
+LOOP  DEY
+      BNE LOOP
+      LDA $C${slot}0D   ; poll IFR before a counter read can clear the flag
+  `.split("\n")
+}
+
+test.each([
+  ["Timer 1", 0, 0x40],
+  ["Timer 2", 1, 0x20],
+])("%s sets its IFR flag while its interrupt is disabled", (_name, timer, flag) => {
+  runAssemblyTest(pollTimerWithInterruptDisabled(timer), flag, 0)
+})
+
+test("a disabled timer does not clear the other VIA's interrupt", () => {
+  resetMockingboard(slot)
+  interruptRequest(slot, false)
+  runAssemblyTest(`
+      SEI
+      LDA #$7F
+      STA $C40E       ; disable all chip 0 interrupts
+      STA $C48E       ; disable all chip 1 interrupts
+      LDA #$C0
+      STA $C48E       ; enable chip 1 Timer 1 interrupts
+      LDA #$20
+      STA $C404
+      STZ $C405       ; start chip 0 Timer 1 without enabling its interrupt
+      LDA #$08
+      STA $C484
+      STZ $C485       ; start chip 1 Timer 1
+      LDY #$20
+LOOP  DEY
+      BNE LOOP
+      LDA $C48D       ; confirm chip 1 still asserts its interrupt
+  `.split("\n"), 0xC0, N | I)
+
+  const irqActive = s6502.flagIRQ & (1 << slot)
+  interruptRequest(slot, false)
+  expect(irqActive).not.toBe(0)
+})
 
 const interrupt = (chip: number, timer: number) => {
   const X = chip ? "8" : "0"

--- a/src/worker/devices/mockingboard.ts
+++ b/src/worker/devices/mockingboard.ts
@@ -31,6 +31,7 @@ const IER = [0xE, 0x8E]
 const T2LL = [0x10, 0x91]
 const REG_LATCH = [0x11, 0x91]
 const TIMER_FIRED = [0x12, 0x92]
+const TIMER_STARTED = [0x13, 0x93]
 const REG = [0x20, 0xA0]   // $C420...C42F and $C4A0...$C4AF
 
 const TIMER1 = 64
@@ -50,6 +51,7 @@ export const resetMockingboard = (slot = 4) => {
 
 const T1enabled = (slot: number, chip: number) => (memGetSlotROM(slot, IER[chip]) & TIMER1) !== 0
 const T1fired = (slot: number, chip: number) => (memGetSlotROM(slot, TIMER_FIRED[chip]) & TIMER1) !== 0
+const T1started = (slot: number, chip: number) => (memGetSlotROM(slot, TIMER_STARTED[chip]) & TIMER1) !== 0
 const T1continuous = (slot: number, chip: number) => (memGetSlotROM(slot, ACR[chip]) & TIMER1) !== 0
 
 const handleTimerT1 = (slot: number, chip: number, cycleDelta: number) => {
@@ -64,15 +66,14 @@ const handleTimerT1 = (slot: number, chip: number, cycleDelta: number) => {
     if (t1high < 0) {
       t1high += 256
       memSetSlotROM(slot, T1CH[chip], t1high)
-      // if (T1enabled(chip)) {
-      //   console.log(`T1: ${T1enabled(chip)} ${T1fired(chip)} ${T1continuous(chip)}`)
-      // }
-      if (T1enabled(slot, chip) && (!T1fired(slot, chip) || T1continuous(slot, chip))) {
+      if (T1started(slot, chip) && (!T1fired(slot, chip) || T1continuous(slot, chip))) {
         const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
         memSetSlotROM(slot, TIMER_FIRED[chip], fired | TIMER1)
         const ifr = memGetSlotROM(slot, IFR[chip])
         memSetSlotROM(slot, IFR[chip], ifr | TIMER1)
-        handleInterruptFlag(slot, chip, -1)
+        if (T1enabled(slot, chip)) {
+          handleInterruptFlag(slot, chip, -1)
+        }
         if (T1continuous(slot, chip)) {
           const t1NewHigh = memGetSlotROM(slot, T1LH[chip])
           const t1NewLow = memGetSlotROM(slot, T1LL[chip])
@@ -86,6 +87,7 @@ const handleTimerT1 = (slot: number, chip: number, cycleDelta: number) => {
 
 const T2enabled = (slot: number, chip: number) => (memGetSlotROM(slot, IER[chip]) & TIMER2) !== 0
 const T2fired = (slot: number, chip: number) => (memGetSlotROM(slot, TIMER_FIRED[chip]) & TIMER2) !== 0
+const T2started = (slot: number, chip: number) => (memGetSlotROM(slot, TIMER_STARTED[chip]) & TIMER2) !== 0
 
 const handleTimerT2 = (slot: number, chip: number, cycleDelta: number) => {
   // If Timer2 is in pulse-counting mode just bail
@@ -101,15 +103,14 @@ const handleTimerT2 = (slot: number, chip: number, cycleDelta: number) => {
     if (t2high < 0) {
       t2high += 256
       memSetSlotROM(slot, T2CH[chip], t2high)
-//      if (T2enabled(chip)) {
-//        console.log(`T2: ${T2enabled(chip)} ${T2_DIDFIRE[chip]}`)
-//      }
-      if (T2enabled(slot, chip) && !T2fired(slot, chip)) {
+      if (T2started(slot, chip) && !T2fired(slot, chip)) {
         const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
         memSetSlotROM(slot, TIMER_FIRED[chip], fired | TIMER2)
         const ifr = memGetSlotROM(slot, IFR[chip])
         memSetSlotROM(slot, IFR[chip], ifr | TIMER2)
-        handleInterruptFlag(slot, chip, -1)
+        if (T2enabled(slot, chip)) {
+          handleInterruptFlag(slot, chip, -1)
+        }
       }
     }
   }
@@ -268,6 +269,8 @@ export const handleMockingboard: AddressCallback = (addr: number, value = -1) =>
         // Reset T1 interrupt flag
         const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
         memSetSlotROM(slot, TIMER_FIRED[chip], fired & ~TIMER1)
+        const started = memGetSlotROM(slot, TIMER_STARTED[chip])
+        memSetSlotROM(slot, TIMER_STARTED[chip], started | TIMER1)
         handleInterruptFlag(slot, chip, TIMER1)
       }
       break
@@ -300,6 +303,8 @@ export const handleMockingboard: AddressCallback = (addr: number, value = -1) =>
         // Reset T2 interrupt flag
         const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
         memSetSlotROM(slot, TIMER_FIRED[chip], fired & ~TIMER2)
+        const started = memGetSlotROM(slot, TIMER_STARTED[chip])
+        memSetSlotROM(slot, TIMER_STARTED[chip], started | TIMER2)
         handleInterruptFlag(slot, chip, TIMER2)
       }
       break


### PR DESCRIPTION
A 6522 latches its timer flag when a started timer expires regardless of whether that interrupt is enabled. Apple2TS currently latches it only when enabled.

- Track whether Timer 1 and Timer 2 have been loaded.
- Latch their IFR flags while interrupts are disabled; IER still controls IRQ signaling.
- Prevent a disabled timer expiration from deasserting the other VIA's active interrupt.
- Add focused polling and shared-interrupt regression tests.

This makes mb-audit v1.3 test 11:02 pass.

Fixes #308.