### PR TITLE
test(export): restore 4cade failure coverage

### DIFF
--- a/src/common/prodos_hdv_4cade_export.test.ts
+++ b/src/common/prodos_hdv_4cade_export.test.ts
@@ -3,8 +3,8 @@ const mockFetchPrelaunch = jest.fn()
 const mockExtractBinFiles = jest.fn()
 const mockParsePrelaunch = jest.fn()
 
-jest.mock("./four_cade_prelaunch_db", () => ({
-  ...jest.requireActual("./four_cade_prelaunch_db"),
+jest.mock("./four_cade_prelaunch", () => ({
+  ...jest.requireActual("./four_cade_prelaunch"),
   fetchFourCadeDisk: (...args: unknown[]) => mockFetchDisk(...args),
   fetchFourCadePrelaunch: (...args: unknown[]) => mockFetchPrelaunch(...args),
   extractAllBinFiles: (...args: unknown[]) => mockExtractBinFiles(...args),
@@ -35,7 +35,6 @@ describe("4cade HDV export failures", () => {
   })
 
   test("reports a title missing from the catalog", async () => {
-    return
     await expect(preprocessInputFilesForMenu(inputFiles, [
       { ...menuEntry, displayName: "Missing 4cade title" },
     ], undefined, stopExport)).rejects.toThrow(
@@ -48,7 +47,6 @@ describe("4cade HDV export failures", () => {
   })
 
   test("reports failed 4cade preparation", async () => {
-    return
     mockFetchDisk.mockRejectedValue(new Error("HTTP 503"))
 
     await expect(preprocessInputFilesForMenu(inputFiles, [menuEntry], undefined, stopExport))
@@ -56,7 +54,6 @@ describe("4cade HDV export failures", () => {
   })
 
   test("reports a downloaded disk without a usable binary", async () => {
-    return
     mockExtractBinFiles.mockReturnValue([])
 
     await expect(preprocessInputFilesForMenu(inputFiles, [menuEntry], undefined, stopExport))
@@ -64,7 +61,6 @@ describe("4cade HDV export failures", () => {
   })
 
   test("reports an invalid prelaunch script", async () => {
-    return
     mockParsePrelaunch.mockReturnValue(undefined)
 
     await expect(preprocessInputFilesForMenu(inputFiles, [menuEntry], undefined, stopExport))
@@ -72,7 +68,6 @@ describe("4cade HDV export failures", () => {
   })
 
   test("continues after the caller accepts a skipped game", async () => {
-    return
     const continueExport = jest.fn(() => true)
 
     await expect(preprocessInputFilesForMenu(inputFiles, [
@@ -82,7 +77,6 @@ describe("4cade HDV export failures", () => {
   })
 
   test("retains a failed title in the generated HDV menu", async () => {
-    return
     mockFetchDisk.mockRejectedValue(new Error("HTTP 503"))
     const base = new Uint8Array(fs.readFileSync(
       path.resolve(__dirname, "../../public/disks/dosmaster18.po"),


### PR DESCRIPTION
The 4cade helpers moved from `four_cade_prelaunch_db.ts` to `four_cade_prelaunch.ts`, but the export tests continued mocking the old module. Three tests therefore reached the real fetch implementation and failed in CI.

Update the mock target and re-enable all six export-failure tests.