### PR TITLE
fix(remote-control): confirm disk media operations

### DIFF
--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -39,6 +39,7 @@ import {
   passTimeTravelSnapshot,
   passSetShowDebugTab,
   requestKeyboardState,
+  passSetRunMode,
   requestSetRunMode,
   requestLoadBinary,
 } from "../main2worker"
@@ -60,7 +61,7 @@ import {
   handleSetDiskWriteProtected,
   requestEjectDisk,
   requestSetDiskFromURL,
-  requestSetDiskOrFileFromBuffer,
+  requestMountDiskFromBuffer,
 } from "../devices/disk/driveprops"
 import { parseRemoteKeyboardState } from "./remotecontrol_input"
 
@@ -585,10 +586,20 @@ export const executeCommand = async (action: string, payload: Record<string, unk
       const driveIndex = Number(payload.driveIndex || 0)
       const bytes = decodeBase64(dataBase64)
       const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
-      const mountedDrive = await requestSetDiskOrFileFromBuffer(driveIndex, arrayBuffer, filename, null, null)
+      const mountedDrive = await requestMountDiskFromBuffer(
+        driveIndex,
+        arrayBuffer,
+        filename,
+        null,
+        null,
+        undefined,
+        true,
+      )
+      const status = collectStatus()
       return {
         mountedDrive,
-        status: collectStatus(),
+        mountedDriveState: status.drives[mountedDrive],
+        status,
       }
     }
 
@@ -598,12 +609,16 @@ export const executeCommand = async (action: string, payload: Record<string, unk
       if (!url) {
         throw new Error("url is required")
       }
-      const mounted = await requestSetDiskFromURL(url, undefined, driveIndex)
-      if (!mounted) {
+      const mountedDrive = await requestSetDiskFromURL(url, undefined, driveIndex)
+      if (mountedDrive === false) {
         throw new Error(`Unable to mount disk from URL: ${url}`)
       }
+      passSetRunMode(RUN_MODE.NEED_BOOT)
+      const status = collectStatus()
       return {
-        status: collectStatus(),
+        mountedDrive,
+        mountedDriveState: status.drives[mountedDrive],
+        status,
       }
     }
 

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -56,11 +56,11 @@ import { getMockingboardMode } from "../devices/audio/mockingboard_audio"
 import { isAudioEnabled } from "../devices/audio/speaker"
 import {
   handleGetFilename,
-  handleEjectDisk,
   handleGetDriveProps,
-  handleSetDiskOrFileFromBuffer,
-  handleSetDiskFromURL,
   handleSetDiskWriteProtected,
+  requestEjectDisk,
+  requestSetDiskFromURL,
+  requestSetDiskOrFileFromBuffer,
 } from "../devices/disk/driveprops"
 import { parseRemoteKeyboardState } from "./remotecontrol_input"
 
@@ -394,7 +394,7 @@ const connectToRemoteServer = async () => {
   }
 }
 
