### PR TITLE
fix(remote-control): return updated speed state

### DIFF
--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -163,14 +163,29 @@ test("speed operations complete after applying their mode", () => {
   setIsTesting()
   const previousState = getExternalMachineState()
   doSetRunMode(RUN_MODE.PAUSED)
+  const passMachineState = jest.spyOn(worker2main, "passMachineState")
   const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
 
   try {
+    doSetSpeedMode(3)
+    expect(passMachineState).toHaveBeenLastCalledWith(expect.objectContaining({
+      speedMode: 3,
+    }))
+    expect(passOperationResult).not.toHaveBeenCalled()
+    passMachineState.mockClear()
+
     doSetSpeedMode(4, 7)
 
     expect(getExternalMachineState().speedMode).toEqual(4)
+    expect(passMachineState).toHaveBeenCalledWith(expect.objectContaining({
+      speedMode: 4,
+    }))
     expect(passOperationResult).toHaveBeenCalledWith(7)
+    expect(passMachineState.mock.invocationCallOrder[0]).toBeLessThan(
+      passOperationResult.mock.invocationCallOrder[0],
+    )
   } finally {
+    passMachineState.mockRestore()
     passOperationResult.mockRestore()
     doSetSpeedMode(previousState.speedMode)
     doSetRunMode(previousState.runMode)

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -360,6 +360,7 @@ export const doSetSpeedMode = (speedModeIn: number, operationId?: number) => {
   refreshTime = (speedMode === 4) ? 0 : 16.6881
   cpuCyclesPerRefresh = 17030 * ([0.1, 0.5, 1, 2, 3, 4, 24])[speedMode + 2]
   resetRefreshCounter()
+  updateExternalMachineState()
   if (operationId !== undefined) passWorkerOperationResult(operationId)
 }
 


### PR DESCRIPTION
## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per #218.

## Motivation

Apple2TS changed the emulator speed correctly, but the remote-control response could still report the previous speed. The updated speed appeared only in a later machine-state read.

## What was implemented in this slice

After changing speed, the worker publishes its updated machine state before confirming the operation. Ordinary application speed changes use the same state update.

## Verification

- Changing to speed 4 returned speed 4, and the following machine-state read also reported 4.
- Restoring speed 0 returned speed 0, and the following machine-state read also reported 0.
