### PR TITLE
fix(joystick): apply Sirius Joyport setting live

### DIFF
--- a/src/ui/localstorage.ts
+++ b/src/ui/localstorage.ts
@@ -110,6 +110,7 @@ export const setPreferenceBoolean = (
     localStorage.removeItem(key)
   }
   setUIStateBoolean(key as BooleanKeyOf<UIState>, value)
+  if (key === "siriusJoyport") passSiriusJoyport(value)
   const controlId = booleanControlIds[key]
   if (controlId) notifySettingsChanged([controlId], origin)
 }

--- a/src/ui/localstorage_retro.test.ts
+++ b/src/ui/localstorage_retro.test.ts
@@ -1,4 +1,6 @@
-jest.mock("./main2worker", () => ({}))
+const passSiriusJoyport = jest.fn()
+
+jest.mock("./main2worker", () => ({ passSiriusJoyport }))
 jest.mock("./ui_settings", () => ({
   getTheme: jest.fn(),
   setTheme: jest.fn(),
@@ -66,6 +68,12 @@ describe("theme preferences", () => {
 })
 
 describe("settings change events", () => {
+  test.each([true, false])("applies Sirius Joyport setting %s live", enabled => {
+    setPreferenceBoolean("siriusJoyport", enabled)
+
+    expect(passSiriusJoyport).toHaveBeenCalledWith(enabled)
+  })
+
   test("identifies the visible control changed by the standard UI", () => {
     const listener = jest.fn<void, [Event]>()
     window.addEventListener(SETTINGS_CHANGED_EVENT, listener)

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -3,17 +3,90 @@ import { getHires, memGet, memory, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
-import { doBoot, doLoadBinary, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSpeedMode, doSetState6502, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
+import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
 import { getCurrentDriveState } from "./devices/drivestate"
 import * as worker2main from "./worker2main"
+import { getSiriusJoyport } from "./devices/sirius_joyport"
 
 // Make sure we don't accidentally leave debug mode on.
 test("debugMode", () => {
   expect(TEST_DEBUG).toEqual(false)
   expect(TEST_GRAPHICS).toEqual(false)
+})
+
+describe("Sirius reset", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    setIsTesting()
+    doSetCycleCount(0)
+    doSetSiriusJoyport(true)
+    doReset()
+  })
+
+  afterEach(() => {
+    doSetSiriusJoyport(false)
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test("a live disable cancels delayed re-enable", () => {
+    expect(getSiriusJoyport()).toBe(false)
+
+    doSetSiriusJoyport(false)
+
+    expect(getSiriusJoyport()).toBe(false)
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  test("a live enable waits for reset protection", () => {
+    doSetSiriusJoyport(true)
+    expect(getSiriusJoyport()).toBe(false)
+    expect(jest.getTimerCount()).toBe(1)
+
+    doSetCycleCount(1001)
+    jest.advanceTimersByTime(50)
+    expect(getSiriusJoyport()).toBe(true)
+  })
+
+  test("enabling after a disabled reset waits for reset protection", () => {
+    doSetSiriusJoyport(false)
+    doReset()
+
+    doSetSiriusJoyport(true)
+
+    expect(getSiriusJoyport()).toBe(false)
+    expect(jest.getTimerCount()).toBe(1)
+  })
+
+  test("disabling and re-enabling does not bypass reset protection", () => {
+    doSetSiriusJoyport(false)
+    doSetSiriusJoyport(true)
+
+    expect(getSiriusJoyport()).toBe(false)
+    expect(jest.getTimerCount()).toBe(1)
+  })
+
+  test("restores an unchanged setting after startup", () => {
+    doSetCycleCount(1001)
+    jest.advanceTimersByTime(50)
+
+    expect(getSiriusJoyport()).toBe(true)
+  })
+
+  test("a second reset restarts delayed re-enable", () => {
+    doSetCycleCount(999)
+    doReset()
+    doSetCycleCount(1001)
+    jest.advanceTimersByTime(50)
+    expect(getSiriusJoyport()).toBe(false)
+
+    doSetCycleCount(2000)
+    jest.advanceTimersByTime(50)
+    expect(getSiriusJoyport()).toBe(true)
+  })
 })
 
 test("run binary resets hardware before loading and starting the program", () => {

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -41,7 +41,7 @@ import { enableHardDrive } from "./devices/harddrivedata"
 import { parseAssembly } from "./utility/assembler"
 import { code } from "../common/assemblycode"
 import { clearTracelog, getTracelog, updateTrace } from "./tracelog"
-import { getSiriusJoyport, setSiriusJoyport } from "./devices/sirius_joyport"
+import { setSiriusJoyport } from "./devices/sirius_joyport"
 import { doSnapshot, fixSaveStates, getGoBackwardIndex, getGoForwardIndex, getTempStateIndex, getTimeTravelThumbnails } from "./save_restore"
 import { SoftCard } from "./devices/softcard"
 import { setSlotIOCallback } from "./memory"
@@ -62,11 +62,44 @@ let machineName: MACHINE_NAME = "APPLE2EE"
 let veraSlot: VERA_SLOT = 0
 let takeSnapshot = false
 let gameSetupTimerID: NodeJS.Timeout | number = 0
+let siriusJoyportMode = false
+let siriusJoyportResetCycle: number | null = null
+let siriusJoyportResetTimerID: NodeJS.Timeout | number = 0
 let tracing = TEST_DEBUG
 let speedTracker: Array<{time: number, cycles: number}> = []
 
 export const resetCpuSpeedForTesting = () => {
   cpuSpeed = 0
+}
+
+const startSiriusJoyportResetTimer = () => {
+  if (siriusJoyportResetTimerID) return
+  const resetTimerID: NodeJS.Timeout | number = setInterval(() => {
+    if (resetTimerID !== siriusJoyportResetTimerID) return
+    if (siriusJoyportResetCycle !== null
+      && (s6502.cycleCount - siriusJoyportResetCycle) > 1000) {
+      setSiriusJoyport(siriusJoyportMode)
+      clearInterval(resetTimerID)
+      siriusJoyportResetCycle = null
+      siriusJoyportResetTimerID = 0
+    }
+  }, 50)
+  siriusJoyportResetTimerID = resetTimerID
+}
+
+export const doSetSiriusJoyport = (mode: boolean) => {
+  siriusJoyportMode = mode
+  clearInterval(siriusJoyportResetTimerID)
+  siriusJoyportResetTimerID = 0
+  setSiriusJoyport(false)
+  if (!mode) return
+  if (siriusJoyportResetCycle !== null
+    && (s6502.cycleCount - siriusJoyportResetCycle) <= 1000) {
+    startSiriusJoyportResetTimer()
+    return
+  }
+  siriusJoyportResetCycle = null
+  setSiriusJoyport(true)
 }
 
 export const setTracing = (doTracing: boolean) => {
@@ -318,15 +351,12 @@ export const doReset = () => {
   resetMachine()
   // Force the help text panel back to default on reset/reboot paths.
   handleGameSetup(true)
-  if (getSiriusJoyport()) {
-    setSiriusJoyport(false)
-    const currentCycle = s6502.cycleCount
-    const intervalId = setInterval(() => {
-      if ((s6502.cycleCount - currentCycle) > 1000) {
-        setSiriusJoyport(true)
-        clearInterval(intervalId)
-      }
-    }, 50)
+  clearInterval(siriusJoyportResetTimerID)
+  siriusJoyportResetTimerID = 0
+  siriusJoyportResetCycle = s6502.cycleCount
+  setSiriusJoyport(false)
+  if (siriusJoyportMode) {
+    startSiriusJoyportResetTimer()
   }
 }
 

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -9,6 +9,7 @@ import { doSetRunMode, doSetSpeedMode,
   doSetCycleCount,
   doSetShowDebugTab,
   doSetAppMode,
+  doSetSiriusJoyport,
   setTracing,
   doExecuteBasicCommand,
   doSetCyclesToRun} from "./motherboard"
@@ -21,7 +22,6 @@ import { MouseCardEvent } from "./devices/mouse"
 import { receiveMidiData } from "./devices/passport/passport"
 import { receiveCommData } from "./devices/superserial/serial"
 import { setTraceSettings } from "./tracelog"
-import { setSiriusJoyport } from "./devices/sirius_joyport"
 import { getMemoryDump } from "./memory"
 import { doGotoTimeTravelIndex, doSetThumbnailImage, doGetSaveStateWithSnapshots, doGetSaveState, doGoBackInTime, doGoForwardInTime, doRestoreSaveState } from "./save_restore"
 
@@ -309,7 +309,7 @@ if (typeof self !== "undefined") {
         forceVideo7Override(e.data.payload as Video7Override)
         break
       case MSG_MAIN.SIRIUS_JOYPORT:
-        setSiriusJoyport(e.data.payload)
+        doSetSiriusJoyport(e.data.payload)
         break
       case MSG_MAIN.EXECUTE_BASIC_COMMAND: {
         const command = e.data.payload as string


### PR DESCRIPTION
While testing joystick input, I found that Sirius Joyport mode appeared as constant joystick-button input in the game. Turning Sirius Joyport mode off in the UI did not change the running emulator; the setting took effect only after restarting the browser session.

The preference setter updated local storage and the UI but did not call `passSiriusJoyport()` to send the new value to the emulator worker. This adds that missing handoff.

Sirius Joyport is intentionally disabled during a 1,000-cycle delay after reset to prevent the Apple IIe from entering its self-test. The delay now restarts if another reset occurs, while menu changes made during the delay are remembered and applied afterward.

Fixes #297.
