### PR TITLE
fix(i18n): localize HDV export failure prompt

### DIFF
--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -1867,6 +1867,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Exportproblem melden"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -1701,6 +1701,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Report trouble wit' export"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
 msgstr "Turn Back th' Clock"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -1852,6 +1852,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Reportar un problema de exportación"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -1869,6 +1869,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Signaler un problème d'exportation"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -1855,6 +1855,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Segnala un problema di esportazione"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -1806,6 +1806,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "エクスポートの問題を報告"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -1813,6 +1813,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "내보내기 문제 보고"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -1553,6 +1553,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr ""
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
 msgstr ""

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -1837,6 +1837,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Exportprobleem melden"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -1843,6 +1843,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Reportar um problema de exportação"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -1859,6 +1859,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Сообщить о проблеме экспорта"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -1847,6 +1847,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "Rapportera ett exportproblem"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -1789,6 +1789,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "报告导出问题"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -1802,6 +1802,14 @@ msgctxt "collection.reportExportIssue"
 msgid "Report an export issue"
 msgstr "回報匯出問題"
 
+msgctxt "collection.hdvExportTitleUnavailable"
+msgid "Apple2TS could not include \"{{title}}\" in the HDV."
+msgstr ""
+
+msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
+msgid "Continue creating the HDV and skip unavailable titles?"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/ui/diskdialog/diskpanel_utils.test.ts
+++ b/src/ui/diskdialog/diskpanel_utils.test.ts
@@ -108,8 +108,8 @@ describe("createHdv", () => {
 
     expect(confirm).toHaveBeenCalledTimes(1)
     expect(confirm).toHaveBeenCalledWith(
-      "\"Aztec\" could not be included.\n\n" +
-      "OK to continue creating the HDV, skipping unavailable titles?",
+      "Apple2TS could not include \"Aztec\" in the HDV.\n\n" +
+      "Continue creating the HDV and skip unavailable titles?",
     )
     expect(alert).toHaveBeenCalledWith(
       "HDV created without:\n\n\"Aztec\": no usable binary\n\"Chivalry\": download failed",

--- a/src/ui/diskdialog/diskpanel_utils.ts
+++ b/src/ui/diskdialog/diskpanel_utils.ts
@@ -1,5 +1,6 @@
 import { ImportedDiskFile, loadWozAndExtractProDosFiles, loadWozAndExtractDosImage, classifyImageKind, stripTwoImgHeader, ensureDosVolumeHasHelloGreeting, PRODOS_FILE_TYPE_TEXT, PRODOS_FILE_TYPE_DOS_MASTER, MenuDiskEntry, buildProDosHdv, VTOC_REFRESH, determineVtocType, FourCadeExportFailure } from "../../common/prodos_hdv"
 import { RUN_MODE } from "../../common/utility"
+import { i18n } from "../../i18n"
 import { DiskBookmarks } from "../devices/disk/diskbookmarks"
 import { diskImages } from "../devices/disk/diskimages"
 import { handleSetDiskFromCloudData, handleSetDiskFromFile, handleSetDiskFromURL } from "../devices/disk/driveprops"
@@ -351,8 +352,8 @@ export const createHdv = async (orderedDownloadedDisks: DownloadedExportDisk[]) 
 
       showGlobalProgressModal(false)
       skipUnavailableTitles = window.confirm(
-        `"${failure.title}" could not be included.\n\n` +
-        "OK to continue creating the HDV, skipping unavailable titles?",
+        `${i18n.t("collection.hdvExportTitleUnavailable", {title: failure.title})}\n\n` +
+        i18n.t("collection.continueHdvExportWithoutUnavailableTitles"),
       )
       if (skipUnavailableTitles) {
         showGlobalProgressModal(true, "Creating HDV image")


### PR DESCRIPTION
Route the HDV export failure confirmation through the translation catalogs so Weblate can translate both sentences.

Follow-up to #384.