### PR TITLE
fix(cpu): correct NMOS decimal-mode behavior

### DIFF
--- a/src/worker/instructions.test.ts
+++ b/src/worker/instructions.test.ts
@@ -243,6 +243,18 @@ test.each([
     doSetRom("APPLE2EE")
   }
 })
+test.each([
+  ["enhanced IIe", "APPLE2EE", 0x8F],
+  ["unenhanced IIe", "APPLE2EU", 0x9F],
+  ["Apple II+", "APPLE2P", 0x9F],
+] as const)("%s decimal SBC handles invalid low digits", (_name, machine, expected) => {
+  doSetRom(machine)
+  try {
+    runAssemblyTest([" SED", " SEC", " LDA #$00", " SBC #$0B"], expected, N | D)
+  } finally {
+    doSetRom("APPLE2EE")
+  }
+})
 test("SED SBC 99", () => runAssemblyTest(doSED_SBC(0x99), 0x99, N | C | D))
 test("SED SBC BD", () => runAssemblyTest(doSED_SBC(0xBD), 0xBD, N | C | D))
 test("SED SBC FF", () => runAssemblyTest(doSED_SBC(0xFF), 0xFF, N | C | D))

--- a/src/worker/instructions.test.ts
+++ b/src/worker/instructions.test.ts
@@ -205,6 +205,19 @@ test("SED ADC invalid low digits", () =>
 test("SED ADC invalid low digits carry into high digit", () =>
   runAssemblyTest([" SED", " SEC", " LDA #$1F", " ADC #$2A"], 0x40, D))
 
+test.each([
+  ["enhanced IIe", "APPLE2EE", Z | C | D],
+  ["unenhanced IIe", "APPLE2EU", N | C | D],
+  ["Apple II+", "APPLE2P", N | C | D],
+] as const)("%s decimal ADC sets CPU-specific N/Z flags", (_name, machine, expected) => {
+  doSetRom(machine)
+  try {
+    runAssemblyTest([" SED", " SEC", " LDA #$99", " ADC #$00"], 0x00, expected)
+  } finally {
+    doSetRom("APPLE2EE")
+  }
+})
+
 const doSED_SBC = (v1: number, v2 = 0) => {
   const instr = [
     " SED",
@@ -218,6 +231,18 @@ test("SED SBC 1", () => runAssemblyTest(doSED_SBC(1), 0x01, C | D))
 test("SED SBC 9", () => runAssemblyTest(doSED_SBC(9), 0x09, C | D))
 test("SED SBC 10", () => runAssemblyTest(doSED_SBC(0x10), 0x10, C | D))
 test("SED SBC 1D", () => runAssemblyTest(doSED_SBC(0x1D), 0x1D, C | D))
+test.each([
+  ["enhanced IIe", "APPLE2EE", V | D],
+  ["unenhanced IIe", "APPLE2EU", N | V | D],
+  ["Apple II+", "APPLE2P", N | V | D],
+] as const)("%s decimal SBC sets CPU-specific N/Z flags", (_name, machine, expected) => {
+  doSetRom(machine)
+  try {
+    runAssemblyTest(doSED_SBC(0, 0x80), 0x20, expected)
+  } finally {
+    doSetRom("APPLE2EE")
+  }
+})
 test("SED SBC 99", () => runAssemblyTest(doSED_SBC(0x99), 0x99, N | C | D))
 test("SED SBC BD", () => runAssemblyTest(doSED_SBC(0xBD), 0xBD, N | C | D))
 test("SED SBC FF", () => runAssemblyTest(doSED_SBC(0xFF), 0xFF, N | C | D))

--- a/src/worker/instructions.ts
+++ b/src/worker/instructions.ts
@@ -232,7 +232,9 @@ const doIndirectInstruction = (vZP: number,
 
 // 300: F8 18 B8 A9 BD 69 00 D8 00
 const doADC_BCD = (value: number) => {
-  let ones = (s6502.Accum & 0x0F) + (value & 0x0F) + (isCarry() ? 1 : 0)
+  const carryIn = isCarry() ? 1 : 0
+  const binarySum = (s6502.Accum + value + carryIn) & 0xFF
+  let ones = (s6502.Accum & 0x0F) + (value & 0x0F) + carryIn
   let onesCarry = 0
   // Handle illegal BCD hex values by wrapping to "tens" digit
   if (ones >= 0xA) {
@@ -242,6 +244,7 @@ const doADC_BCD = (value: number) => {
 
   const tens = (s6502.Accum & 0xF0) + (value & 0xF0) + onesCarry
   let tmp = tens + ones
+  const preHighAdjustSum = tmp
   // Pretend we're doing normal addition to set overflow flag
   const bothPositive = (s6502.Accum <= 127 && value <= 127)
   const bothNegative = (s6502.Accum >= 128 && value >= 128)
@@ -252,9 +255,13 @@ const doADC_BCD = (value: number) => {
     tmp += 0x60
   }
   s6502.Accum = tmp & 0xFF
-  // Assume we're a 65c02 and set the zero flag properly.
-  // This doesn't happen on a 6502 for BCD mode.
-  checkStatus(s6502.Accum)
+  if (getCurrentMachineName() === "APPLE2EE") {
+    checkStatus(s6502.Accum)
+  } else {
+    // NMOS ADC sets Z from the binary sum and N after low-digit correction.
+    setZero(binarySum === 0)
+    setNegative((preHighAdjustSum & 0x80) !== 0)
+  }
 }
 
 const doADC_HEX = (value: number) => {
@@ -650,6 +657,7 @@ const doSBC_BCD = (value: number) => {
   // On 65c02, do normal hex subtraction to set the carry & overflow flags.
   const vtmp = 255 - value
   let tmp = s6502.Accum + vtmp + (isCarry() ? 1 : 0)
+  const binaryResult = tmp & 0xFF
   const newCarry = (tmp >= 256)
   const bothPositive = (s6502.Accum <= 127 && vtmp <= 127)
   const bothNegative = (s6502.Accum >= 128 && vtmp >= 128)
@@ -664,9 +672,8 @@ const doSBC_BCD = (value: number) => {
     tmp -= 0x06
   }
   s6502.Accum = tmp & 0xFF
-  // Assume we're a 65c02 and set the zero flag properly.
-  // This doesn't happen on a 6502 for BCD mode.
-  checkStatus(s6502.Accum)
+  // 65C02 sets N/Z from the decimal result; NMOS uses the binary result.
+  checkStatus(getCurrentMachineName() === "APPLE2EE" ? s6502.Accum : binaryResult)
   setCarry(newCarry)
 }
 

--- a/src/worker/instructions.ts
+++ b/src/worker/instructions.ts
@@ -655,25 +655,33 @@ PCODE("RTS", ADDR_MODE.IMPLIED, 0x60, 1, () => {setPC(address(popStack(), popSta
 // 300: F8 38 B8 A9 00 E9 00 D8 00
 const doSBC_BCD = (value: number) => {
   // On 65c02, do normal hex subtraction to set the carry & overflow flags.
+  const is65C02 = getCurrentMachineName() === "APPLE2EE"
+  const borrowIn = isCarry() ? 0 : 1
   const vtmp = 255 - value
-  let tmp = s6502.Accum + vtmp + (isCarry() ? 1 : 0)
+  let tmp = s6502.Accum + vtmp + (1 - borrowIn)
   const binaryResult = tmp & 0xFF
   const newCarry = (tmp >= 256)
   const bothPositive = (s6502.Accum <= 127 && vtmp <= 127)
   const bothNegative = (s6502.Accum >= 128 && vtmp >= 128)
   setOverflow((tmp % 256) >= 128 ? bothPositive : bothNegative)
 
-  const ones = (s6502.Accum & 0x0F) - (value & 0x0F) + (isCarry() ? 0 : -1)
-  tmp = s6502.Accum - value + (isCarry() ? 0 : -1)
-  if (tmp < 0) {
-    tmp -= 0x60
-  }
-  if (ones < 0) {
-    tmp -= 0x06
+  let ones = (s6502.Accum & 0x0F) - (value & 0x0F) - borrowIn
+  tmp = s6502.Accum - value - borrowIn
+  if (is65C02) {
+    if (tmp < 0) tmp -= 0x60
+    if (ones < 0) tmp -= 0x06
+  } else {
+    let tens = (s6502.Accum & 0xF0) - (value & 0xF0)
+    if (ones < 0) {
+      ones = (ones - 0x06) & 0x0F
+      tens -= 0x10
+    }
+    if (tens < 0) tens -= 0x60
+    tmp = tens + ones
   }
   s6502.Accum = tmp & 0xFF
   // 65C02 sets N/Z from the decimal result; NMOS uses the binary result.
-  checkStatus(getCurrentMachineName() === "APPLE2EE" ? s6502.Accum : binaryResult)
+  checkStatus(is65C02 ? s6502.Accum : binaryResult)
   setCarry(newCarry)
 }
 


### PR DESCRIPTION
Correct NMOS 6502 decimal behavior:

- Use the NMOS intermediate results for ADC flags and the binary subtraction result for SBC flags.
- Correct invalid-digit NMOS SBC by carrying the low-digit borrow into the high-digit correction.

All four applicable modes of the Klaus decimal test now pass: NMOS valid and all-byte values, plus 65C02 valid and all-byte values.

Related to #375.