### PR TITLE
fix(ui): restore minimal Help paper gutter

### DIFF
--- a/src/ui/panels/help/helppanel.minimal.css
+++ b/src/ui/panels/help/helppanel.minimal.css
@@ -50,12 +50,12 @@
 }
 
 .help-text-light {
-  margin-left: 0;
+  margin-left: 40px;
   margin-top: 0px;
   margin-bottom: 0px;
   padding-top: 10px;
   padding-bottom: 10px;
-  padding-left: 50px;
+  padding-left: 20px;
   border-left: 1px solid #d8e6e1;
   color: var(--text-color);
 }


### PR DESCRIPTION
Restore the original 40px binder gutter and 20px inner padding in the minimal Help paper.

The 2024 Help-paper layout used this spacing, and the minimal stylesheet initially retained it. A later unrelated edit accidentally changed the margin declaration to invalid margin-left: px; subsequent fixes made the CSS valid and compensated with padding, but left the minimal and regular Help layouts inconsistent.