### PR TITLE
Fix: Google Drive security warning

### DIFF
--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -455,6 +455,15 @@ body.dark-mode .divider {
   align-items: center;
 }
 
+/* Google Picker defaults to z-index 1000, below the retro control panel. */
+.picker-dialog-bg {
+  z-index: 10030 !important;
+}
+
+.picker-dialog {
+  z-index: 10031 !important;
+}
+
 .global-progress-spinner {
   width: 25%;
   height: 25%;

--- a/src/ui/api/messagelistener.ts
+++ b/src/ui/api/messagelistener.ts
@@ -20,7 +20,10 @@ export const messagelistener = (event: MessageEvent) => {
   )
   
   if (!isTrusted) {
-    console.warn("Received message from untrusted origin:", event.origin)
+    const externalSdkOrigins = ["https://accounts.google.com", "https://docs.google.com"]
+    if (!externalSdkOrigins.includes(event.origin)) {
+      console.warn("Received message from untrusted origin:", event.origin)
+    }
     return
   }
 

--- a/src/ui/devices/disk/googledrive.test.ts
+++ b/src/ui/devices/disk/googledrive.test.ts
@@ -77,7 +77,7 @@ describe("Google Drive REST provider", () => {
 
     expect(mockInitTokenClient).toHaveBeenCalledWith(expect.objectContaining({
       client_id: "app-id-client-id.apps.googleusercontent.com",
-      scope: "https://www.googleapis.com/auth/drive",
+      scope: "https://www.googleapis.com/auth/drive.file",
     }))
     expect(mockRequestAccessToken).toHaveBeenCalledWith({ prompt: "consent" })
     const firstUrl = new URL(fetchMock.mock.calls[0][0] as string)

--- a/src/ui/devices/disk/googledrive.ts
+++ b/src/ui/devices/disk/googledrive.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SYNC_INTERVAL = 1 * 60 * 1000
 let g_accessToken: string = ""
 let g_pickerInited = false
 
-const driveScope = "https://www.googleapis.com/auth/drive"
+const driveScope = "https://www.googleapis.com/auth/drive.file"
 
 type GoogleDriveFile = {
   id?: string

--- a/src/ui/devices/disk/googledrive_retro.test.ts
+++ b/src/ui/devices/disk/googledrive_retro.test.ts
@@ -1,0 +1,43 @@
+const mockLoadDiskFromCloudDrive = jest.fn()
+
+jest.mock("./diskdrive", () => ({
+  loadDiskFromCloudDrive: (...args: unknown[]) => mockLoadDiskFromCloudDrive(...args),
+}))
+jest.mock("./googledrive", () => ({ GoogleDrive: jest.fn() }))
+
+import { ControlRegistry } from "../../controls/controlregistry"
+import { createControlContext } from "../../retro/retromenucontext"
+import { GoogleDrive } from "./googledrive"
+import { createRetroGoogleDriveControl } from "./googledrive_retro"
+
+describe("retro Google Drive control", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test("loads through Google Picker and closes after success", async () => {
+    mockLoadDiskFromCloudDrive.mockResolvedValue(true)
+    const context = createControlContext(undefined, key => key, "en", () => undefined)
+    context.close = jest.fn()
+    const metadata = createRetroGoogleDriveControl(2)
+    metadata.parentId = null
+    const control = new ControlRegistry([metadata]).resolve(context)[0]
+
+    await control.action?.()
+
+    expect(GoogleDrive).toHaveBeenCalledWith()
+    expect(mockLoadDiskFromCloudDrive).toHaveBeenCalledWith(expect.any(GoogleDrive), 2)
+    expect(context.close).toHaveBeenCalled()
+  })
+
+  test("keeps the menu open when selection is cancelled", async () => {
+    mockLoadDiskFromCloudDrive.mockResolvedValue(false)
+    const context = createControlContext(undefined, key => key, "en", () => undefined)
+    context.close = jest.fn()
+    const metadata = createRetroGoogleDriveControl(0)
+    metadata.parentId = null
+    const control = new ControlRegistry([metadata]).resolve(context)[0]
+
+    await control.action?.()
+
+    expect(context.close).not.toHaveBeenCalled()
+  })
+})

--- a/src/ui/devices/disk/googledrive_retro.ts
+++ b/src/ui/devices/disk/googledrive_retro.ts
@@ -1,19 +1,12 @@
 import type { RetroControlMetadata } from "../../retro/retromenucontext"
-import { createRetroCloudDriveControl } from "./clouddrive_retro"
 import { loadDiskFromCloudDrive } from "./diskdrive"
 import { GoogleDrive } from "./googledrive"
 
-export const createRetroGoogleDriveControl = (driveIndex: number): RetroControlMetadata => {
-  const googleDrive = new GoogleDrive()
-  const control = createRetroCloudDriveControl(driveIndex, {
+export const createRetroGoogleDriveControl = (driveIndex: number): RetroControlMetadata => ({
     id: `diskDrives.${driveIndex}.load.googleDrive`,
-    displayName: "Google Drive",
-    loadLabelKey: "disk.loadDiskFromGoogleDrive",
-    hasAuthToken: () => googleDrive.hasAuthToken(),
-    signIn: () => googleDrive.signIn(),
-    listFolder: folderId => googleDrive.listFolder(folderId),
-    loadFile: (item, targetDriveIndex) =>
-      loadDiskFromCloudDrive(new GoogleDrive(item), targetDriveIndex),
+    label: context => context.t("disk.loadDiskFromGoogleDrive"),
+    actionLabel: context => context.t("retroControl.load"),
+    action: async context => {
+      if (await loadDiskFromCloudDrive(new GoogleDrive(), driveIndex)) context.close()
+    },
   })
-  return control
-}


### PR DESCRIPTION
# Changes:
- Restored previous 'drive.file' scope to avoid Google Drive security warning
- Updated Google Drive control panel to use UI picker to browse for disks

# Verification:
- Verified Google Drive UI and control panel no longer show security warning dialog
- Tested on multiple platforms (Windows, Mac OS) and browsers (Edge, Chrome)