### PR TITLE
feat(remote-control): load binaries into main memory

### DIFF
--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -39,8 +39,9 @@ import {
   passTimeTravelSnapshot,
   passSetShowDebugTab,
   requestSetRunMode,
+  requestLoadBinary,
 } from "../main2worker"
-import { getBinaryLoadError, loadBinary, runBinary } from "../binaryload"
+import { getBinaryLoadError, runBinary } from "../binaryload"
 import {
   setPreferenceBreakpoints,
   setPreferenceColorMode,
@@ -635,11 +636,12 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
       const data = decodeBase64(dataBase64)
       const error = getBinaryLoadError(address, data, null)
       if (error) throw new Error(error)
-      loadBinary(address, data)
+      await requestLoadBinary(address, data)
       return {
         accepted: true,
         address,
         size: data.length,
+        status: collectStatus(),
       }
     }
 

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -1,6 +1,7 @@
-import { MSG_WORKER, RUN_MODE } from "../common/utility"
+import { MSG_MAIN, MSG_WORKER, RUN_MODE } from "../common/utility"
 import {
   doOnMessage,
+  requestLoadBinary,
   requestSetRunMode,
   requestSpeedMode,
   setMain2Worker,
@@ -86,5 +87,18 @@ describe("worker operations", () => {
     } finally {
       jest.useRealTimers()
     }
+  })
+
+  test("sends binary loads as confirmed worker operations", async () => {
+    const data = new Uint8Array([0xA9, 0x42])
+    const operation = requestLoadBinary(0x6000, data)
+    const message = worker.postMessage.mock.calls.at(-1)[0]
+    expect(message).toEqual(expect.objectContaining({
+      msg: MSG_MAIN.LOAD_BINARY,
+      payload: {address: 0x6000, data},
+    }))
+
+    sendOperationResult(message.operationId)
+    await expect(operation).resolves.toBeUndefined()
   })
 })

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -246,6 +246,15 @@ export const passLoadBinary = (address: number, data: Uint8Array) => {
   doPostMessage(MSG_MAIN.LOAD_BINARY, binary)
 }
 
+export const requestLoadBinary = (
+  address: number,
+  data: Uint8Array,
+  timeoutMs = 5000,
+) => {
+  const binary: LoadBinary = {address, data}
+  return requestWorkerOperation(MSG_MAIN.LOAD_BINARY, binary, timeoutMs)
+}
+
 export const passExecuteBasicCommand = (command: string) => {
   doPostMessage(MSG_MAIN.EXECUTE_BASIC_COMMAND, command)
 }

--- a/src/worker/memory.test.ts
+++ b/src/worker/memory.test.ts
@@ -10,6 +10,7 @@ import {
   doSetRom,
   setRamWorks,
   setSlotDriver,
+  loadMainMemoryBlock,
 } from "./memory"
 import { hiresLineToAddress, RamWorksMemoryStart } from "../common/utility"
 import { setIsTesting } from "./worker2main"
