### PR TITLE
fix(remote-control): confirm CPU state changes

### DIFF
--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -29,7 +29,7 @@ import {
   passPasteText,
   passSetDebug,
   passSetBinaryBlock,
-  passSetState6502,
+  requestSetState6502,
   passSetMemory,
   passSetSoftSwitches,
   passStepInto,
@@ -473,7 +473,7 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
       return collectStatus()
 
     case "setCpuState":
-      passSetState6502(payload.state as STATE6502)
+      await requestSetState6502(payload.state as STATE6502)
       return collectStatus()
 
     case "getBreakpoints":

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -1,7 +1,8 @@
-import { MSG_MAIN, MSG_WORKER, RUN_MODE } from "../common/utility"
+import { default6502State, MSG_MAIN, MSG_WORKER, RUN_MODE } from "../common/utility"
 import {
   doOnMessage,
   requestLoadBinary,
+  requestSetState6502,
   requestSetRunMode,
   requestSpeedMode,
   setMain2Worker,
@@ -96,6 +97,19 @@ describe("worker operations", () => {
     expect(message).toEqual(expect.objectContaining({
       msg: MSG_MAIN.LOAD_BINARY,
       payload: {address: 0x6000, data},
+    }))
+
+    sendOperationResult(message.operationId)
+    await expect(operation).resolves.toBeUndefined()
+  })
+
+  test("sends CPU state changes as confirmed worker operations", async () => {
+    const state = {...default6502State(), PC: 0x6000, Accum: 0x42}
+    const operation = requestSetState6502(state)
+    const message = worker.postMessage.mock.calls.at(-1)[0]
+    expect(message).toEqual(expect.objectContaining({
+      msg: MSG_MAIN.STATE6502,
+      payload: state,
     }))
 
     sendOperationResult(message.operationId)

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -100,6 +100,10 @@ export const passSetState6502 = (state: STATE6502) => {
   doPostMessage(MSG_MAIN.STATE6502, state)
 }
 
+export const requestSetState6502 = (state: STATE6502, timeoutMs = 5000) => {
+  return requestWorkerOperation(MSG_MAIN.STATE6502, state, timeoutMs)
+}
+
 export const passBreakpoints = (breakpoints: BreakpointMap) => {
   doPostMessage(MSG_MAIN.BREAKPOINTS, breakpoints)
   // Force the state right away, so the UI can update.

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -3,7 +3,7 @@ import { getHires, memGet, memory, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
-import { doBoot, doLoadBinary, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSpeedMode, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
+import { doBoot, doLoadBinary, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSpeedMode, doSetState6502, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
@@ -210,6 +210,28 @@ test("run changes complete after publishing their state", () => {
     passMachineState.mockRestore()
     passOperationResult.mockRestore()
     doSetRunMode(previousState.runMode)
+  }
+})
+
+test("CPU state changes complete after publishing their state", () => {
+  const previousState = {...s6502}
+  const passMachineState = jest.spyOn(worker2main, "passMachineState")
+  const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
+  const nextState = {...previousState, PC: 0x6000, Accum: 0x42}
+
+  try {
+    doSetState6502(nextState, 9)
+    expect(passMachineState).toHaveBeenCalledWith(expect.objectContaining({
+      s6502: expect.objectContaining({PC: 0x6000, Accum: 0x42}),
+    }))
+    expect(passOperationResult).toHaveBeenCalledWith(9)
+    expect(passMachineState.mock.invocationCallOrder[0]).toBeLessThan(
+      passOperationResult.mock.invocationCallOrder[0],
+    )
+  } finally {
+    passMachineState.mockRestore()
+    passOperationResult.mockRestore()
+    doSetState6502(previousState)
   }
 })
 

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -95,9 +95,10 @@ export const getMachineName = () => {
   return machineName
 }
 
-export const doSetState6502 = (newState: STATE6502) => {
+export const doSetState6502 = (newState: STATE6502, operationId?: number) => {
   setState6502(newState)
   updateExternalMachineState()
+  if (operationId !== undefined) passWorkerOperationResult(operationId)
 }
 
 export const doSetCycleCount = (count: number) => {

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -152,7 +152,7 @@ if (typeof self !== "undefined") {
         doSetCyclesToRun(e.data.payload as number)
         break
       case MSG_MAIN.STATE6502:
-        doSetState6502(e.data.payload as STATE6502)
+        doSetState6502(e.data.payload as STATE6502, e.data.operationId)
         break
       case MSG_MAIN.DEBUG:
         doSetIsDebugging(e.data.payload)


### PR DESCRIPTION
## Cross-repository change

This is the Apple2TS half of the CPU-state control slice. A companion Apple2TS Server pull request adds the MCP `set_cpu` tool and depends on this change. Merge this pull request first.

## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per #218.

This slice makes CPU-state changes wait for confirmation from the emulator worker.

## Motivation

Starting a directly loaded program requires its program counter and processor status to be applied before execution resumes. This change makes that ordering explicit across the UI and worker boundary.

## What was implemented in this slice

- `setCpuState` now uses the existing worker request-and-reply path.
- The worker refreshes externally reported machine state before acknowledging completion.

## Verification

- CPU-state requests remain pending until the emulator worker replies.
- The worker publishes the updated CPU state before sending its completion receipt.
