### PR TITLE
fix(export): report skipped 4cade games

### DIFF
--- a/src/common/prodos_hdv.ts
+++ b/src/common/prodos_hdv.ts
@@ -28,6 +28,15 @@ export type MenuDiskEntry = {
   wozExtractedProDosFiles?: ImportedDiskFile[]
 }
 
+export type FourCadeExportFailure = {
+  title: string
+  reason: string
+}
+
+export type FourCadeExportFailureHandler = (
+  failure: FourCadeExportFailure,
+) => boolean | Promise<boolean>
+
 export type ImportedDiskFile = {
   name: string
   relativePath?: string
@@ -2315,10 +2324,22 @@ const applyGenericPrefixRewrite = (type: number, data: Uint8Array): Uint8Array =
   return rewriteImportedProgramPath(type, data, "", "")
 }
 
-const preprocessInputFilesForMenu = async (
+class FourCadeExportCanceledError extends Error {}
+
+const fourCadeExportFailure = (title: string | undefined, reason: string): FourCadeExportFailure => ({
+  title: title || "Untitled disk",
+  reason,
+})
+
+const formatFourCadeExportFailure = ({ title, reason }: FourCadeExportFailure): string =>
+  `Could not export "${title}": ${reason}`
+
+/** @internal Exported for focused 4cade export tests. */
+export const preprocessInputFilesForMenu = async (
   files: BuildInputFile[],
   menuEntries?: MenuDiskEntry[],
   reservedNames?: Set<string>,
+  onFourCadeExportFailure?: FourCadeExportFailureHandler,
 ) => {
   const outputFiles: BuildInputFile[] = []
   const directoryPlans: DirectoryImportPlan[] = []
@@ -2354,6 +2375,7 @@ const preprocessInputFilesForMenu = async (
       // Title-based matching against the 4cade game database
       const displayName = menuEntries?.[i]?.displayName
       const fourCadeEntry = displayName ? lookupFourCadeByTitle(displayName) : undefined
+      let failure: FourCadeExportFailure | undefined
 
       if (fourCadeEntry) {
         try {
@@ -2366,7 +2388,7 @@ const preprocessInputFilesForMenu = async (
           // Extract ALL BIN files from the .po disk
           const allFiles = extractAllBinFiles(poData)
           const packed = allFiles.length > 0 ? allFiles[0] : undefined
-          if (packed) {
+          if (packed && packed.data.length > 0) {
             // Parse the prelaunch script to get the operation sequence
             const parsed = parsePrelaunchScript(prelaunchSource)
             if (parsed) {
@@ -2403,20 +2425,28 @@ const preprocessInputFilesForMenu = async (
               menuProDosCommands[i] = undefined
               continue
             } else {
-              console.warn(`[4cade] "${displayName}": prelaunch script parsed but returned no sequence`)
+              failure = fourCadeExportFailure(displayName, "the 4cade prelaunch script is unsupported or invalid")
             }
           } else {
-            console.warn(`[4cade] "${displayName}": no BIN files found in .po disk`)
+            failure = fourCadeExportFailure(displayName, "the downloaded 4cade disk contains no usable binary")
           }
-        } catch (e) {
-          console.warn(`[4cade] "${displayName}": fetch/parse failed:`, e instanceof Error ? e.message : e)
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error)
+          failure = fourCadeExportFailure(displayName, `4cade preparation failed: ${detail}`)
         }
       } else {
-        console.warn(`[4cade] "${displayName}": no match in 4cade database`)
+        failure = fourCadeExportFailure(displayName, "the title is not in the 4cade catalog")
       }
 
-      // No 4cade DB match or fetch failed — skip this disk for direct-load export.
-      // (Only disks with a known 4cade prelaunch can be block-loaded.)
+      if (failure) {
+        console.warn(`[4cade] ${formatFourCadeExportFailure(failure)}`)
+        const shouldContinue = await onFourCadeExportFailure?.(failure) ?? true
+        if (!shouldContinue) {
+          throw new FourCadeExportCanceledError(formatFourCadeExportFailure(failure))
+        }
+      }
+
+      // A failed title is omitted from direct-load export.
       menuProDosPrefixes[i] = undefined
       menuProDosCommands[i] = undefined
       continue
@@ -5362,6 +5392,7 @@ export const buildProDosHdv = async (
   prodos243Base?: Uint8Array,
   menuEntries?: MenuDiskEntry[],
   dosMasterSlot: number = DOSMASTER_SLOT,
+  onFourCadeExportFailure?: FourCadeExportFailureHandler,
 ): Promise<Uint8Array> => {
   let hdv = prodos243Base
   if (!hdv) {
@@ -5423,7 +5454,7 @@ export const buildProDosHdv = async (
   rootScan.existingNames.add(SCREENSHOT_SUBDIR)
   // Reserve helper-program subdirectory name to avoid root-path exhaustion.
   rootScan.existingNames.add(HELPER_SUBDIR)
-  const { outputFiles, directoryPlans, menuProDosCommands, menuProDosPrefixes, menuNeedsAliasShim, runtimeVolumes, runtimeVolumeByMenuIndex, runtimeHelloModeByMenuIndex, fourCadeEntries } = await preprocessInputFilesForMenu(files, menuEntries, rootScan.existingNames)
+  const { outputFiles, directoryPlans, menuProDosCommands, menuProDosPrefixes, menuNeedsAliasShim, runtimeVolumes, runtimeVolumeByMenuIndex, runtimeHelloModeByMenuIndex, fourCadeEntries } = await preprocessInputFilesForMenu(files, menuEntries, rootScan.existingNames, onFourCadeExportFailure)
   let fileCount = rootScan.fileCount
   const currentTotalBlocks = readLittleEndian16(rootHeader, volumeEntryOffset + 37)
   const bitmapStartBlock = readLittleEndian16(rootHeader, volumeEntryOffset + 35)
@@ -6407,4 +6438,3 @@ export const PRODOS_FILE_TYPE_DOS_MASTER = 0xF1
 // categories). Cached VTOC results older than this version are re-evaluated so
 // disks previously classified as non-exportable can be reclassified.
 export const VTOC_REFRESH = 11
-

--- a/src/common/prodos_hdv.ts
+++ b/src/common/prodos_hdv.ts
@@ -2446,7 +2446,7 @@ export const preprocessInputFilesForMenu = async (
         }
       }
 
-      // A failed title is omitted from direct-load export.
+      // Skip the unavailable game data but retain its menu entry and error screen.
       menuProDosPrefixes[i] = undefined
       menuProDosCommands[i] = undefined
       continue

--- a/src/common/prodos_hdv_4cade_export.test.ts
+++ b/src/common/prodos_hdv_4cade_export.test.ts
@@ -1,0 +1,73 @@
+const mockFetchDisk = jest.fn()
+const mockFetchPrelaunch = jest.fn()
+const mockExtractBinFiles = jest.fn()
+const mockParsePrelaunch = jest.fn()
+
+jest.mock("./four_cade_prelaunch_db", () => ({
+  ...jest.requireActual("./four_cade_prelaunch_db"),
+  fetchFourCadeDisk: (...args: unknown[]) => mockFetchDisk(...args),
+  fetchFourCadePrelaunch: (...args: unknown[]) => mockFetchPrelaunch(...args),
+  extractAllBinFiles: (...args: unknown[]) => mockExtractBinFiles(...args),
+  parsePrelaunchScript: (...args: unknown[]) => mockParsePrelaunch(...args),
+}))
+
+import { preprocessInputFilesForMenu } from "./prodos_hdv"
+
+const inputFiles = [{ name: "AZTEC", type: 0xE0, data: new Uint8Array() }]
+const menuEntry = { filename: "AZTEC", displayName: "Aztec", imageKind: "4cade" as const }
+
+describe("4cade HDV export failures", () => {
+  const stopExport = jest.fn(() => false)
+
+  beforeEach(() => {
+    mockFetchDisk.mockResolvedValue(new Uint8Array([1, 2, 3]))
+    mockFetchPrelaunch.mockResolvedValue("jmp $800")
+    mockExtractBinFiles.mockReturnValue([
+      { data: new Uint8Array([0x60]), loadAddress: 0x0800, name: "AZTEC" },
+    ])
+    mockParsePrelaunch.mockReturnValue({ sequence: [], entry: "loadAddress" })
+    stopExport.mockClear()
+  })
+
+  test("reports a title missing from the catalog", async () => {
+    await expect(preprocessInputFilesForMenu(inputFiles, [
+      { ...menuEntry, displayName: "Missing 4cade title" },
+    ], undefined, stopExport)).rejects.toThrow(
+      "Could not export \"Missing 4cade title\": the title is not in the 4cade catalog",
+    )
+    expect(stopExport).toHaveBeenCalledWith({
+      title: "Missing 4cade title",
+      reason: "the title is not in the 4cade catalog",
+    })
+  })
+
+  test("reports failed 4cade preparation", async () => {
+    mockFetchDisk.mockRejectedValue(new Error("HTTP 503"))
+
+    await expect(preprocessInputFilesForMenu(inputFiles, [menuEntry], undefined, stopExport))
+      .rejects.toThrow("Could not export \"Aztec\": 4cade preparation failed: HTTP 503")
+  })
+
+  test("reports a downloaded disk without a usable binary", async () => {
+    mockExtractBinFiles.mockReturnValue([])
+
+    await expect(preprocessInputFilesForMenu(inputFiles, [menuEntry], undefined, stopExport))
+      .rejects.toThrow("Could not export \"Aztec\": the downloaded 4cade disk contains no usable binary")
+  })
+
+  test("reports an invalid prelaunch script", async () => {
+    mockParsePrelaunch.mockReturnValue(undefined)
+
+    await expect(preprocessInputFilesForMenu(inputFiles, [menuEntry], undefined, stopExport))
+      .rejects.toThrow("Could not export \"Aztec\": the 4cade prelaunch script is unsupported or invalid")
+  })
+
+  test("omits a failed title when the caller continues", async () => {
+    const continueExport = jest.fn(() => true)
+
+    await expect(preprocessInputFilesForMenu(inputFiles, [
+      { ...menuEntry, displayName: "Missing 4cade title" },
+    ], undefined, continueExport)).resolves.toBeDefined()
+    expect(continueExport).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/common/prodos_hdv_4cade_export.test.ts
+++ b/src/common/prodos_hdv_4cade_export.test.ts
@@ -11,7 +11,12 @@ jest.mock("./four_cade_prelaunch_db", () => ({
   parsePrelaunchScript: (...args: unknown[]) => mockParsePrelaunch(...args),
 }))
 
-import { preprocessInputFilesForMenu } from "./prodos_hdv"
+import fs from "fs"
+import path from "path"
+import { TextEncoder } from "util"
+import { buildProDosHdv, preprocessInputFilesForMenu } from "./prodos_hdv"
+
+Object.defineProperty(global, "TextEncoder", { configurable: true, value: TextEncoder })
 
 const inputFiles = [{ name: "AZTEC", type: 0xE0, data: new Uint8Array() }]
 const menuEntry = { filename: "AZTEC", displayName: "Aztec", imageKind: "4cade" as const }
@@ -62,12 +67,25 @@ describe("4cade HDV export failures", () => {
       .rejects.toThrow("Could not export \"Aztec\": the 4cade prelaunch script is unsupported or invalid")
   })
 
-  test("omits a failed title when the caller continues", async () => {
+  test("continues after the caller accepts a skipped game", async () => {
     const continueExport = jest.fn(() => true)
 
     await expect(preprocessInputFilesForMenu(inputFiles, [
       { ...menuEntry, displayName: "Missing 4cade title" },
     ], undefined, continueExport)).resolves.toBeDefined()
     expect(continueExport).toHaveBeenCalledTimes(1)
+  })
+
+  test("retains a failed title in the generated HDV menu", async () => {
+    mockFetchDisk.mockRejectedValue(new Error("HTTP 503"))
+    const base = new Uint8Array(fs.readFileSync(
+      path.resolve(__dirname, "../../public/disks/dosmaster18.po"),
+    ))
+
+    const hdv = await buildProDosHdv(inputFiles, "APPLE2TS", base, [
+      { ...menuEntry, filename: "FAILED", screenshotData: new Uint8Array([1]) },
+    ], undefined, () => true)
+
+    expect(Buffer.from(hdv).includes(Buffer.from("FAILED"))).toBe(true)
   })
 })

--- a/src/ui/diskdialog/diskpanel_utils.test.ts
+++ b/src/ui/diskdialog/diskpanel_utils.test.ts
@@ -1,5 +1,12 @@
 const mockHandleSetDiskFromFile = jest.fn()
 const mockPassSetRunMode = jest.fn()
+const mockBuildProDosHdv = jest.fn()
+const mockShowGlobalProgressModal = jest.fn()
+
+jest.mock("../../common/prodos_hdv", () => ({
+  ...jest.requireActual("../../common/prodos_hdv"),
+  buildProDosHdv: (...args: unknown[]) => mockBuildProDosHdv(...args),
+}))
 
 jest.mock("../devices/disk/driveprops", () => ({
   handleSetDiskFromCloudData: jest.fn(),
@@ -9,8 +16,11 @@ jest.mock("../devices/disk/driveprops", () => ({
 jest.mock("../main2worker", () => ({
   passSetRunMode: (...args: unknown[]) => mockPassSetRunMode(...args),
 }))
+jest.mock("../ui_utilities", () => ({
+  showGlobalProgressModal: (...args: unknown[]) => mockShowGlobalProgressModal(...args),
+}))
 
-import { DISK_COLLECTION_ITEM_TYPE, loadDisk, loadDiskIntoDrive } from "./diskpanel_utils"
+import { createHdv, DISK_COLLECTION_ITEM_TYPE, loadDisk, loadDiskIntoDrive } from "./diskpanel_utils"
 
 describe("loadDisk", () => {
   const disk = {
@@ -22,6 +32,8 @@ describe("loadDisk", () => {
   beforeEach(() => {
     mockHandleSetDiskFromFile.mockClear()
     mockPassSetRunMode.mockClear()
+    mockBuildProDosHdv.mockReset()
+    mockShowGlobalProgressModal.mockClear()
   })
 
   test("installs a collection disk before reporting load success", () => {
@@ -68,5 +80,71 @@ describe("loadDisk", () => {
       true,
     )
     expect(mockPassSetRunMode).not.toHaveBeenCalled()
+  })
+})
+
+describe("createHdv", () => {
+  beforeEach(() => {
+    mockBuildProDosHdv.mockReset()
+    mockShowGlobalProgressModal.mockClear()
+  })
+
+  test("continues after confirmation and summarizes omitted titles", async () => {
+    const alert = jest.spyOn(window, "alert").mockImplementation(() => undefined)
+    const confirm = jest.spyOn(window, "confirm").mockReturnValue(true)
+    const createElement = jest.spyOn(document, "createElement")
+    const createObjectURL = jest.fn(() => "blob:test")
+    const revokeObjectURL = jest.fn()
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: revokeObjectURL })
+    mockBuildProDosHdv.mockImplementation(async (...args: unknown[]) => {
+      const reportFailure = args[5] as (failure: { title: string; reason: string }) => boolean
+      expect(reportFailure({ title: "Aztec", reason: "no usable binary" })).toBe(true)
+      expect(reportFailure({ title: "Chivalry", reason: "download failed" })).toBe(true)
+      return new Uint8Array([1])
+    })
+
+    await createHdv([])
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect(confirm).toHaveBeenCalledWith(
+      "\"Aztec\" could not be included.\n\n" +
+      "OK to continue creating the HDV, skipping unavailable titles?",
+    )
+    expect(alert).toHaveBeenCalledWith(
+      "HDV created without:\n\n\"Aztec\": no usable binary\n\"Chivalry\": download failed",
+    )
+    expect(createElement).toHaveBeenCalledWith("a")
+    expect(mockShowGlobalProgressModal).toHaveBeenNthCalledWith(1, true, "Creating HDV image")
+    expect(mockShowGlobalProgressModal).toHaveBeenLastCalledWith(false)
+
+    alert.mockRestore()
+    confirm.mockRestore()
+    createElement.mockRestore()
+  })
+
+  test("cancels the export when continuation is declined", async () => {
+    const alert = jest.spyOn(window, "alert").mockImplementation(() => undefined)
+    const confirm = jest.spyOn(window, "confirm").mockReturnValue(false)
+    const createElement = jest.spyOn(document, "createElement")
+    mockBuildProDosHdv.mockImplementation(async (...args: unknown[]) => {
+      const reportFailure = args[5] as (failure: { title: string; reason: string }) => boolean
+      if (!reportFailure({ title: "Aztec", reason: "no usable binary" })) {
+        throw new Error("Could not export \"Aztec\": no usable binary")
+      }
+      return new Uint8Array([1])
+    })
+
+    await createHdv([])
+
+    expect(alert).toHaveBeenCalledWith(
+      "Failed to build ProDOS HDV: Could not export \"Aztec\": no usable binary",
+    )
+    expect(createElement).not.toHaveBeenCalledWith("a")
+    expect(mockShowGlobalProgressModal).toHaveBeenLastCalledWith(false)
+
+    alert.mockRestore()
+    confirm.mockRestore()
+    createElement.mockRestore()
   })
 })

--- a/src/ui/diskdialog/diskpanel_utils.ts
+++ b/src/ui/diskdialog/diskpanel_utils.ts
@@ -1,4 +1,4 @@
-import { ImportedDiskFile, loadWozAndExtractProDosFiles, loadWozAndExtractDosImage, classifyImageKind, stripTwoImgHeader, ensureDosVolumeHasHelloGreeting, PRODOS_FILE_TYPE_TEXT, PRODOS_FILE_TYPE_DOS_MASTER, MenuDiskEntry, buildProDosHdv, VTOC_REFRESH, determineVtocType } from "../../common/prodos_hdv"
+import { ImportedDiskFile, loadWozAndExtractProDosFiles, loadWozAndExtractDosImage, classifyImageKind, stripTwoImgHeader, ensureDosVolumeHasHelloGreeting, PRODOS_FILE_TYPE_TEXT, PRODOS_FILE_TYPE_DOS_MASTER, MenuDiskEntry, buildProDosHdv, VTOC_REFRESH, determineVtocType, FourCadeExportFailure } from "../../common/prodos_hdv"
 import { RUN_MODE } from "../../common/utility"
 import { DiskBookmarks } from "../devices/disk/diskbookmarks"
 import { diskImages } from "../devices/disk/diskimages"
@@ -343,6 +343,23 @@ export const createHdv = async (orderedDownloadedDisks: DownloadedExportDisk[]) 
 
   showGlobalProgressModal(true, "Creating HDV image")
   try {
+    const omittedFourCadeTitles: FourCadeExportFailure[] = []
+    let skipUnavailableTitles = false
+    const handleFourCadeExportFailure = (failure: FourCadeExportFailure): boolean => {
+      omittedFourCadeTitles.push(failure)
+      if (skipUnavailableTitles) return true
+
+      showGlobalProgressModal(false)
+      skipUnavailableTitles = window.confirm(
+        `"${failure.title}" could not be included.\n\n` +
+        "OK to continue creating the HDV, skipping unavailable titles?",
+      )
+      if (skipUnavailableTitles) {
+        showGlobalProgressModal(true, "Creating HDV image")
+      }
+      return skipUnavailableTitles
+    }
+
     const wozExtractedByIndex = new Map<number, ImportedDiskFile[]>()
     // WOZ DOS disks decoded to a flat DOS 3.3 (.dsk) sector image, keyed by disk index.
     // DOS.MASTER runtime volumes must be plain DOS-order sector images, but classifyImageKind
@@ -453,8 +470,23 @@ export const createHdv = async (orderedDownloadedDisks: DownloadedExportDisk[]) 
       wozExtractedProDosFiles: wozExtractedByIndex.get(index),
     }))
 
-    const hdvData = await buildProDosHdv(fileEntries, "APPLE2TS", undefined, menuEntries)
+    const hdvData = await buildProDosHdv(
+      fileEntries,
+      "APPLE2TS",
+      undefined,
+      menuEntries,
+      undefined,
+      handleFourCadeExportFailure,
+    )
     downloadExportHdv(hdvData, "APPLE2TS.HDV")
+    if (omittedFourCadeTitles.length > 0) {
+      showGlobalProgressModal(false)
+      alert(
+        "HDV created without:\n\n" + omittedFourCadeTitles
+          .map(({ title, reason }) => `"${title}": ${reason}`)
+          .join("\n"),
+      )
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     alert(`Failed to build ProDOS HDV: ${message}`)


### PR DESCRIPTION
Fixes #315.

- Ask whether to continue when a 4cade game cannot be prepared.
- Report skipped games after creation.