### PR TITLE
fix(cpu): stack interrupt-specific break flags

### DIFF
--- a/src/worker/instructions.test.ts
+++ b/src/worker/instructions.test.ts
@@ -590,6 +590,23 @@ test("NMI with RTI",   () => {
   runAssemblyTest(nmi_rti.split("\n"), 0x34, 0)
 })
 
+test("BRK followed by NMI stacks source-specific break flags", () => {
+  memory[ROMmemoryStart + 0x3FFE] = 0x00
+  memory[ROMmemoryStart + 0x3FFF] = 0x30
+  memory[ROMmemoryStart + 0x3FFA] = 0x00
+  memory[ROMmemoryStart + 0x3FFB] = 0x40
+  reset6502()
+  updateAddressTables()
+  memory[0x2000] = 0x00
+  setPC(0x2000)
+  s6502.flagNMI = true
+
+  processInstruction()
+
+  expect(memory[0x1FD] & B).toEqual(B)
+  expect(memory[0x1FA] & B).toEqual(0)
+})
+
 const crossPageTest = (start: number, cyclesExpect: number) => {
   reset6502()
   const pcode = parseAssembly(start,

--- a/src/worker/instructions.ts
+++ b/src/worker/instructions.ts
@@ -363,6 +363,7 @@ const doInterrupt = (name: string, addr: number, pcOffset = 0) => {
   const vHi = memGet(addr + 1)
   pushStack(`${name} $` + toHex(vHi) + toHex(vLo), Math.trunc(PCreturn / 256))
   pushStack(name, PCreturn % 256)
+  setBreak(name === "BRK")
   pushStack("P", s6502.PStatus)
   setDecimal(false)  // 65c02 only
   setInterruptDisabled()


### PR DESCRIPTION
On a real 6502, the Break bit in the saved status byte identifies how interrupt entry began: BRK stacks it set, while IRQ and NMI stack it clear.

Apple2TS stores Break in its live processor status, so an NMI following BRK could inherit the stale value and leave a stack frame falsely claiming it came from BRK.

Set Break from the current interrupt source immediately before stacking the status. Add a regression test covering BRK followed by NMI.

This fixes one of the Klaus interrupt-test failures identified in #370.