@@ -447,6 +448,16 @@ test("test RamWorks Save/Restore", () => {
 
 const LOC1 = 0xD17B   // $53 in Apple II/plus/e/enhanced
 const LOC2 = 0xFE1F		// $60 in Apple II/plus/e/enhanced
+
+test("main-memory binary blocks reject non-RAM ranges before writing", () => {
+  const previous = memory[0xBFFF]
+  memory[0xBFFF] = 0x11
+
+  expect(() => loadMainMemoryBlock(0xBFFF, new Uint8Array([0x22, 0x33])))
+    .toThrow("main RAM at $0000-$BFFF")
+  expect(memory[0xBFFF]).toEqual(0x11)
+  memory[0xBFFF] = previous
+})
 
 const setupBSR = () => {
   memGet(0xC089)  // enable R/W RAM, bank 1

--- a/src/worker/memory.ts
+++ b/src/worker/memory.ts
@@ -748,6 +748,13 @@ export const setMemoryBlock = (addr: number, data: Uint8Array) => {
   memory.set(data, offset)
 }
 
+export const loadMainMemoryBlock = (addr: number, data: Uint8Array) => {
+  if (!Number.isInteger(addr) || addr < 0 || addr + data.length > 0xC000) {
+    throw new Error("Binary block must fit within main RAM at $0000-$BFFF")
+  }
+  memory.set(data, addr)
+}
+
 export const setMappedMemoryBlock = (addr: number, data: Uint8Array) => {
   let dataOffset = 0
   while (dataOffset < data.length) {

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -76,17 +76,12 @@ test("load binary changes memory without changing execution or device state", ()
   }
 })
 
-test("load binary follows auxiliary-memory mappings across page boundaries", () => {
+test("load binary writes main RAM independently of auxiliary-memory mappings", () => {
   const previousAltZp = SWITCHES.ALTZP.isSet
   const previousPage2 = SWITCHES.PAGE2.isSet
   const previousRamWrite = SWITCHES.RAMWRT.isSet
   const previousStore80 = SWITCHES.STORE80.isSet
-  const touchedAddresses = [
-    RamWorksMemoryStart + 0x01FF,
-    0x0200,
-    0x03FF,
-    RamWorksMemoryStart + 0x0400,
-  ]
+  const touchedAddresses = [0x01FF, RamWorksMemoryStart + 0x01FF, 0x0200, 0x03FF, RamWorksMemoryStart + 0x0400, 0x0400]
   const previousMemory = touchedAddresses.map((address) => memory[address])
 
   try {
@@ -94,8 +89,9 @@ test("load binary follows auxiliary-memory mappings across page boundaries", () 
     SWITCHES.RAMWRT.isSet = false
     updateAddressTables()
     doLoadBinary(0x01FF, new Uint8Array([0xA1, 0xB2]))
-    expect(memory[RamWorksMemoryStart + 0x01FF]).toEqual(0xA1)
+    expect(memory[0x01FF]).toEqual(0xA1)
     expect(memory[0x0200]).toEqual(0xB2)
+    expect(memory[RamWorksMemoryStart + 0x01FF]).toEqual(previousMemory[1])
 
     SWITCHES.ALTZP.isSet = false
     SWITCHES.STORE80.isSet = true
@@ -103,7 +99,8 @@ test("load binary follows auxiliary-memory mappings across page boundaries", () 
     updateAddressTables()
     doLoadBinary(0x03FF, new Uint8Array([0xC3, 0xD4]))
     expect(memory[0x03FF]).toEqual(0xC3)
-    expect(memory[RamWorksMemoryStart + 0x0400]).toEqual(0xD4)
+    expect(memory[0x0400]).toEqual(0xD4)
+    expect(memory[RamWorksMemoryStart + 0x0400]).toEqual(previousMemory[4])
   } finally {
     SWITCHES.ALTZP.isSet = previousAltZp
     SWITCHES.PAGE2.isSet = previousPage2
@@ -198,6 +195,44 @@ test("run changes complete after publishing their state", () => {
     passMachineState.mockRestore()
     passOperationResult.mockRestore()
     doSetRunMode(previousState.runMode)
+  }
+})
+
+test("memory blocks complete after all bytes are applied", () => {
+  setIsTesting()
+  const address = 0x6000
+  const previousMemory = memory.slice(address, address + 3)
+  const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
+  passOperationResult.mockImplementation((operationId) => {
+    expect(operationId).toEqual(11)
+    expect(memory.slice(address, address + 3)).toEqual(new Uint8Array([0xA9, 0x42, 0x60]))
+  })
+
+  try {
+    doLoadBinary(address, new Uint8Array([0xA9, 0x42, 0x60]), 11)
+    expect(passOperationResult).toHaveBeenCalledTimes(1)
+  } finally {
+    memory.set(previousMemory, address)
+    passOperationResult.mockRestore()
+  }
+})
+
+test("invalid binary loads fail before changing memory", () => {
+  setIsTesting()
+  const previousValue = memory[0xBFFF]
+  memory[0xBFFF] = 0x11
+  const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
+
+  try {
+    doLoadBinary(0xBFFF, new Uint8Array([0x22, 0x33]), 12)
+    expect(memory[0xBFFF]).toEqual(0x11)
+    expect(passOperationResult).toHaveBeenCalledWith(
+      12,
+      "Binary block must fit within main RAM at $0000-$BFFF",
+    )
+  } finally {
+    memory[0xBFFF] = previousValue
+    passOperationResult.mockRestore()
   }
 })
 

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -9,7 +9,7 @@ import { SWITCHES, overrideSoftSwitch, resetSoftSwitches, setVideo7Override,
   syncSoftSwitchStatusFlags} from "./softswitches"
 import { memory, memGet, getTextPage, getHires, memoryReset,
   updateAddressTables, setMemoryBlock, addressGetTable,
-  setMappedMemoryBlock,
+  loadMainMemoryBlock,
   getBasePlusAuxMemory,
   setRamWorks,
   setAuxCardEnabled,
@@ -540,6 +540,36 @@ export const doSetMemory = (addr: number, value: number) => {
   updateExternalMachineState()
 }
 
+const refreshMemoryBlock = (addr: number, length: number) => {
+  if (cpuRunMode === RUN_MODE.PAUSED) {
+    const hiresLines = new Set<number>()
+    for (let offset = 0; offset < length; offset++) {
+      const address = addr + offset
+      if (address >= 0x2000 && address <= 0x5FFF) {
+        hiresLines.add(hiresAddressToLine(address))
+      }
+    }
+    hiresLines.forEach(exportMemoryToHiresLine)
+  }
+  updateExternalMachineState()
+}
+
+export const doLoadBinary = (
+  addr: number,
+  data: Uint8Array,
+  operationId?: number,
+) => {
+  try {
+    configureMachine()
+    loadMainMemoryBlock(addr, data)
+    refreshMemoryBlock(addr, data.length)
+    if (operationId !== undefined) passWorkerOperationResult(operationId)
+  } catch (error) {
+    if (operationId === undefined) throw error
+    passWorkerOperationResult(operationId, error instanceof Error ? error.message : String(error))
+  }
+}
+
 export const doSetMachineName = (name: MACHINE_NAME, reset = true) => {
   machineName = name
   if (name === "APPLE2P") {
@@ -775,13 +805,6 @@ export const doRunBinary = (addr: number, data: Uint8Array, entryAddress = addr)
   setMemoryBlock(addr, data)
   setPC(entryAddress)
   doSetRunMode(RUN_MODE.RUNNING, false)
-}
-
-export const doLoadBinary = (addr: number, data: Uint8Array) => {
-  // A direct load changes memory without changing CPU or device state.
-  configureMachine()
-  updateAddressTables()
-  setMappedMemoryBlock(addr, data)
 }
 
 export const doSetPastedText = (text: string) => {

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -264,7 +264,7 @@ if (typeof self !== "undefined") {
       }
       case MSG_MAIN.LOAD_BINARY: {
         const binary = e.data.payload as LoadBinary
-        doLoadBinary(binary.address, binary.data)
+        doLoadBinary(binary.address, binary.data, e.data.operationId)
         break
       }
       case MSG_MAIN.SET_CYCLECOUNT:


### PR DESCRIPTION
## Cross-repository change

This is the Apple2TS half of a cross-repository change. The companion
[Apple2TS Server change](https://github.com/ct6502/apple2ts-server/pull/4) uses
the completed load operation added here and should merge after this change.

## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per
[issue #218](https://github.com/ct6502/apple2ts/issues/218).

This step gives the remote-control interface a deterministic way to load a
program into main memory.

## Motivation

An external controller needs to know that a binary has finished loading into
main memory before issuing the next command.

## What was implemented in this slice

- A direct main-memory loader for binary data from `$0000` through `$BFFF`.
- Full-range validation before the worker changes memory.
- A request-and-reply path that completes after the emulator worker finishes
  the load and updates related state.
- Worker-error propagation through the existing remote-control reply path.

## Verification

- Binary data reached main RAM while auxiliary-memory writing was active.
- A successful reply arrived only after the complete load and related state
  update.
- Invalid ranges were rejected without partially changing memory.