-const executeCommand = async (action: string, payload: Record<string, unknown>) => {
+export const executeCommand = async (action: string, payload: Record<string, unknown>) => {
   switch (action) {
     case "getStatus":
       return collectStatus()
@@ -585,7 +585,7 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
       const driveIndex = Number(payload.driveIndex || 0)
       const bytes = decodeBase64(dataBase64)
       const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
-      const mountedDrive = handleSetDiskOrFileFromBuffer(driveIndex, arrayBuffer, filename, null, null)
+      const mountedDrive = await requestSetDiskOrFileFromBuffer(driveIndex, arrayBuffer, filename, null, null)
       return {
         mountedDrive,
         status: collectStatus(),
@@ -598,7 +598,10 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
       if (!url) {
         throw new Error("url is required")
       }
-      await handleSetDiskFromURL(url, undefined, driveIndex)
+      const mounted = await requestSetDiskFromURL(url, undefined, driveIndex)
+      if (!mounted) {
+        throw new Error(`Unable to mount disk from URL: ${url}`)
+      }
       return {
         status: collectStatus(),
       }
@@ -689,7 +692,7 @@ const executeCommand = async (action: string, payload: Record<string, unknown>) 
     }
 
     case "ejectDisk":
-      handleEjectDisk(Number(payload.driveIndex))
+      await requestEjectDisk(Number(payload.driveIndex))
       return {
         status: collectStatus(),
       }

--- a/src/ui/api/remotecontrol_media.test.ts
+++ b/src/ui/api/remotecontrol_media.test.ts
@@ -1,9 +1,11 @@
 import { executeCommand } from "./remotecontrol"
+import { RUN_MODE } from "../../common/utility"
+import { passSetRunMode } from "../main2worker"
 import {
   handleGetDriveProps,
   requestEjectDisk,
   requestSetDiskFromURL,
-  requestSetDiskOrFileFromBuffer,
+  requestMountDiskFromBuffer,
 } from "../devices/disk/driveprops"
 
 jest.mock("../main2worker", () => ({
@@ -44,6 +46,7 @@ jest.mock("../main2worker", () => ({
   passTimeTravelIndex: jest.fn(),
   passTimeTravelSnapshot: jest.fn(),
   passSetShowDebugTab: jest.fn(),
+  passSetRunMode: jest.fn(),
   requestSetRunMode: jest.fn(),
   requestLoadBinary: jest.fn(),
 }))
@@ -67,7 +70,7 @@ jest.mock("../devices/disk/driveprops", () => ({
     index,
     drive: index % 2 + 1,
     hardDrive: index < 2,
-    filename: "",
+    filename: index === 0 ? "unrelated.hdv" : "",
     status: "",
     motorRunning: false,
     diskHasChanges: false,
@@ -77,20 +80,21 @@ jest.mock("../devices/disk/driveprops", () => ({
   handleSetDiskWriteProtected: jest.fn(),
   requestEjectDisk: jest.fn(),
   requestSetDiskFromURL: jest.fn(),
-  requestSetDiskOrFileFromBuffer: jest.fn(),
+  requestMountDiskFromBuffer: jest.fn(),
 }))
 
 const mockHandleGetDriveProps = jest.mocked(handleGetDriveProps)
+const mockPassSetRunMode = jest.mocked(passSetRunMode)
 const mockRequestEjectDisk = jest.mocked(requestEjectDisk)
 const mockRequestSetDiskFromURL = jest.mocked(requestSetDiskFromURL)
-const mockRequestSetDiskOrFileFromBuffer = jest.mocked(requestSetDiskOrFileFromBuffer)
+const mockRequestMountDiskFromBuffer = jest.mocked(requestMountDiskFromBuffer)
 
 describe("remote-control media confirmation", () => {
   beforeEach(() => jest.clearAllMocks())
 
   test("collects mount status only after the worker applies the disk", async () => {
     let confirmMount!: (drive: number) => void
-    mockRequestSetDiskOrFileFromBuffer.mockReturnValue(new Promise((resolve) => {
+    mockRequestMountDiskFromBuffer.mockReturnValue(new Promise((resolve) => {
       confirmMount = resolve
     }))
 
@@ -101,10 +105,29 @@ describe("remote-control media confirmation", () => {
     })
     await Promise.resolve()
     expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
+    expect(mockPassSetRunMode).not.toHaveBeenCalled()
 
     confirmMount(2)
-    await expect(command).resolves.toEqual(expect.objectContaining({mountedDrive: 2}))
+    await expect(command).resolves.toEqual(expect.objectContaining({
+      mountedDrive: 2,
+      mountedDriveState: expect.objectContaining({index: 2}),
+      status: expect.objectContaining({
+        drives: expect.arrayContaining([
+          expect.objectContaining({index: 0, filename: "unrelated.hdv"}),
+        ]),
+      }),
+    }))
+    expect(mockRequestMountDiskFromBuffer).toHaveBeenCalledWith(
+      2,
+      expect.any(ArrayBuffer),
+      "remote.woz",
+      null,
+      null,
+      undefined,
+      true,
+    )
     expect(mockHandleGetDriveProps).toHaveBeenCalledTimes(4)
+    expect(mockPassSetRunMode).not.toHaveBeenCalled()
   })
 
   test("treats a false URL loader result as a mount failure", async () => {
@@ -114,6 +137,73 @@ describe("remote-control media confirmation", () => {
       driveIndex: 2,
       url: "https://example.test/bad.woz",
     })).rejects.toThrow("Unable to mount disk from URL")
+    expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
+    expect(mockPassSetRunMode).not.toHaveBeenCalled()
+  })
+
+  test("preserves the requested URL drive and reports its post-ack state", async () => {
+    let confirmMount!: (drive: number | false) => void
+    mockRequestSetDiskFromURL.mockReturnValue(new Promise((resolve) => {
+      confirmMount = resolve
+    }))
+
+    const command = executeCommand("mountDiskFromUrl", {
+      driveIndex: 3,
+      url: "https://example.test/disk.hdv",
+    })
+    await Promise.resolve()
+    expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
+    expect(mockPassSetRunMode).not.toHaveBeenCalled()
+
+    confirmMount(3)
+    await expect(command).resolves.toEqual(expect.objectContaining({
+      mountedDrive: 3,
+      mountedDriveState: expect.objectContaining({index: 3}),
+    }))
+    expect(mockRequestSetDiskFromURL).toHaveBeenCalledWith(
+      "https://example.test/disk.hdv",
+      undefined,
+      3,
+    )
+    expect(mockPassSetRunMode).toHaveBeenCalledWith(RUN_MODE.NEED_BOOT)
+    expect(mockPassSetRunMode).toHaveBeenCalledTimes(1)
+    expect(mockHandleGetDriveProps).toHaveBeenCalledTimes(4)
+  })
+
+  test("does not report an invalid worker-rejected disk as mounted", async () => {
+    mockRequestMountDiskFromBuffer.mockImplementation(async (_index, buffer) => {
+      expect(Array.from(new Uint8Array(buffer))).toEqual([1, 2, 3])
+      throw new Error("Worker rejected disk image")
+    })
+
+    await expect(executeCommand("mountDisk", {
+      driveIndex: 3,
+      filename: "invalid.woz",
+      dataBase64: "AQID",
+    })).rejects.toThrow("Worker rejected disk image")
+    expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
+    expect(mockPassSetRunMode).not.toHaveBeenCalled()
+  })
+
+  test("does not route remote disk mounts through generic binary handling", async () => {
+    mockRequestMountDiskFromBuffer.mockRejectedValue(
+      new Error("Remote disk mount requires disk media"),
+    )
+
+    await expect(executeCommand("mountDisk", {
+      driveIndex: 1,
+      filename: "program.bin",
+      dataBase64: "AQID",
+    })).rejects.toThrow("Remote disk mount requires disk media")
+    expect(mockRequestMountDiskFromBuffer).toHaveBeenCalledWith(
+      1,
+      expect.any(ArrayBuffer),
+      "program.bin",
+      null,
+      null,
+      undefined,
+      true,
+    )
     expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
   })
 

--- a/src/ui/api/remotecontrol_media.test.ts
+++ b/src/ui/api/remotecontrol_media.test.ts
@@ -1,0 +1,134 @@
+import { executeCommand } from "./remotecontrol"
+import {
+  handleGetDriveProps,
+  requestEjectDisk,
+  requestSetDiskFromURL,
+  requestSetDiskOrFileFromBuffer,
+} from "../devices/disk/driveprops"
+
+jest.mock("../main2worker", () => ({
+  handleGetBreakpoints: () => new Map(),
+  handleCanGoBackward: () => false,
+  handleCanGoForward: () => false,
+  handleGetC800Slot: () => 0,
+  handleGetIsDebugging: () => false,
+  handleGetMachineName: () => "APPLE2EE",
+  handleGetMemSize: () => 64,
+  handleGetMemoryDump: () => new Uint8Array(),
+  handleGetRunMode: () => 0,
+  handleGetSaveState: jest.fn(),
+  handleGetShowDebugTab: () => false,
+  handleGetSoftSwitches: () => ({}),
+  handleGetSpeedMode: () => 0,
+  handleGetStackString: () => "",
+  handleGetState6502: () => ({}),
+  handleGetTextPageAsString: () => "",
+  handleGetTempStateIndex: () => 0,
+  handleGetTimeTravelThumbnails: () => [],
+  passGoBackInTime: jest.fn(),
+  passGoForwardInTime: jest.fn(),
+  passAppleCommandKeyPress: jest.fn(),
+  passAppleCommandKeyRelease: jest.fn(),
+  passKeyRelease: jest.fn(),
+  passKeypress: jest.fn(),
+  passMouseEvent: jest.fn(),
+  passPasteText: jest.fn(),
+  passSetDebug: jest.fn(),
+  passSetBinaryBlock: jest.fn(),
+  requestSetState6502: jest.fn(),
+  passSetMemory: jest.fn(),
+  passSetSoftSwitches: jest.fn(),
+  passStepInto: jest.fn(),
+  passStepOut: jest.fn(),
+  passStepOver: jest.fn(),
+  passTimeTravelIndex: jest.fn(),
+  passTimeTravelSnapshot: jest.fn(),
+  passSetShowDebugTab: jest.fn(),
+  requestSetRunMode: jest.fn(),
+  requestLoadBinary: jest.fn(),
+}))
+
+jest.mock("../localstorage", () => ({
+  setPreferenceBreakpoints: jest.fn(),
+  setPreferenceColorMode: jest.fn(),
+  setPreferenceMachineName: jest.fn(),
+  setPreferenceRamWorks: jest.fn(),
+  requestPreferenceSpeedMode: jest.fn(),
+}))
+
+jest.mock("../savestate", () => ({ RestoreSaveState: jest.fn() }))
+jest.mock("../ui_settings", () => ({ getUIState: () => ({}) }))
+jest.mock("../devices/audio/mockingboard_audio", () => ({ getMockingboardMode: () => 0 }))
+jest.mock("../devices/audio/speaker", () => ({ isAudioEnabled: () => false }))
+
+jest.mock("../devices/disk/driveprops", () => ({
+  handleGetFilename: () => null,
+  handleGetDriveProps: jest.fn((index: number) => ({
+    index,
+    drive: index % 2 + 1,
+    hardDrive: index < 2,
+    filename: "",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData: new Uint8Array(),
+  })),
+  handleSetDiskWriteProtected: jest.fn(),
+  requestEjectDisk: jest.fn(),
+  requestSetDiskFromURL: jest.fn(),
+  requestSetDiskOrFileFromBuffer: jest.fn(),
+}))
+
+const mockHandleGetDriveProps = jest.mocked(handleGetDriveProps)
+const mockRequestEjectDisk = jest.mocked(requestEjectDisk)
+const mockRequestSetDiskFromURL = jest.mocked(requestSetDiskFromURL)
+const mockRequestSetDiskOrFileFromBuffer = jest.mocked(requestSetDiskOrFileFromBuffer)
+
+describe("remote-control media confirmation", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test("collects mount status only after the worker applies the disk", async () => {
+    let confirmMount!: (drive: number) => void
+    mockRequestSetDiskOrFileFromBuffer.mockReturnValue(new Promise((resolve) => {
+      confirmMount = resolve
+    }))
+
+    const command = executeCommand("mountDisk", {
+      driveIndex: 2,
+      filename: "remote.woz",
+      dataBase64: "AQID",
+    })
+    await Promise.resolve()
+    expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
+
+    confirmMount(2)
+    await expect(command).resolves.toEqual(expect.objectContaining({mountedDrive: 2}))
+    expect(mockHandleGetDriveProps).toHaveBeenCalledTimes(4)
+  })
+
+  test("treats a false URL loader result as a mount failure", async () => {
+    mockRequestSetDiskFromURL.mockResolvedValue(false)
+
+    await expect(executeCommand("mountDiskFromUrl", {
+      driveIndex: 2,
+      url: "https://example.test/bad.woz",
+    })).rejects.toThrow("Unable to mount disk from URL")
+    expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
+  })
+
+  test("collects eject status only after the worker applies the empty drive", async () => {
+    let confirmEject!: () => void
+    mockRequestEjectDisk.mockReturnValue(new Promise((resolve) => {
+      confirmEject = resolve
+    }))
+
+    const command = executeCommand("ejectDisk", {driveIndex: 2})
+    await Promise.resolve()
+    expect(mockHandleGetDriveProps).not.toHaveBeenCalled()
+
+    confirmEject()
+    await expect(command).resolves.toEqual(expect.objectContaining({status: expect.any(Object)}))
+    expect(mockHandleGetDriveProps).toHaveBeenCalledTimes(4)
+  })
+})

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -89,13 +89,13 @@ export const handleGetFilename = (index: number) => {
   return null
 }
 
-export const doSetUIDriveProps = (props: DriveProps) => {
+export const doSetUIDriveProps = (props: DriveProps, replaceDiskData = false) => {
   // For efficiency we only receive disk data if it has changed.
   // If our disk is the same but it hasn't changed, keep the existing data.
   // Also preserve writableFileHandle (custom Electron handlers aren't sent to worker)
   const existingWritableFileHandle = driveProps[props.index].writableFileHandle
   
-  if (props.diskData.length === 0) {
+  if (props.diskData.length === 0 && !replaceDiskData) {
     const tmp = driveProps[props.index].diskData
     const diskHasChanges = driveProps[props.index].diskHasChanges
     driveProps[props.index] = props
@@ -142,9 +142,12 @@ const setDiskData = (
     ...driveProps[index],
     writableFileHandle: isFileSystemHandle ? writableFileHandle : null
   }
-  const workerOperation = confirmed
-    ? requestSetDriveNewData(propsForWorker, forceIndex)
-    : Promise.resolve(passSetDriveNewData(propsForWorker, forceIndex))
+  let workerOperation: Promise<void> | undefined
+  if (confirmed) {
+    workerOperation = requestSetDriveNewData(propsForWorker, forceIndex)
+  } else {
+    passSetDriveNewData(propsForWorker, forceIndex)
+  }
   if (filename) {
     setTimeout(() => {
       selectHelpText(helpFile, applyHelpText)
@@ -238,7 +241,28 @@ const setDiskOrFileFromBuffer = (
 
   const fname = filename.toLowerCase()
   let newIndex = index
-  let workerOperation = Promise.resolve()
+  const isGenericProgram = fname.endsWith(".bin") || fname.endsWith(".bas") || fname.endsWith(".a")
+
+  if (confirmed) {
+    if (isGenericProgram) {
+      // A confirmed remote disk mount is intentionally narrower than the GUI's
+      // generic file loader and must not execute a program as a side effect.
+      return { mountedDrive: index, workerOperation: undefined }
+    }
+    const workerOperation = setDiskData(
+      index,
+      new Uint8Array(buffer),
+      filename,
+      cloudData,
+      writableFileHandle,
+      Date.now(),
+      helpFile,
+      setHelpText,
+      true,
+      true,
+    )
+    return { mountedDrive: index, workerOperation }
+  }
 
   if (fname.endsWith(".bin")) {
     passSetBinaryBlock(binaryRunAddress, new Uint8Array(buffer), true)
@@ -269,7 +293,7 @@ const setDiskOrFileFromBuffer = (
         newIndex = defaultDriveIndex
       }
     }
-    workerOperation = setDiskData(
+    setDiskData(
       newIndex,
       new Uint8Array(buffer),
       filename,
@@ -279,16 +303,17 @@ const setDiskOrFileFromBuffer = (
       helpFile,
       setHelpText,
       preserveDriveIndex,
-      confirmed,
+      false,
     )
-    if (bootsExplicitDrive || handleGetRunMode() === RUN_MODE.IDLE) {
+    const shouldBoot = bootsExplicitDrive || handleGetRunMode() === RUN_MODE.IDLE
+    if (shouldBoot) {
       passSetRunMode(RUN_MODE.NEED_BOOT)
     } else {
 //      props.updateDisplay()
     }
   }
 
-  return { mountedDrive: newIndex, workerOperation }
+  return { mountedDrive: newIndex, workerOperation: undefined }
 }
 
 export const handleSetDiskOrFileFromBuffer = (
@@ -310,7 +335,7 @@ export const handleSetDiskOrFileFromBuffer = (
   ).mountedDrive
 }
 
-export const requestSetDiskOrFileFromBuffer = async (
+export const requestMountDiskFromBuffer = async (
   index: number,
   buffer: ArrayBuffer,
   filename: string,
@@ -328,6 +353,9 @@ export const requestSetDiskOrFileFromBuffer = async (
     preserveDriveIndex,
     true,
   )
+  if (!result.workerOperation) {
+    throw new Error("Remote disk mount requires disk media")
+  }
   await result.workerOperation
   return result.mountedDrive
 }
@@ -643,10 +671,36 @@ const diskImageLocalStorageSync = (url: string, index: number) => {
 const setDiskFromURL = async (url: string,
   updateDisplay?: UpdateDisplay, index = 0, cloudData?: CloudData, callback?: (buffer: ArrayBuffer | null) => void,
   debug?: (message: string) => void, preserveDriveIndex = false, confirmed = false): Promise<boolean> => {
-  const installDisk = (...args: Parameters<typeof handleSetDiskOrFileFromBuffer>) => {
-    return confirmed
-      ? requestSetDiskOrFileFromBuffer(...args)
-      : Promise.resolve(handleSetDiskOrFileFromBuffer(...args))
+  const requestedIndex = index
+  const installDisk = (
+    installIndex: number,
+    buffer: ArrayBuffer,
+    filename: string,
+    installCloudData: CloudData | null,
+    writableFileHandle: WritableFileHandle | null,
+    helpFile?: string,
+    preserveInstallIndex = false,
+  ) => {
+    if (confirmed) {
+      return requestMountDiskFromBuffer(
+        requestedIndex,
+        buffer,
+        filename,
+        installCloudData,
+        writableFileHandle,
+        helpFile,
+        true,
+      )
+    }
+    return Promise.resolve(handleSetDiskOrFileFromBuffer(
+      installIndex,
+      buffer,
+      filename,
+      installCloudData,
+      writableFileHandle,
+      helpFile,
+      preserveInstallIndex,
+    ))
   }
   debug?.(`handleSetDiskFromURL(${url}) drive=${index}`)
   let helpFile = findCatalogHelpFile(url)
@@ -659,13 +713,13 @@ const setDiskFromURL = async (url: string,
         // Fetch for browser (may fail for local files due to CORS)
         const state = getDiskImageFromLocalStorage()
         if (state) {
-          resetAllDiskDrives()
+          if (!preserveDriveIndex) resetAllDiskDrives()
           index = await installDisk(state.index, state.data.buffer, url, null, null, helpFile)
         } else {
           const response = await fetch(url)
           const buffer = await response.arrayBuffer()
           const fileName = url.split("/").pop() || url        
-          resetAllDiskDrives()
+          if (!preserveDriveIndex) resetAllDiskDrives()
           index = await installDisk(
             index,
             buffer,
@@ -968,8 +1022,9 @@ export const handleSetDiskFromURL = async (url: string,
 
 export const requestSetDiskFromURL = async (url: string,
   updateDisplay?: UpdateDisplay, index = 0, cloudData?: CloudData, callback?: (buffer: ArrayBuffer | null) => void,
-  debug?: (message: string) => void, preserveDriveIndex = false): Promise<boolean> => {
-  return setDiskFromURL(url, updateDisplay, index, cloudData, callback, debug, preserveDriveIndex, true)
+  debug?: (message: string) => void): Promise<number | false> => {
+  const mounted = await setDiskFromURL(url, updateDisplay, index, cloudData, callback, debug, true, true)
+  return mounted ? index : false
 }
 
 export const prepWritableFile = async (index: number, writableFileHandle: WritableFileHandle) => {

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -10,7 +10,7 @@ import {
   RUN_MODE,
 } from "../../../common/utility"
 
-import { passSetDriveNewData, passSetDriveProps, passSetBinaryBlock, passPasteText, handleGetRunMode, passSetRunMode, handleGetProdosFloppy } from "../../main2worker"
+import { passSetDriveNewData, requestSetDriveNewData, passSetDriveProps, passSetBinaryBlock, passPasteText, handleGetRunMode, passSetRunMode, handleGetProdosFloppy } from "../../main2worker"
 import { showGlobalProgressModal } from "../../ui_utilities"
 import { internetArchiveUrlProtocol, getDiskImageUrlFromIdentifier } from "./internetarchive_utils"
 import { apple2tsProxyPath, hasApple2tsProxy } from "./apple2tsproxy"
@@ -115,7 +115,7 @@ export const handleGetDriveProps = (index: number) => {
   return driveProps[index]
 }
 
-export const handleSetDiskData = (
+const setDiskData = (
   index: number,
   data: Uint8Array,
   filename: string,
@@ -124,7 +124,8 @@ export const handleSetDiskData = (
   lastLocalFileWriteTime: number,
   helpFile?: string,
   applyHelpText: (helpText: string) => void = setHelpText,
-  forceIndex = false) => {
+  forceIndex = false,
+  confirmed = false) => {
   if (cloudData) {
     cloudData.fileSize = data.length
   }
@@ -141,13 +142,39 @@ export const handleSetDiskData = (
     ...driveProps[index],
     writableFileHandle: isFileSystemHandle ? writableFileHandle : null
   }
-  passSetDriveNewData(propsForWorker, forceIndex)
+  const workerOperation = confirmed
+    ? requestSetDriveNewData(propsForWorker, forceIndex)
+    : Promise.resolve(passSetDriveNewData(propsForWorker, forceIndex))
   if (filename) {
     setTimeout(() => {
       selectHelpText(helpFile, applyHelpText)
     }, 150)
   }
 
+  return workerOperation
+}
+
+export const handleSetDiskData = (
+  index: number,
+  data: Uint8Array,
+  filename: string,
+  cloudData: CloudData | null,
+  writableFileHandle: WritableFileHandle | null,
+  lastLocalFileWriteTime: number,
+  helpFile?: string,
+  applyHelpText: (helpText: string) => void = setHelpText,
+  forceIndex = false) => {
+  void setDiskData(
+    index,
+    data,
+    filename,
+    cloudData,
+    writableFileHandle,
+    lastLocalFileWriteTime,
+    helpFile,
+    applyHelpText,
+    forceIndex,
+  )
 }
 
 export const handleSetDiskWriteProtected = (index: number, isWriteProtected: boolean) => {
@@ -158,6 +185,11 @@ export const handleSetDiskWriteProtected = (index: number, isWriteProtected: boo
 export const handleEjectDisk = (index: number) => {
   driveProps[index] = initDriveProps(index, driveProps[index].drive, driveProps[index].hardDrive)
   passSetDriveNewData(driveProps[index])
+}
+
+export const requestEjectDisk = (index: number) => {
+  driveProps[index] = initDriveProps(index, driveProps[index].drive, driveProps[index].hardDrive)
+  return requestSetDriveNewData(driveProps[index])
 }
 
 const findMatchingDiskImage = (url: string) => {
@@ -189,14 +221,15 @@ export const setDefaultBinaryAddress = (address: number) => {
   binaryRunAddress = address
 }
 
-export const handleSetDiskOrFileFromBuffer = (
+const setDiskOrFileFromBuffer = (
   index: number,
   buffer: ArrayBuffer,
   filename: string,
   cloudData: CloudData | null,
   writableFileHandle: WritableFileHandle | null,
   helpFile?: string,
-  preserveDriveIndex = false) => {
+  preserveDriveIndex = false,
+  confirmed = false) => {
 
   // Sanity check for strange downloads with no filename.
   if (buffer.byteLength === 143360 && !filename.includes(".")) {
@@ -205,6 +238,7 @@ export const handleSetDiskOrFileFromBuffer = (
 
   const fname = filename.toLowerCase()
   let newIndex = index
+  let workerOperation = Promise.resolve()
 
   if (fname.endsWith(".bin")) {
     passSetBinaryBlock(binaryRunAddress, new Uint8Array(buffer), true)
@@ -235,7 +269,7 @@ export const handleSetDiskOrFileFromBuffer = (
         newIndex = defaultDriveIndex
       }
     }
-    handleSetDiskData(
+    workerOperation = setDiskData(
       newIndex,
       new Uint8Array(buffer),
       filename,
@@ -245,6 +279,7 @@ export const handleSetDiskOrFileFromBuffer = (
       helpFile,
       setHelpText,
       preserveDriveIndex,
+      confirmed,
     )
     if (bootsExplicitDrive || handleGetRunMode() === RUN_MODE.IDLE) {
       passSetRunMode(RUN_MODE.NEED_BOOT)
@@ -253,7 +288,48 @@ export const handleSetDiskOrFileFromBuffer = (
     }
   }
 
-  return newIndex
+  return { mountedDrive: newIndex, workerOperation }
+}
+
+export const handleSetDiskOrFileFromBuffer = (
+  index: number,
+  buffer: ArrayBuffer,
+  filename: string,
+  cloudData: CloudData | null,
+  writableFileHandle: WritableFileHandle | null,
+  helpFile?: string,
+  preserveDriveIndex = false) => {
+  return setDiskOrFileFromBuffer(
+    index,
+    buffer,
+    filename,
+    cloudData,
+    writableFileHandle,
+    helpFile,
+    preserveDriveIndex,
+  ).mountedDrive
+}
+
+export const requestSetDiskOrFileFromBuffer = async (
+  index: number,
+  buffer: ArrayBuffer,
+  filename: string,
+  cloudData: CloudData | null,
+  writableFileHandle: WritableFileHandle | null,
+  helpFile?: string,
+  preserveDriveIndex = false) => {
+  const result = setDiskOrFileFromBuffer(
+    index,
+    buffer,
+    filename,
+    cloudData,
+    writableFileHandle,
+    helpFile,
+    preserveDriveIndex,
+    true,
+  )
+  await result.workerOperation
+  return result.mountedDrive
 }
 
 export const handleSetDiskFromCloudData = async (
@@ -564,9 +640,14 @@ const diskImageLocalStorageSync = (url: string, index: number) => {
   }, 3 * 1000)
 }
 
-export const handleSetDiskFromURL = async (url: string,
+const setDiskFromURL = async (url: string,
   updateDisplay?: UpdateDisplay, index = 0, cloudData?: CloudData, callback?: (buffer: ArrayBuffer | null) => void,
-  debug?: (message: string) => void, preserveDriveIndex = false): Promise<boolean> => {
+  debug?: (message: string) => void, preserveDriveIndex = false, confirmed = false): Promise<boolean> => {
+  const installDisk = (...args: Parameters<typeof handleSetDiskOrFileFromBuffer>) => {
+    return confirmed
+      ? requestSetDiskOrFileFromBuffer(...args)
+      : Promise.resolve(handleSetDiskOrFileFromBuffer(...args))
+  }
   debug?.(`handleSetDiskFromURL(${url}) drive=${index}`)
   let helpFile = findCatalogHelpFile(url)
   // Check if it's a local file (not http/https URL and not Internet Archive)
@@ -579,13 +660,13 @@ export const handleSetDiskFromURL = async (url: string,
         const state = getDiskImageFromLocalStorage()
         if (state) {
           resetAllDiskDrives()
-          index = handleSetDiskOrFileFromBuffer(state.index, state.data.buffer, url, null, null, helpFile)
+          index = await installDisk(state.index, state.data.buffer, url, null, null, helpFile)
         } else {
           const response = await fetch(url)
           const buffer = await response.arrayBuffer()
           const fileName = url.split("/").pop() || url        
           resetAllDiskDrives()
-          index = handleSetDiskOrFileFromBuffer(
+          index = await installDisk(
             index,
             buffer,
             fileName,
@@ -841,7 +922,7 @@ export const handleSetDiskFromURL = async (url: string,
           resetAllDiskDrives()
         }
         
-        handleSetDiskOrFileFromBuffer(
+        await installDisk(
           index,
           buffer,
           name,
@@ -877,6 +958,18 @@ export const handleSetDiskFromURL = async (url: string,
       showGlobalProgressModal(false)
     }
   }
+}
+
+export const handleSetDiskFromURL = async (url: string,
+  updateDisplay?: UpdateDisplay, index = 0, cloudData?: CloudData, callback?: (buffer: ArrayBuffer | null) => void,
+  debug?: (message: string) => void, preserveDriveIndex = false): Promise<boolean> => {
+  return setDiskFromURL(url, updateDisplay, index, cloudData, callback, debug, preserveDriveIndex)
+}
+
+export const requestSetDiskFromURL = async (url: string,
+  updateDisplay?: UpdateDisplay, index = 0, cloudData?: CloudData, callback?: (buffer: ArrayBuffer | null) => void,
+  debug?: (message: string) => void, preserveDriveIndex = false): Promise<boolean> => {
+  return setDiskFromURL(url, updateDisplay, index, cloudData, callback, debug, preserveDriveIndex, true)
 }
 
 export const prepWritableFile = async (index: number, writableFileHandle: WritableFileHandle) => {

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -3,6 +3,7 @@ import {
   doOnMessage,
   requestLoadBinary,
   requestKeyboardState,
+  requestSetDriveNewData,
   requestSetState6502,
   requestSetRunMode,
   requestSpeedMode,
@@ -131,5 +132,31 @@ describe("worker operations", () => {
 
     sendOperationResult(message.operationId)
     await expect(operation).resolves.toBeUndefined()
+  })
+
+  test("sends drive data as a confirmed worker operation", async () => {
+    const props = {index: 2, filename: "test.woz"} as DriveProps
+    let resolved = false
+    const operation = requestSetDriveNewData(props).then(() => {
+      resolved = true
+    })
+    const message = worker.postMessage.mock.calls.at(-1)[0]
+    expect(message).toEqual(expect.objectContaining({
+      msg: MSG_MAIN.DRIVE_NEW_DATA,
+      payload: props,
+    }))
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    sendOperationResult(message.operationId)
+    await expect(operation).resolves.toBeUndefined()
+  })
+
+  test("reports a rejected drive operation", async () => {
+    const operation = requestSetDriveNewData({index: 2, filename: "bad.woz"} as DriveProps)
+
+    sendOperationResult(lastOperationId(), "Invalid disk image")
+
+    await expect(operation).rejects.toThrow("Invalid disk image")
   })
 })

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -335,6 +335,14 @@ export const passSetDriveNewData = (props: DriveProps, forceIndex = false) => {
   doPostMessage(MSG_MAIN.DRIVE_NEW_DATA, forceIndex ? { props, forceIndex } : props)
 }
 
+export const requestSetDriveNewData = (props: DriveProps, forceIndex = false, timeoutMs = 5000) => {
+  return requestWorkerOperation(
+    MSG_MAIN.DRIVE_NEW_DATA,
+    forceIndex ? { props, forceIndex } : props,
+    timeoutMs,
+  )
+}
+
 export const passSetDriveProps = (props: DriveProps) => {
   doPostMessage(MSG_MAIN.DRIVE_PROPS, props)
 }

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -433,9 +433,13 @@ export const doOnMessage = (e: MessageEvent): {speed: number, helptext: string} 
       clickSpeaker(e.data.payload as number)
       break
     case MSG_WORKER.DRIVE_PROPS: {
-      doSetUIDriveProps(e.data.payload as DriveProps)
+      const payload = e.data.payload as DriveProps | {props: DriveProps, replaceDiskData: boolean}
+      if ("props" in payload) {
+        doSetUIDriveProps(payload.props, payload.replaceDiskData)
+      } else {
+        doSetUIDriveProps(payload)
+      }
       return {speed: machineState.cpuSpeed, helptext: ""}
-      break
     }
     case MSG_WORKER.DRIVE_SOUND: {
       const sound = e.data.payload as DRIVE

--- a/src/worker/devices/drivestate.ts
+++ b/src/worker/devices/drivestate.ts
@@ -82,7 +82,24 @@ export const getFilename = () => {
 const previousProps: Array<{diskHasChanges: boolean,
   motorRunning: boolean, status: string}> = []
 
-export const passDriveData = () => {
+const getDriveProps = (index: number): DriveProps => ({
+  index,
+  hardDrive: driveState[index].hardDrive,
+  drive: driveState[index].drive,
+  filename: driveState[index].filename,
+  status: driveState[index].status,
+  motorRunning: driveState[index].motorRunning,
+  diskHasChanges: driveState[index].diskHasChanges,
+  isWriteProtected: driveState[index].isWriteProtected,
+  diskData: (driveState[index].diskHasChanges && !driveState[index].motorRunning) ?
+    driveData[index] : new Uint8Array(),
+  lastAppleWriteTime: driveState[index].lastAppleWriteTime,
+  lastLocalFileWriteTime: driveState[index].lastLocalFileWriteTime,
+  cloudData: driveState[index].cloudData,
+  writableFileHandle: driveState[index].writableFileHandle
+})
+
+export const passDriveData = (replaceDiskDataIndex = -1) => {
   for (let i = 0; i < driveState.length; i++) {
     // For empty drives, only update if one of our special properties changed.
     if (driveState[i].filename === "" &&
@@ -90,26 +107,12 @@ export const passDriveData = () => {
       previousProps[i] &&
       previousProps[i].diskHasChanges === driveState[i].diskHasChanges &&
       previousProps[i].motorRunning === driveState[i].motorRunning &&
-      previousProps[i].status === driveState[i].status) {
+      previousProps[i].status === driveState[i].status &&
+      i !== replaceDiskDataIndex) {
       continue
     }
-    const dprops: DriveProps = {
-      index: i,
-      hardDrive: driveState[i].hardDrive,
-      drive: driveState[i].drive,
-      filename: driveState[i].filename,
-      status: driveState[i].status,
-      motorRunning: driveState[i].motorRunning,
-      diskHasChanges: driveState[i].diskHasChanges,
-      isWriteProtected: driveState[i].isWriteProtected,
-      diskData: (driveState[i].diskHasChanges && !driveState[i].motorRunning) ?
-        driveData[i] : new Uint8Array(),
-      lastAppleWriteTime: driveState[i].lastAppleWriteTime,
-      lastLocalFileWriteTime: driveState[i].lastLocalFileWriteTime,
-      cloudData: driveState[i].cloudData,
-      writableFileHandle: driveState[i].writableFileHandle
-    }
-    passDriveProps(dprops)
+    const dprops = getDriveProps(i)
+    passDriveProps(dprops, i === replaceDiskDataIndex)
     previousProps[i] = {diskHasChanges: dprops.diskHasChanges,
       motorRunning: dprops.motorRunning,
       status: dprops.status}
@@ -185,6 +188,7 @@ export const doPauseDrive = (resume = false) => {
 
 // Send in a new disk image to be loaded into the emulator.
 export const doSetEmuDriveNewData = (props: DriveProps, forceIndex: boolean = false) => {
+  const hasRequestedMedia = props.filename !== "" || props.diskData.length !== 0
   let index = props.index
   let drive = props.drive
   
@@ -218,8 +222,8 @@ export const doSetEmuDriveNewData = (props: DriveProps, forceIndex: boolean = fa
   driveData[index] = decodeDiskData(driveState[index], props.diskData, treatProdosAsFloppy)
   if (driveData[index].length === 0) {
     driveState[index].filename = ""
-    passDriveData()
-    return
+    passDriveData(index)
+    return !hasRequestedMedia
   }
   if (isHardDrive) {
     enableHardDrive(true)
@@ -229,6 +233,7 @@ export const doSetEmuDriveNewData = (props: DriveProps, forceIndex: boolean = fa
   driveState[index].writableFileHandle = props.writableFileHandle
   driveState[index].lastLocalFileWriteTime = props.lastLocalFileWriteTime
   passDriveData()
+  return true
 }
 
 // Set properties on the current disk, without changing the data.

--- a/src/worker/devices/drivestate_save.test.ts
+++ b/src/worker/devices/drivestate_save.test.ts
@@ -3,6 +3,7 @@ import { doSetEmuDriveNewData, getDriveSaveState, getHardDriveData, getHardDrive
   restoreDriveSaveState } from "./drivestate"
 import { doGetSaveState, doRestoreSaveState } from "../save_restore"
 import { setIsTesting } from "../worker2main"
+import * as workerMessages from "../worker2main"
 
 const largeDiskSize = 32_000_000
 
@@ -34,6 +35,72 @@ const mountHardDrive = (diskData: Uint8Array, filename = "large-disk.hdv") => {
 beforeAll(() => setIsTesting())
 beforeEach(() => restoreDriveSaveState(emptyDriveSaveState()))
 afterEach(() => jest.restoreAllMocks())
+
+test("rejects invalid non-empty media and forces the empty canonical drive to the UI", () => {
+  const passDriveProps = jest.spyOn(workerMessages, "passDriveProps")
+  const result = doSetEmuDriveNewData({
+    index: 2,
+    hardDrive: false,
+    drive: 1,
+    filename: "invalid.woz",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData: new Uint8Array([1, 2, 3]),
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0,
+  })
+
+  expect(result).toBe(false)
+  expect(passDriveProps).toHaveBeenCalledWith(expect.objectContaining({
+    index: 2,
+    filename: "",
+    diskData: new Uint8Array(),
+  }), true)
+})
+
+test("accepts valid media at a forced drive index", () => {
+  const result = doSetEmuDriveNewData({
+    index: 3,
+    hardDrive: true,
+    drive: 2,
+    filename: "valid.hdv",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData: new Uint8Array(16_384),
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0,
+  }, true)
+
+  expect(result).toBe(true)
+})
+
+test("accepts an empty drive as an eject operation", () => {
+  const result = doSetEmuDriveNewData({
+    index: 2,
+    hardDrive: false,
+    drive: 1,
+    filename: "",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData: new Uint8Array(),
+    lastAppleWriteTime: -1,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: -1,
+  })
+
+  expect(result).toBe(true)
+})
 
 test("a time-travel snapshot omits large-disk data without losing the disk on restore", () => {
   const diskData = new Uint8Array(largeDiskSize)

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -71,8 +71,8 @@ export const passClickSpeaker = (cycleCount: number) => {
   doPostMessage(MSG_WORKER.CLICK, cycleCount)
 }
 
-export const passDriveProps = (props: DriveProps) => {
-  doPostMessage(MSG_WORKER.DRIVE_PROPS, props)
+export const passDriveProps = (props: DriveProps, replaceDiskData = false) => {
+  doPostMessage(MSG_WORKER.DRIVE_PROPS, replaceDiskData ? {props, replaceDiskData} : props)
 }
 
 export const passDriveSound = (sound: DRIVE) => {
@@ -239,12 +239,13 @@ if (typeof self !== "undefined") {
       case MSG_MAIN.DRIVE_NEW_DATA: {
         const payload = e.data.payload as DriveProps | { props: DriveProps, forceIndex: boolean }
         try {
-          if ("props" in payload) {
-            doSetEmuDriveNewData(payload.props, payload.forceIndex)
-          } else {
-            doSetEmuDriveNewData(payload)
+          const accepted = "props" in payload
+            ? doSetEmuDriveNewData(payload.props, payload.forceIndex)
+            : doSetEmuDriveNewData(payload)
+          if (e.data.operationId !== undefined) {
+            if (!accepted) throw new Error("Worker rejected disk image")
+            passWorkerOperationResult(e.data.operationId)
           }
-          if (e.data.operationId !== undefined) passWorkerOperationResult(e.data.operationId)
         } catch (error) {
           if (e.data.operationId === undefined) throw error
           passWorkerOperationResult(

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -238,10 +238,19 @@ if (typeof self !== "undefined") {
       }
       case MSG_MAIN.DRIVE_NEW_DATA: {
         const payload = e.data.payload as DriveProps | { props: DriveProps, forceIndex: boolean }
-        if ("props" in payload) {
-          doSetEmuDriveNewData(payload.props, payload.forceIndex)
-        } else {
-          doSetEmuDriveNewData(payload)
+        try {
+          if ("props" in payload) {
+            doSetEmuDriveNewData(payload.props, payload.forceIndex)
+          } else {
+            doSetEmuDriveNewData(payload)
+          }
+          if (e.data.operationId !== undefined) passWorkerOperationResult(e.data.operationId)
+        } catch (error) {
+          if (e.data.operationId === undefined) throw error
+          passWorkerOperationResult(
+            e.data.operationId,
+            error instanceof Error ? error.message : String(error),
+          )
         }
         break
       }


### PR DESCRIPTION
## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per #218. This is the Apple2TS half of disk-media control; a companion Apple2TS Server change will expose it through MCP.

## Motivation

The GUI loading path is designed for interactive use: it queues worker changes and may infer how a file should be handled. Remote commands need a definite result for the exact operation requested.

## What was implemented in this slice

- Mount and eject commands wait for the emulator worker and return the resulting drive state.
- Mount uses the requested drive and rejects invalid disk media or program files.
- URL mounts request a boot after confirmation. Direct mounts leave execution control to the caller.
- Confirmed operations apply to remote calls without changing the desktop interface’s loading path.
