### PR TITLE
feat(remote-control): capture the rendered screen

### DIFF
--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -65,6 +65,7 @@ import {
   requestMountDiskFromBuffer,
 } from "../devices/disk/driveprops"
 import { parseRemoteKeyboardState } from "./remotecontrol_input"
+import { captureRenderedScreen } from "./remotecontrol_screen"
 
 const CONNECT_RETRY_MS = 3000
 const HEARTBEAT_MS = 2000
@@ -403,6 +404,9 @@ export const executeCommand = async (action: string, payload: Record<string, unk
 
     case "getMemory":
       return collectMemory()
+
+    case "captureScreen":
+      return captureRenderedScreen()
 
     case "setRunMode": {
       const runMode = Number(payload.runMode) as RUN_MODE

--- a/src/ui/api/remotecontrol_screen.test.ts
+++ b/src/ui/api/remotecontrol_screen.test.ts
@@ -1,0 +1,58 @@
+import { captureRenderedScreen } from "./remotecontrol_screen"
+
+afterEach(() => {
+  document.body.replaceChildren()
+  jest.useRealTimers()
+  jest.restoreAllMocks()
+})
+
+test("captures the rendered screen after its next display refresh", async () => {
+  const callbacks: FrameRequestCallback[] = []
+  jest.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callbacks.push(callback)
+    return callbacks.length
+  })
+  jest.spyOn(performance, "now").mockReturnValue(100)
+
+  const canvas = document.createElement("canvas")
+  canvas.id = "apple2canvas"
+  canvas.width = 560
+  canvas.height = 384
+  jest.spyOn(canvas, "toDataURL").mockReturnValue("data:image/png;base64,AQID")
+  document.body.append(canvas)
+
+  const capture = captureRenderedScreen()
+  expect(canvas.toDataURL).not.toHaveBeenCalled()
+
+  callbacks.shift()?.(110)
+  callbacks.shift()?.(125)
+
+  await expect(capture).resolves.toEqual({
+    mimeType: "image/png",
+    dataBase64: "AQID",
+    width: 560,
+    height: 384,
+  })
+  expect(canvas.toDataURL).toHaveBeenCalledWith("image/png")
+})
+
+test("rejects when the rendered screen is unavailable", async () => {
+  await expect(captureRenderedScreen()).rejects.toThrow("screen is unavailable")
+})
+
+test("rejects when the rendered screen does not refresh", async () => {
+  jest.useFakeTimers()
+  const frameId = 17
+  jest.spyOn(window, "requestAnimationFrame").mockReturnValue(frameId)
+  const cancelFrame = jest.spyOn(window, "cancelAnimationFrame").mockImplementation()
+
+  const canvas = document.createElement("canvas")
+  canvas.id = "apple2canvas"
+  document.body.append(canvas)
+
+  const capture = captureRenderedScreen()
+  jest.advanceTimersByTime(1000)
+
+  await expect(capture).rejects.toThrow("screen did not refresh")
+  expect(cancelFrame).toHaveBeenCalledWith(frameId)
+})

--- a/src/ui/api/remotecontrol_screen.ts
+++ b/src/ui/api/remotecontrol_screen.ts
@@ -1,0 +1,39 @@
+const SLOWEST_RENDER_INTERVAL_MS = 1000 / 45
+const SCREEN_CAPTURE_TIMEOUT_MS = 1000
+
+const waitForDisplayRefresh = () => {
+  const requestedAt = performance.now()
+  return new Promise<void>((resolve, reject) => {
+    let frameId = 0
+    const timeoutId = window.setTimeout(() => {
+      window.cancelAnimationFrame(frameId)
+      reject(new Error("Rendered Apple II screen did not refresh"))
+    }, SCREEN_CAPTURE_TIMEOUT_MS)
+    const checkFrame = (timestamp: number) => {
+      if (timestamp - requestedAt >= SLOWEST_RENDER_INTERVAL_MS) {
+        window.clearTimeout(timeoutId)
+        resolve()
+      } else {
+        frameId = window.requestAnimationFrame(checkFrame)
+      }
+    }
+    frameId = window.requestAnimationFrame(checkFrame)
+  })
+}
+
+export const captureRenderedScreen = async () => {
+  const canvas = document.getElementById("apple2canvas") as HTMLCanvasElement | null
+  if (!canvas) throw new Error("Rendered Apple II screen is unavailable")
+  await waitForDisplayRefresh()
+
+  const dataUrl = canvas.toDataURL("image/png")
+  const prefix = "data:image/png;base64,"
+  if (!dataUrl.startsWith(prefix)) throw new Error("Rendered Apple II screen is not a PNG")
+
+  return {
+    mimeType: "image/png",
+    dataBase64: dataUrl.slice(prefix.length),
+    width: canvas.width,
+    height: canvas.height,
+  }
+}


### PR DESCRIPTION
## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per issue #218. This slice lets a remote controller capture the emulator's rendered screen.

## What was implemented in this slice

- Added a remote-control command that waits for the next rendered frame and returns the main canvas as a PNG.
- Added bounded errors for a missing canvas or a render that does not complete.
- Added coverage for successful capture and both error paths.

A companion Apple2TS Server change will expose the captured image through MCP.
