### PR TITLE
feat(remote-control): confirm keyboard state changes

### DIFF
--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -38,6 +38,7 @@ import {
   passTimeTravelIndex,
   passTimeTravelSnapshot,
   passSetShowDebugTab,
+  requestKeyboardState,
   requestSetRunMode,
   requestLoadBinary,
 } from "../main2worker"
@@ -61,6 +62,7 @@ import {
   handleSetDiskFromURL,
   handleSetDiskWriteProtected,
 } from "../devices/disk/driveprops"
+import { parseRemoteKeyboardState } from "./remotecontrol_input"
 
 const CONNECT_RETRY_MS = 3000
 const HEARTBEAT_MS = 2000
@@ -430,6 +432,10 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
 
     case "setShowDebugTab":
       passSetShowDebugTab(Boolean(payload.enabled))
+      return collectStatus()
+
+    case "setKeyboardState":
+      await requestKeyboardState(parseRemoteKeyboardState(payload))
       return collectStatus()
 
     case "keypress": {

--- a/src/ui/api/remotecontrol_input.test.ts
+++ b/src/ui/api/remotecontrol_input.test.ts
@@ -1,0 +1,9 @@
+import { parseRemoteKeyboardState } from "./remotecontrol_input"
+
+test.each([
+  [{key: "j", isDown: true, repeat: false}, {key: 0x6A, isDown: true, repeat: false}],
+  [{key: " ", isDown: true, repeat: true}, {key: 0x20, isDown: true, repeat: true}],
+  [{key: 0x41, isDown: false}, {key: 0x41, isDown: false, repeat: false}],
+])("parses remote keyboard state", (payload, expected) => {
+  expect(parseRemoteKeyboardState(payload)).toEqual(expected)
+})

--- a/src/ui/api/remotecontrol_input.ts
+++ b/src/ui/api/remotecontrol_input.ts
@@ -1,0 +1,8 @@
+export const parseRemoteKeyboardState = (payload: Record<string, unknown>): KeyboardState => {
+  const value = payload.key
+  return {
+    key: typeof value === "string" ? value.charCodeAt(0) : Number(value),
+    isDown: Boolean(payload.isDown),
+    repeat: Boolean(payload.repeat),
+  }
+}

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -2,6 +2,7 @@ import { default6502State, MSG_MAIN, MSG_WORKER, RUN_MODE } from "../common/util
 import {
   doOnMessage,
   requestLoadBinary,
+  requestKeyboardState,
   requestSetState6502,
   requestSetRunMode,
   requestSpeedMode,
@@ -110,6 +111,22 @@ describe("worker operations", () => {
     expect(message).toEqual(expect.objectContaining({
       msg: MSG_MAIN.STATE6502,
       payload: state,
+    }))
+
+    sendOperationResult(message.operationId)
+    await expect(operation).resolves.toBeUndefined()
+  })
+
+  test.each([
+    {key: 0x41, isDown: true, repeat: false},
+    {key: 0x41, isDown: true, repeat: true},
+    {key: 0, isDown: false, repeat: false},
+  ])("sends keyboard state as a confirmed worker operation", async (keyboardState) => {
+    const operation = requestKeyboardState(keyboardState)
+    const message = worker.postMessage.mock.calls.at(-1)[0]
+    expect(message).toEqual(expect.objectContaining({
+      msg: MSG_MAIN.KEYBOARD_STATE,
+      payload: keyboardState,
     }))
 
     sendOperationResult(message.operationId)

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -181,6 +181,10 @@ export const passKeyboardState = (payload: KeyboardState) => {
   doPostMessage(MSG_MAIN.KEYBOARD_STATE, payload)
 }
 
+export const requestKeyboardState = (payload: KeyboardState, timeoutMs = 5000) => {
+  return requestWorkerOperation(MSG_MAIN.KEYBOARD_STATE, payload, timeoutMs)
+}
+
 export const passKeyRelease = () => {
   setTimeout(() => {
     // Delay the key release to give the emulator time to process the keypress

--- a/src/worker/worker2main.test.ts
+++ b/src/worker/worker2main.test.ts
@@ -1,0 +1,28 @@
+import { MSG_MAIN, MSG_WORKER } from "../common/utility"
+import { setKeyboardState } from "./devices/keyboard"
+
+jest.mock("./devices/keyboard", () => ({
+  apple2KeyRelease: jest.fn(),
+  setKeyboardState: jest.fn(),
+  sendTextToEmulator: jest.fn(),
+}))
+
+import "./worker2main"
+
+test("confirms keyboard state after applying it", () => {
+  const postMessage = jest.spyOn(self, "postMessage").mockImplementation()
+  const keyboardState = {key: 0, isDown: false, repeat: false}
+
+  self.onmessage?.({
+    data: {msg: MSG_MAIN.KEYBOARD_STATE, payload: keyboardState, operationId: 17},
+  } as MessageEvent)
+
+  expect(setKeyboardState).toHaveBeenCalledWith(keyboardState)
+  expect(postMessage).toHaveBeenCalledWith({
+    msg: MSG_WORKER.OPERATION_RESULT,
+    payload: {operationId: 17, error: undefined},
+  })
+  expect(jest.mocked(setKeyboardState).mock.invocationCallOrder[0])
+    .toBeLessThan(postMessage.mock.invocationCallOrder[0])
+  postMessage.mockRestore()
+})

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -202,6 +202,7 @@ if (typeof self !== "undefined") {
         break
       case MSG_MAIN.KEYBOARD_STATE:
         setKeyboardState(e.data.payload as KeyboardState)
+        if (e.data.operationId !== undefined) passWorkerOperationResult(e.data.operationId)
         break
       case MSG_MAIN.KEYPRESS:
         sendTextToEmulator(e.data.payload as number)


### PR DESCRIPTION
## Cross-repository change

Companion server change: [ct6502/apple2ts-server#9](https://github.com/ct6502/apple2ts-server/pull/9).

## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per #218.

This slice adds the Apple2TS support needed to hold, repeat, replace, and release one keyboard key.

## What was implemented in this slice

- Added a confirmed keyboard-state operation between the browser and emulator worker.
- Converted remote character values to the Apple II key codes used by the worker.
- Returned the resulting emulator state through the existing remote-control reply.

## Verification

- A private headless session sent `j` through MCP; a small Apple II program read `$EA` from the keyboard latch.
- Repeat and release completed in the same renderer.
- Worker checks confirmed that each keyboard change was applied before Apple2TS acknowledged it.
