### PR TITLE
fix(mockingboard): rearm Timer 1 after continuous reload

### DIFF
--- a/src/worker/devices/mockingboard.test.ts
+++ b/src/worker/devices/mockingboard.test.ts
@@ -187,6 +187,49 @@ test.each([
   runAssemblyTest(pollTimerWithInterruptDisabled(timer), flag, 0)
 })
 
+test("Timer 1 continuous reload permits one underflow after switching to one-shot", () => {
+  runAssemblyTest(`
+      SEI
+      LDA #$7F
+      STA $C${slot}0E   ; disable all VIA interrupts
+      LDA #$40
+      STA $C${slot}0D   ; clear any pending Timer 1 flag
+      STA $C${slot}0B   ; continuous Timer 1 mode
+      LDA #$C0
+      STA $C${slot}0E   ; enable Timer 1 IRQ
+      LDA #$40
+      STA $C${slot}04
+      STZ $C${slot}05   ; load and start Timer 1
+FIRST LDA $C${slot}0D
+      AND #$40
+      BEQ FIRST         ; first continuous-mode underflow reloads the counter
+      STZ $C${slot}0B   ; switch the reloaded interval to one-shot mode
+      BIT $C${slot}04   ; acknowledge the first underflow
+      LDY #$40
+NEXT  LDA $C${slot}0D
+      AND #$C0
+      CMP #$C0          ; IFR and IRQ summary must assert on the next underflow
+      BEQ SECOND
+      DEY
+      BNE NEXT
+      LDA #$FF
+      BNE DONE
+SECOND BIT $C${slot}04  ; acknowledge the permitted one-shot underflow
+      LDX #$00
+      LDY #$00
+WAIT  DEY
+      BNE WAIT
+      DEX
+      BNE WAIT          ; wait through multiple subsequent counter wraps
+      LDA $C${slot}0D
+      AND #$C0          ; later one-shot underflows remain inhibited
+DONE  CMP #$00
+      CLV
+      CLC
+      CLI
+  `.split("\n"), 0, Z)
+})
+
 test("a disabled timer does not clear the other VIA's interrupt", () => {
   resetMockingboard(slot)
   interruptRequest(slot, false)

--- a/src/worker/devices/mockingboard.ts
+++ b/src/worker/devices/mockingboard.ts
@@ -79,6 +79,10 @@ const handleTimerT1 = (slot: number, chip: number, cycleDelta: number) => {
           const t1NewLow = memGetSlotROM(slot, T1LL[chip])
           memSetSlotROM(slot, T1CL[chip], t1NewLow)
           memSetSlotROM(slot, T1CH[chip], t1NewHigh)
+          // The reloaded interval can still fire once if software switches
+          // the timer to one-shot mode before its next underflow.
+          const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
+          memSetSlotROM(slot, TIMER_FIRED[chip], fired & ~TIMER1)
         }
       }
     }

--- a/src/worker/devices/mockingboard.ts
+++ b/src/worker/devices/mockingboard.ts
@@ -54,6 +54,15 @@ const T1fired = (slot: number, chip: number) => (memGetSlotROM(slot, TIMER_FIRED
 const T1started = (slot: number, chip: number) => (memGetSlotROM(slot, TIMER_STARTED[chip]) & TIMER1) !== 0
 const T1continuous = (slot: number, chip: number) => (memGetSlotROM(slot, ACR[chip]) & TIMER1) !== 0
 
+// Keep the counter transfer and rearming together so every reload creates
+// one complete timer interval.
+const reloadTimer1 = (slot: number, chip: number) => {
+  memSetSlotROM(slot, T1CL[chip], memGetSlotROM(slot, T1LL[chip]))
+  memSetSlotROM(slot, T1CH[chip], memGetSlotROM(slot, T1LH[chip]))
+  const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
+  memSetSlotROM(slot, TIMER_FIRED[chip], fired & ~TIMER1)
+}
+
 const handleTimerT1 = (slot: number, chip: number, cycleDelta: number) => {
   let t1low = memGetSlotROM(slot, T1CL[chip]) - cycleDelta
   memSetSlotROM(slot, T1CL[chip], t1low)
@@ -75,14 +84,7 @@ const handleTimerT1 = (slot: number, chip: number, cycleDelta: number) => {
           handleInterruptFlag(slot, chip, -1)
         }
         if (T1continuous(slot, chip)) {
-          const t1NewHigh = memGetSlotROM(slot, T1LH[chip])
-          const t1NewLow = memGetSlotROM(slot, T1LL[chip])
-          memSetSlotROM(slot, T1CL[chip], t1NewLow)
-          memSetSlotROM(slot, T1CH[chip], t1NewHigh)
-          // The reloaded interval can still fire once if software switches
-          // the timer to one-shot mode before its next underflow.
-          const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
-          memSetSlotROM(slot, TIMER_FIRED[chip], fired & ~TIMER1)
+          reloadTimer1(slot, chip)
         }
       }
     }
@@ -268,11 +270,7 @@ export const handleMockingboard: AddressCallback = (addr: number, value = -1) =>
     case T1CH[chip]: // Timer 1 high-order counter, fall thru
       if (value >= 0) {
         memSetSlotROM(slot, T1LH[chip], value)
-        memSetSlotROM(slot, T1CL[chip], memGetSlotROM(slot, T1LL[chip]))
-        memSetSlotROM(slot, T1CH[chip], value)
-        // Reset T1 interrupt flag
-        const fired = memGetSlotROM(slot, TIMER_FIRED[chip])
-        memSetSlotROM(slot, TIMER_FIRED[chip], fired & ~TIMER1)
+        reloadTimer1(slot, chip)
         const started = memGetSlotROM(slot, TIMER_STARTED[chip])
         memSetSlotROM(slot, TIMER_STARTED[chip], started | TIMER1)
         handleInterruptFlag(slot, chip, TIMER1)


### PR DESCRIPTION
Fix the mb-audit Timer 1 free-running-to-one-shot IRQ transition test (`11:01:01`) tracked in #364.

- Treat every Timer 1 reload as a new interval.
- Allow an automatically reloaded interval to expire once after switching from free-running to one-shot mode.
- Prevent later one-shot counter wraps from raising another interrupt.
