### PR TITLE
fix(remote-control): enforce explicit disk targets

### DIFF
--- a/src/worker/devices/decodedisk.ts
+++ b/src/worker/devices/decodedisk.ts
@@ -72,14 +72,26 @@ const decodeDSK = (driveState: DriveState, diskData: Uint8Array) => {
   return newData
 }
 
-export const decodeDiskData = (driveState: DriveState, diskData: Uint8Array, isProdosFloppy: boolean): Uint8Array => {
+export const decodeDiskData = (
+  driveState: DriveState,
+  diskData: Uint8Array,
+  isProdosFloppy: boolean,
+  enforceDriveKind = false,
+): Uint8Array => {
   driveState.diskHasChanges = false
   const fname = driveState.filename.toLowerCase()
   if (diskData.length > 10000) {
     if (isHardDriveImage(fname, diskData?.length, isProdosFloppy)) {
+      if (enforceDriveKind && !driveState.hardDrive) {
+        return new Uint8Array()
+      }
       driveState.hardDrive = true
       driveState.status = ""
       return diskData
+    }
+    if (enforceDriveKind && driveState.hardDrive &&
+      (fname.endsWith(".woz") || fname.endsWith(".dsk") || fname.endsWith(".do") || fname.endsWith(".po"))) {
+      return new Uint8Array()
     }
     // We might have a DSK file that has already been renamed as a WOZ
     // but is still in DSK format. So double check the disk data length.

--- a/src/worker/devices/drivestate.ts
+++ b/src/worker/devices/drivestate.ts
@@ -215,11 +215,10 @@ export const doSetEmuDriveNewData = (props: DriveProps, forceIndex: boolean = fa
   }
   driveState[index] = initDriveState(index, drive, isHardDrive)
   driveState[index].filename = props.filename
-  // Tricky code: if we are forcing a disk into a certain drive,
-  // then whether we treat a ProDOS floppy as a hard drive is determined by the caller.
-  // If we are not forcing the index, then we look at our isProdosFloppy preference.
-  const treatProdosAsFloppy = forceIndex ? (!isHardDrive) : isProdosFloppy
-  driveData[index] = decodeDiskData(driveState[index], props.diskData, treatProdosAsFloppy)
+  // For a forced mount, classify a .po image from its size before comparing it
+  // with the requested drive.
+  const treatProdosAsFloppy = forceIndex || isProdosFloppy
+  driveData[index] = decodeDiskData(driveState[index], props.diskData, treatProdosAsFloppy, forceIndex)
   if (driveData[index].length === 0) {
     driveState[index].filename = ""
     passDriveData(index)

--- a/src/worker/devices/drivestate_save.test.ts
+++ b/src/worker/devices/drivestate_save.test.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "buffer"
-import { doSetEmuDriveNewData, getDriveSaveState, getHardDriveData, getHardDriveState,
-  restoreDriveSaveState } from "./drivestate"
+import { convertdsk2woz } from "./convertdsk2woz"
+import { doSetEmuDriveNewData, getCurrentDriveData, getCurrentDriveState, getDriveSaveState,
+  getHardDriveData, getHardDriveState, restoreDriveSaveState } from "./drivestate"
 import { doGetSaveState, doRestoreSaveState } from "../save_restore"
 import { setIsTesting } from "../worker2main"
 import * as workerMessages from "../worker2main"
@@ -80,6 +81,148 @@ test("accepts valid media at a forced drive index", () => {
   }, true)
 
   expect(result).toBe(true)
+})
+
+test("rejects hard-drive-sized ProDOS media forced into fd1 and publishes empty state", () => {
+  const passDriveProps = jest.spyOn(workerMessages, "passDriveProps")
+  const result = doSetEmuDriveNewData({
+    index: 2,
+    hardDrive: false,
+    drive: 1,
+    filename: "large.po",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData: new Uint8Array(143361),
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0,
+  }, true)
+
+  expect(result).toBe(false)
+  expect(getCurrentDriveState()).toEqual(expect.objectContaining({
+    index: 2,
+    hardDrive: false,
+    filename: "",
+  }))
+  expect(getCurrentDriveData()).toHaveLength(0)
+  expect(passDriveProps).toHaveBeenCalledWith(expect.objectContaining({
+    index: 2,
+    hardDrive: false,
+    filename: "",
+    diskData: new Uint8Array(),
+  }), true)
+})
+
+test("accepts the same hard-drive-sized ProDOS media forced into hd1", () => {
+  const diskData = new Uint8Array(143361)
+  diskData[0] = 0xA5
+  const result = doSetEmuDriveNewData({
+    index: 0,
+    hardDrive: true,
+    drive: 1,
+    filename: "large.po",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData,
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0,
+  }, true)
+
+  expect(result).toBe(true)
+  expect(getHardDriveState(1)).toEqual(expect.objectContaining({
+    index: 0,
+    hardDrive: true,
+    filename: "large.po",
+  }))
+  expect(getHardDriveData(1)[0]).toBe(diskData)
+})
+
+test("accepts a standard-sized ProDOS floppy forced into fd1", () => {
+  const result = doSetEmuDriveNewData({
+    index: 2,
+    hardDrive: false,
+    drive: 1,
+    filename: "standard.po",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData: new Uint8Array(143360),
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0,
+  }, true)
+
+  expect(result).toBe(true)
+  expect(getCurrentDriveState()).toEqual(expect.objectContaining({
+    index: 2,
+    hardDrive: false,
+    filename: "standard.woz",
+  }))
+  expect(getCurrentDriveData().length).toBeGreaterThan(0)
+})
+
+test("rejects a standard-sized ProDOS floppy forced into hd1", () => {
+  const result = doSetEmuDriveNewData({
+    index: 0,
+    hardDrive: true,
+    drive: 1,
+    filename: "standard.po",
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData: new Uint8Array(143360),
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0,
+  }, true)
+
+  expect(result).toBe(false)
+  expect(getHardDriveState(1)).toEqual(expect.objectContaining({
+    index: 0,
+    hardDrive: true,
+    filename: "",
+  }))
+  expect(getHardDriveData(1)[0]).toHaveLength(0)
+})
+
+test.each([
+  ["valid.woz", convertdsk2woz(new Uint8Array(143360), false)],
+  ["valid.dsk", new Uint8Array(143360)],
+])("rejects floppy-only %s media forced into hd1", (filename, diskData) => {
+  const result = doSetEmuDriveNewData({
+    index: 0,
+    hardDrive: true,
+    drive: 1,
+    filename,
+    status: "",
+    motorRunning: false,
+    diskHasChanges: false,
+    isWriteProtected: false,
+    diskData,
+    lastAppleWriteTime: 0,
+    cloudData: null,
+    writableFileHandle: null,
+    lastLocalFileWriteTime: 0,
+  }, true)
+
+  expect(result).toBe(false)
+  expect(getHardDriveState(1)).toEqual(expect.objectContaining({
+    index: 0,
+    hardDrive: true,
+    filename: "",
+  }))
+  expect(getHardDriveData(1)[0]).toHaveLength(0)
 })
 
 test("accepts an empty drive as an eject operation", () => {


### PR DESCRIPTION
## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per #218.

## What was implemented in this slice

- Treat remote requests for `fd1`, `fd2`, `hd1`, and `hd2` as exact targets.
- Classify `.po` images by size before comparing them with the requested drive.
- Reject an incompatible forced mount instead of changing its drive type.

## Verification

- A standard ProDOS floppy image mounts in a floppy drive and is rejected by a hard-drive target.
- A larger ProDOS image mounts in a hard-drive target and is rejected by a floppy target.
- Forced `.woz`, `.dsk`, and `.do` images are rejected by hard-drive targets.