### PR TITLE
fix(i18n): localize HDV export status text

### DIFF
--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -1875,6 +1875,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -1709,6 +1709,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
 msgstr "Turn Back th' Clock"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -1860,6 +1860,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -1877,6 +1877,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -1863,6 +1863,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -1814,6 +1814,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -1821,6 +1821,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -1561,6 +1561,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"
 msgstr ""

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -1845,6 +1845,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -1851,6 +1851,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -1867,6 +1867,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -1855,6 +1855,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -1792,6 +1792,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -1810,6 +1810,65 @@ msgctxt "collection.continueHdvExportWithoutUnavailableTitles"
 msgid "Continue creating the HDV and skip unavailable titles?"
 msgstr ""
 
+msgctxt "collection.exportUnavailable"
+msgid "This disk cannot be exported"
+msgstr ""
+
+msgctxt "collection.exportTooLarge"
+msgid "This disk is too large to export"
+msgstr ""
+
+msgctxt "collection.exportCopyProtected"
+msgid "Copy protection prevents exporting this disk"
+msgstr ""
+
+msgctxt "collection.exportDosMasterIncompatible"
+msgid "This disk is incompatible with DOS.MASTER"
+msgstr ""
+
+msgctxt "collection.exportStatusPending"
+msgid "Checking whether this disk can be exported"
+msgstr ""
+
+msgctxt "collection.exportAvailable"
+msgid "This disk can be exported"
+msgstr ""
+
+msgctxt "collection.creatingHdv"
+msgid "Creating the HDV image"
+msgstr ""
+
+msgctxt "collection.hdvCreatedWithOmissions"
+msgid ""
+"Apple2TS created the HDV with some titles omitted:\n"
+"\n"
+"{{details}}"
+msgstr ""
+
+msgctxt "collection.hdvCreationFailed"
+msgid "Apple2TS could not create the HDV: {{message}}"
+msgstr ""
+
+msgctxt "collection.hdvDownloadFailed"
+msgid "Apple2TS could not download the disk, so HDV creation was canceled."
+msgstr ""
+
+msgctxt "collection.fetchingDisk"
+msgid "Fetching disk {{current}} of {{total}}"
+msgstr ""
+
+msgctxt "collection.checkingDiskForExport"
+msgid "Checking disk {{current}} of {{total}} for export"
+msgstr ""
+
+msgctxt "collection.selectAllDisks"
+msgid "Select all disks"
+msgstr ""
+
+msgctxt "collection.clearDiskSelection"
+msgid "Clear disk selection"
+msgstr ""
+
 #, fuzzy
 msgctxt "debugControls.goBackInTime"
 msgid "Go Back in Time"

--- a/src/ui/diskdialog/diskcollectionpanel.tsx
+++ b/src/ui/diskdialog/diskcollectionpanel.tsx
@@ -345,7 +345,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
       // Dismiss the disk collection dialog/flyout so the error isn't left
       // hanging over a half-finished export.
       dismissDiskCollection()
-      alert("An unexpected error occurred while downloading the disk. Export to HDV has been aborted.")
+      alert(t("collection.hdvDownloadFailed"))
     } else if (buffer !== undefined) {
       const currentItem = exportQueue[0]
       if (!currentItem) {
@@ -359,7 +359,10 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
       ]))
       setExportQueue((prevExportQueue) => prevExportQueue.slice(1))
     } else if (exportQueue.length > 0) {
-      showGlobalProgressModal(true, `Fetching disk ${selectedDisks.length - exportQueue.length + 1}/${selectedDisks.length}`)
+      showGlobalProgressModal(true, t("collection.fetchingDisk", {
+        current: String(selectedDisks.length - exportQueue.length + 1),
+        total: String(selectedDisks.length),
+      }))
       loadDisk(-1, exportQueue[0], props.updateDisplay, processExportQueue)
     }
   }
