### PR TITLE
fix(cpu): correct invalid BCD ADC carry

### DIFF
--- a/src/worker/instructions.test.ts
+++ b/src/worker/instructions.test.ts
@@ -200,6 +200,10 @@ test("SED ADC 45,45", () => runAssemblyTest(doSED_ADC(0x45, 0x45), 0x90, N | V |
 test("SED ADC 50,50", () => runAssemblyTest(doSED_ADC(0x50, 0x50), 0x0, V | Z | C | D))
 test("SED ADC 99,99", () => runAssemblyTest(doSED_ADC(0x99, 0x99), 0x98, N | V | C | D))
 test("SED ADC B1,C1", () => runAssemblyTest(doSED_ADC(0xB1, 0xC1), 0xD2, N | V | C | D))
+test("SED ADC invalid low digits", () =>
+  runAssemblyTest([" SED", " SEC", " LDA #$0F", " ADC #$0A"], 0x10, D))
+test("SED ADC invalid low digits carry into high digit", () =>
+  runAssemblyTest([" SED", " SEC", " LDA #$1F", " ADC #$2A"], 0x40, D))
 
 const doSED_SBC = (v1: number, v2 = 0) => {
   const instr = [

--- a/src/worker/instructions.ts
+++ b/src/worker/instructions.ts
@@ -233,11 +233,15 @@ const doIndirectInstruction = (vZP: number,
 // 300: F8 18 B8 A9 BD 69 00 D8 00
 const doADC_BCD = (value: number) => {
   let ones = (s6502.Accum & 0x0F) + (value & 0x0F) + (isCarry() ? 1 : 0)
+  let onesCarry = 0
   // Handle illegal BCD hex values by wrapping to "tens" digit
   if (ones >= 0xA) {
-    ones += 6
+    ones = (ones + 6) & 0x0F
+    onesCarry = 0x10
   }
-  let tmp = (s6502.Accum & 0xF0) + (value & 0xF0) + ones
+
+  const tens = (s6502.Accum & 0xF0) + (value & 0xF0) + onesCarry
+  let tmp = tens + ones
   // Pretend we're doing normal addition to set overflow flag
   const bothPositive = (s6502.Accum <= 127 && value <= 127)
   const bothNegative = (s6502.Accum >= 128 && value >= 128)


### PR DESCRIPTION
Correct invalid-BCD ADC handling so low-digit correction contributes exactly one carry into the high digit. This makes the generated Klaus decimal binary pass its 65C02 all-byte-values mode at `$0208`, covering Apple2TS’s enhanced Apple IIe CPU mode.

Add focused coverage for invalid low digits.

Related to #375.
