### PR TITLE
Preserve Mockingboard state in v2 saves

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -83,11 +83,18 @@ type Apple2SaveState = {
   s6502: STATE6502,
   extraRamSize: number,
   machineName: MACHINE_NAME,
+  cardStates?: SlotCardSaveState[],
   softSwitches: {[name: string]: boolean},
   stackDump: Array<string>,
   memvalid: string,
   memC000: string,
   memory: string
+}
+
+type SlotCardSaveState = {
+  slot: number,
+  card: SLOT_CARD_ID,
+  state: unknown
 }
 
 type UpdateDisplay = (speed = 0, helptext = "") => void

--- a/src/worker/devices/mockingboard.ts
+++ b/src/worker/devices/mockingboard.ts
@@ -2,12 +2,27 @@ import { interruptRequest, registerCycleCountCallback } from "../cpu6502"
 import { s6502 } from "../instructions"
 import { debugSlot, memGetSlotROM, memSetSlotROM, setSlotIOCallback } from "../memory"
 import { passMockingboard } from "../worker2main"
+import { registerSlotCardState } from "./slot_card_state"
+
+type MockingboardSaveState = {
+  data: number[],
+  prevCycleCount: number,
+}
 
 export const enableMockingboard = (enable = true, slot = 4) => {
   if (!enable)
     return
   setSlotIOCallback(slot, handleMockingboard)
   registerCycleCountCallback(cycleCountCallback, slot)
+  registerSlotCardState(
+    slot,
+    "mockingboard",
+    () => ({
+      data: Array.from({length: 256}, (_, addr) => memGetSlotROM(slot, addr)),
+      prevCycleCount: prevCycleCount[slot],
+    }),
+    state => restoreMockingboardState(slot, state as MockingboardSaveState),
+  )
 }
 
 const ORB = [0x0, 0x80]
@@ -123,6 +138,18 @@ const handleTimerT2 = (slot: number, chip: number, cycleDelta: number) => {
 }
 
 const prevCycleCount = new Array<number>(8).fill(0)
