### PR TITLE
fix(cpu): preserve decimal mode on NMOS interrupts

### DIFF
--- a/src/worker/instructions.test.ts
+++ b/src/worker/instructions.test.ts
@@ -1,6 +1,6 @@
 import { ROMmemoryStart, toHex } from "../common/utility"
 import { interruptRequest, nonMaskableInterrupt, processInstruction } from "./cpu6502"
-import { memory, updateAddressTables } from "./memory"
+import { doSetRom, memory, updateAddressTables } from "./memory"
 import { reset6502, doBranch, s6502, setPC, setInterruptDisabled, setCycleCount, incrementPC } from "./instructions"
 import { enableMockingboard } from "./devices/mockingboard"
 import { parseAssembly } from "./utility/assembler"
@@ -605,6 +605,30 @@ test("BRK followed by NMI stacks source-specific break flags", () => {
 
   expect(memory[0x1FD] & B).toEqual(B)
   expect(memory[0x1FA] & B).toEqual(0)
+})
+
+test.each([
+  ["enhanced IIe", "APPLE2EE", 0],
+  ["unenhanced IIe", "APPLE2EU", D],
+  ["Apple II+", "APPLE2P", D],
+] as const)("%s interrupt entry handles decimal mode for its CPU", (_name, machine, expected) => {
+  doSetRom(machine)
+  try {
+    reset6502()
+    updateAddressTables()
+    memory[0x2000] = 0xEA
+    memory[ROMmemoryStart + 0x3FFA] = 0x00
+    memory[ROMmemoryStart + 0x3FFB] = 0x30
+    setPC(0x2000)
+    s6502.PStatus |= D
+    nonMaskableInterrupt()
+
+    processInstruction()
+
+    expect(s6502.PStatus & D).toEqual(expected)
+  } finally {
+    doSetRom("APPLE2EE")
+  }
 })
 
 const crossPageTest = (start: number, cyclesExpect: number) => {

--- a/src/worker/instructions.ts
+++ b/src/worker/instructions.ts
@@ -1,5 +1,5 @@
 import { toHex, ADDR_MODE, default6502State } from "../common/utility"
-import { getDataBlock, memGet, memSet } from "./memory"
+import { getCurrentMachineName, getDataBlock, memGet, memSet } from "./memory"
 import { pass6502Instructions } from "./worker2main"
 // var startTime = performance.now()
 
@@ -365,7 +365,7 @@ const doInterrupt = (name: string, addr: number, pcOffset = 0) => {
   pushStack(name, PCreturn % 256)
   setBreak(name === "BRK")
   pushStack("P", s6502.PStatus)
-  setDecimal(false)  // 65c02 only
+  if (getCurrentMachineName() === "APPLE2EE") setDecimal(false)
   setInterruptDisabled()
   // Since we're in the middle of the BRK, set our new program counter to
   // be one less than our vector address. Don't do this for IRQ and NMI.


### PR DESCRIPTION
Interrupt entry cleared decimal mode unconditionally, even though the existing comment identified that behavior as 65C02-only. This was correct when Apple2TS modeled only the enhanced IIe, but not after adding the NMOS-based unenhanced IIe and Apple II+ modes.

Clear decimal mode during interrupt entry only for the enhanced IIe's 65C02. Preserve it for the unenhanced IIe and Apple II+, and test all three machine profiles.

This fixes the NMOS decimal-mode failure identified by the Klaus interrupt testing in #370.
