### PR TITLE
fix(ui): improve dark mode panel contrast

### DIFF
--- a/src/ui/diskdialog/diskcollectionpanel.css
+++ b/src/ui/diskdialog/diskcollectionpanel.css
@@ -18,6 +18,11 @@
   overflow-y: auto;
 }
 
+body.dark-mode .disk-collection-panel {
+  outline: 1px solid var(--button-active);
+  outline-offset: -1px;
+}
+
 .dcp-tab-row {
   display: flex;
   align-items: stretch;
@@ -96,6 +101,11 @@
   width: 1.25em;
   height: 1.25em;
   vertical-align: middle;
+}
+
+body.dark-mode .dcp-tab {
+  border-color: var(--button-active);
+  color: var(--button-active);
 }
 
 .dcp-export-row {
@@ -196,6 +206,11 @@
   background-color: var(--button-active);
 }
 
+body.dark-mode .dcp-tab:hover,
+body.dark-mode .dcp-tab-active {
+  color: var(--text-color);
+}
+
 .dcp-tab-highlighted {
   animation: tabFadeInOut 3s 5;
 }
@@ -205,10 +220,12 @@
   0%,
   100% {
     background-color: #aba7a2;
+    color: var(--text-color);
   }
 
   50% {
     background-color: gray;
+    color: var(--text-color);
   }
 }
 

--- a/src/ui/panels/panels.css
+++ b/src/ui/panels/panels.css
@@ -614,6 +614,12 @@ body.dark-mode .icon-text {
   background-color: var(--background-color);
 }
 
+body.dark-mode .dbg-tab {
+  background-color: var(--background-color-dark);
+  border-color: var(--button-active);
+  color: var(--button-active);
+}
+
 .dbg-tab:hover {
   background-color: var(--button-active);
 }
@@ -621,6 +627,12 @@ body.dark-mode .icon-text {
 .dbg-tab-active {
   background-color: var(--button-active);
   border-bottom-style: none;
+}
+
+body.dark-mode .dbg-tab:hover,
+body.dark-mode .dbg-tab-active {
+  background-color: var(--button-active);
+  color: var(--text-color);
 }
 
 .dbg-tab-horizontal {


### PR DESCRIPTION
Improve dark-mode contrast for the Disk Collection and main panel tabs.

- Give inactive tabs beige outlines and icons.
- Use a beige fill with black icons for hovered and selected tabs.
- Outline the Disk Collection grid without changing its layout.

Fixes #383.