+
+const restoreMockingboardState = (slot: number, state: MockingboardSaveState) => {
+  prevCycleCount[slot] = state.prevCycleCount
+  state.data.forEach((value, addr) => memSetSlotROM(slot, addr, value))
+  for (let chip = 0; chip <= 1; chip++) {
+    handleInterruptFlag(slot, chip, -1)
+    doPassRegisters(slot, chip)
+  }
+  const slotActive = [0, 1].some(chip =>
+    (memGetSlotROM(slot, IFR[chip]) & memGetSlotROM(slot, IER[chip]) & 0x7F) !== 0)
+  interruptRequest(slot, slotActive)
+}
 
 const cycleCountCallback = (slot: number) => {
   const cycleDelta = s6502.cycleCount - prevCycleCount[slot]

--- a/src/worker/devices/slot_card_state.test.ts
+++ b/src/worker/devices/slot_card_state.test.ts
@@ -1,0 +1,37 @@
+import {
+  clearSlotCardStateHandlers,
+  getSlotCardSaveState,
+  registerSlotCardState,
+  restoreSlotCardSaveState,
+} from "./slot_card_state"
+
+beforeEach(clearSlotCardStateHandlers)
+
+test("saves and restores registered card state", () => {
+  let value = 42
+  registerSlotCardState(4, "mockingboard", () => value, state => { value = state as number })
+
+  const saved = getSlotCardSaveState()
+  value = 0
+  restoreSlotCardSaveState(saved)
+
+  expect(saved).toEqual([{slot: 4, card: "mockingboard", state: 42}])
+  expect(value).toBe(42)
+})
+
+test("does not restore state into a different card", () => {
+  let restored = false
+  registerSlotCardState(4, "mouse", () => null, () => { restored = true })
+
+  restoreSlotCardSaveState([{slot: 4, card: "mockingboard", state: null}])
+
+  expect(restored).toBe(false)
+})
+
+test("accepts save files without card state", () => {
+  registerSlotCardState(4, "mockingboard", () => null, () => {
+    throw new Error("restore should not run")
+  })
+
+  restoreSlotCardSaveState(undefined)
+})

--- a/src/worker/devices/slot_card_state.ts
+++ b/src/worker/devices/slot_card_state.ts
@@ -1,0 +1,30 @@
+type SlotCardStateHandler = {
+  card: SLOT_CARD_ID,
+  save: () => unknown,
+  restore: (state: unknown) => void,
+}
+
+const handlers = new Map<number, SlotCardStateHandler>()
+
+export const clearSlotCardStateHandlers = () => handlers.clear()
+
+export const registerSlotCardState = (
+  slot: number,
+  card: SLOT_CARD_ID,
+  save: () => unknown,
+  restore: (state: unknown) => void,
+) => handlers.set(slot, {card, save, restore})
+
+export const getSlotCardSaveState = (): SlotCardSaveState[] =>
+  Array.from(handlers, ([slot, handler]) => ({
+    slot,
+    card: handler.card,
+    state: handler.save(),
+  }))
+
+export const restoreSlotCardSaveState = (states: SlotCardSaveState[] | undefined) => {
+  for (const saved of states ?? []) {
+    const handler = handlers.get(saved.slot)
+    if (handler?.card === saved.card) handler.restore(saved.state)
+  }
+}

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -34,6 +34,7 @@ import { enableVera, resetVera } from "./devices/vera/vera"
 import { videoTerm, enableVideoTerm, disableVideoTerm } from "./devices/videoterm"
 import { vidhd } from "./devices/vidhd"
 import { enableMockingboard, resetMockingboard } from "./devices/mockingboard"
+import { clearSlotCardStateHandlers } from "./devices/slot_card_state"
 import { resetMouse, onMouseVBL } from "./devices/mouse"
 import { enableDiskDrive } from "./devices/diskdata"
 import { pollKeyboardRepeat, sendPastedText } from "./devices/keyboard"
@@ -148,6 +149,7 @@ export const configureMachine = () => {
   if (didConfiguration) return
   didConfiguration = true
   resetCycleCountCallbacks()
+  clearSlotCardStateHandlers()
 
   for (let s = 1; s <= 7; s++) {
     clearSlot(s)

--- a/src/worker/save_restore.ts
+++ b/src/worker/save_restore.ts
@@ -8,6 +8,7 @@ import { configureMachine, doReset, doSetMachineName, doSetRunMode, getMachineNa
 import { SWITCHES } from "./softswitches"
 import { vidhd } from "./devices/vidhd"
 import { passRequestThumbnail } from "./worker2main"
+import { getSlotCardSaveState, restoreSlotCardSaveState } from "./devices/slot_card_state"
 
 let iTempState = 0
 const saveStates: Array<EmulatorSaveState> = []
@@ -58,6 +59,7 @@ export const getApple2State = (): Apple2SaveState => {
     s6502: save6502,
     extraRamSize: 64 * (RamWorksMaxBank + 1),
     machineName: getMachineName(),
+    cardStates: getSlotCardSaveState(),
     softSwitches: getSoftSwitches(),
     stackDump: getStackDump(),
     memvalid: memvalid.slice(0, maxGood + 1).join(""),
@@ -139,6 +141,7 @@ export const setApple2State = (newState: Apple2SaveState, version: number) => {
   if (newState.stackDump) {
     setStackDump(newState.stackDump)
   }
+  restoreSlotCardSaveState(newState.cardStates)
   updateAddressTables()
   // Force the help text to be reset if necessary.
   handleGameSetup(true)

--- a/src/worker/save_restore_card.test.ts
+++ b/src/worker/save_restore_card.test.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_SLOT_CONFIG } from "../common/utility"
+import { interruptRequest } from "./cpu6502"
+import { memGetSlotROM, memSetSlotROM } from "./memory"
+import { resetMockingboard } from "./devices/mockingboard"
+import { configureMachine, doSetSlotConfig } from "./motherboard"
+import { getApple2State, setApple2State } from "./save_restore"
+import { setIsTesting } from "./worker2main"
+import { s6502 } from "./instructions"
+
+afterEach(() => interruptRequest(4, false))
+
+test("v2 save state preserves Mockingboard registers and timers", () => {
+  setIsTesting()
+  doSetSlotConfig({...DEFAULT_SLOT_CONFIG})
+  configureMachine()
+  resetMockingboard(4)
+  memSetSlotROM(4, 0x04, 0x34)
+  memSetSlotROM(4, 0x05, 0x12)
+  memSetSlotROM(4, 0x20, 0x56)
+  memSetSlotROM(4, 0x13, 0x40)
+  memSetSlotROM(4, 0x0D, 0x40)
+  memSetSlotROM(4, 0x0E, 0x40)
+
+  const saved = getApple2State()
+  resetMockingboard(4)
+  setApple2State(saved, 2)
+
+  expect(memGetSlotROM(4, 0x04)).toBe(0x34)
+  expect(memGetSlotROM(4, 0x05)).toBe(0x12)
+  expect(memGetSlotROM(4, 0x20)).toBe(0x56)
+  expect(memGetSlotROM(4, 0x13)).toBe(0x40)
+  expect(memGetSlotROM(4, 0x0D)).toBe(0xC0)
+  expect(s6502.flagIRQ & (1 << 4)).not.toBe(0)
+})


### PR DESCRIPTION
Fixes #378.

- Add card-provided save and restore handlers to v2 state.
- Preserve Mockingboard VIA, AY, and timer state.
- Restore its shared IRQ and audio registers coherently.

In A/B testing with Ultima V, current main lost the music after restoring state, while this change resumed it.