@@ -915,7 +918,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
             ...(activeTab == TAB_INDEX.EXPORT
               ? [
                 {
-                  label: "Select all disks",
+                  label: t("collection.selectAllDisks"),
                   icon: faCheckCircle,
                   onClick: () => {
                     const newSelectedDisks = [...selectedDisks]
@@ -928,7 +931,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
                   }
                 },
                 {
-                  label: "Unselect all disks",
+                  label: t("collection.clearDiskSelection"),
                   icon: faCircle,
                   onClick: () => {
                     setSelectedDisks([])

--- a/src/ui/diskdialog/diskpanel_utils.test.ts
+++ b/src/ui/diskdialog/diskpanel_utils.test.ts
@@ -20,7 +20,7 @@ jest.mock("../ui_utilities", () => ({
   showGlobalProgressModal: (...args: unknown[]) => mockShowGlobalProgressModal(...args),
 }))
 
-import { createHdv, DISK_COLLECTION_ITEM_TYPE, loadDisk, loadDiskIntoDrive } from "./diskpanel_utils"
+import { createHdv, DISK_COLLECTION_ITEM_TYPE, getExportBadgeInfo, loadDisk, loadDiskIntoDrive } from "./diskpanel_utils"
 
 describe("loadDisk", () => {
   const disk = {
@@ -112,10 +112,11 @@ describe("createHdv", () => {
       "Continue creating the HDV and skip unavailable titles?",
     )
     expect(alert).toHaveBeenCalledWith(
-      "HDV created without:\n\n\"Aztec\": no usable binary\n\"Chivalry\": download failed",
+      "Apple2TS created the HDV with some titles omitted:\n\n" +
+      "\"Aztec\": no usable binary\n\"Chivalry\": download failed",
     )
     expect(createElement).toHaveBeenCalledWith("a")
-    expect(mockShowGlobalProgressModal).toHaveBeenNthCalledWith(1, true, "Creating HDV image")
+    expect(mockShowGlobalProgressModal).toHaveBeenNthCalledWith(1, true, "Creating the HDV image")
     expect(mockShowGlobalProgressModal).toHaveBeenLastCalledWith(false)
 
     alert.mockRestore()
@@ -138,7 +139,7 @@ describe("createHdv", () => {
     await createHdv([])
 
     expect(alert).toHaveBeenCalledWith(
-      "Failed to build ProDOS HDV: Could not export \"Aztec\": no usable binary",
+      "Apple2TS could not create the HDV: Could not export \"Aztec\": no usable binary",
     )
     expect(createElement).not.toHaveBeenCalledWith("a")
     expect(mockShowGlobalProgressModal).toHaveBeenLastCalledWith(false)
@@ -146,5 +147,24 @@ describe("createHdv", () => {
     alert.mockRestore()
     confirm.mockRestore()
     createElement.mockRestore()
+  })
+})
+
+describe("getExportBadgeInfo", () => {
+  const disk = {
+    fileSize: 143360,
+    title: "Example",
+    type: DISK_COLLECTION_ITEM_TYPE.A2TS_ARCHIVE,
+  } as DiskCollectionItem
+
+  test.each([
+    [{ ...disk, exportDisabled: true }, "blocked", "This disk cannot be exported"],
+    [{ ...disk, fileSize: 33554432 }, "blocked", "This disk is too large to export"],
+    [{ ...disk, vtocType: "other" }, "blocked", "Copy protection prevents exporting this disk"],
+    [{ ...disk, vtocType: "dosup" }, "blocked", "This disk is incompatible with DOS.MASTER"],
+    [{ ...disk, vtocType: undefined }, "pending", "Checking whether this disk can be exported"],
+    [{ ...disk, vtocType: "prodos" }, "exportable", "This disk can be exported"],
+  ])("returns localized export status", (item, state, title) => {
+    expect(getExportBadgeInfo(item as DiskCollectionItem)).toEqual({ state, title })
   })
 })

--- a/src/ui/diskdialog/diskpanel_utils.ts
+++ b/src/ui/diskdialog/diskpanel_utils.ts
@@ -323,26 +323,26 @@ export const diskItemKey = (item: DiskCollectionItem): string =>
 // why; disks whose VTOC hasn't been determined yet show a yellow "pending" badge.
 export const getExportBadgeInfo = (disk: DiskCollectionItem): { state: "exportable" | "blocked" | "pending"; title: string } => {
   if (disk.exportDisabled) {
-    return { state: "blocked", title: "Export is not currently supported for this disk" }
+    return { state: "blocked", title: i18n.t("collection.exportUnavailable") }
   }
   if (disk.fileSize >= maxHdvBytes * 0.95) {
-    return { state: "blocked", title: "Disk is too large to be exported" }
+    return { state: "blocked", title: i18n.t("collection.exportTooLarge") }
   }
   if (disk.vtocType === "other") {
-    return { state: "blocked", title: "Disk is not exportable due to copy protection" }
+    return { state: "blocked", title: i18n.t("collection.exportCopyProtected") }
   }
   if (disk.vtocType === "dosup") {
-    return { state: "blocked", title: "Disk is not exportable due to DOS Master incompatibility" }
+    return { state: "blocked", title: i18n.t("collection.exportDosMasterIncompatible") }
   }
   if (disk.vtocType === undefined) {
-    return { state: "pending", title: "Disk export status pending" }
+    return { state: "pending", title: i18n.t("collection.exportStatusPending") }
   }
-  return { state: "exportable", title: "Disk can be exported" }
+  return { state: "exportable", title: i18n.t("collection.exportAvailable") }
 }
 
 export const createHdv = async (orderedDownloadedDisks: DownloadedExportDisk[]) => {
 
-  showGlobalProgressModal(true, "Creating HDV image")
+  showGlobalProgressModal(true, i18n.t("collection.creatingHdv"))
   try {
     const omittedFourCadeTitles: FourCadeExportFailure[] = []
     let skipUnavailableTitles = false
@@ -356,7 +356,7 @@ export const createHdv = async (orderedDownloadedDisks: DownloadedExportDisk[]) 
         i18n.t("collection.continueHdvExportWithoutUnavailableTitles"),
       )
       if (skipUnavailableTitles) {
-        showGlobalProgressModal(true, "Creating HDV image")
+        showGlobalProgressModal(true, i18n.t("collection.creatingHdv"))
       }
       return skipUnavailableTitles
     }
@@ -482,15 +482,14 @@ export const createHdv = async (orderedDownloadedDisks: DownloadedExportDisk[]) 
     downloadExportHdv(hdvData, "APPLE2TS.HDV")
     if (omittedFourCadeTitles.length > 0) {
       showGlobalProgressModal(false)
-      alert(
-        "HDV created without:\n\n" + omittedFourCadeTitles
-          .map(({ title, reason }) => `"${title}": ${reason}`)
-          .join("\n"),
-      )
+      const details = omittedFourCadeTitles
+        .map(({ title, reason }) => `"${title}": ${reason}`)
+        .join("\n")
+      alert(i18n.t("collection.hdvCreatedWithOmissions", {details}))
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    alert(`Failed to build ProDOS HDV: ${message}`)
+    alert(i18n.t("collection.hdvCreationFailed", {message}))
   } finally {
     showGlobalProgressModal(false)
   }

--- a/src/ui/diskdialog/diskpanel_vtoc.tsx
+++ b/src/ui/diskdialog/diskpanel_vtoc.tsx
@@ -7,6 +7,7 @@ import { isDiskExportable, getExportFilename, DISK_COLLECTION_ITEM_TYPE, TAB_IND
 import { DiskBookmarks } from "../devices/disk/diskbookmarks"
 import { handleSetDiskFromCloudData, handleSetDiskFromFile, handleSetDiskFromURL } from "../devices/disk/driveprops"
 import { clearIaResolveCache, internetArchiveUrlProtocol } from "../devices/disk/internetarchive_utils"
+import { i18n } from "../../i18n"
 
 type DiskPanelVtocProps = {
   activeTab: number,
@@ -253,7 +254,10 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     const suppressProgress = suppressProgressRef.current
     suppressProgressRef.current = false
     if (!suppressProgress && props.activeTab === TAB_INDEX.EXPORT && props.showProgressModal !== false) {
-      showGlobalProgressModal(true, `Fetching disk metadata ${currentDisk}/${totalDisks}`)
+      showGlobalProgressModal(true, i18n.t("collection.checkingDiskForExport", {
+        current: String(currentDisk),
+        total: String(totalDisks),
+      }))
       vtocProgressVisibleRef.current = true
     }
 


### PR DESCRIPTION
Make HDV export status, progress, selection, and result messages available for translation. Refine the English wording to be clearer for translators.