### PR TITLE
feat(remote-control): expose physical memory views

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -26,6 +26,43 @@ type MessagePayload = object | number | string | boolean | EmuGamepad[] | null
 type WorkerOperationResult = {
   operationId: number,
   error?: string,
+  value?: MessagePayload,
+}
+
+type MemorySpace = "active" | "main" | "aux"
+
+type MemoryMappingState = {
+  RAMRD: boolean,
+  RAMWRT: boolean,
+  ALTZP: boolean,
+  "80STORE": boolean,
+  PAGE2: boolean,
+  HIRES: boolean,
+}
+
+type MemoryViewRequest = {
+  address: number,
+  length: number,
+  space: MemorySpace,
+  auxBank?: number,
+}
+
+type MemoryViewSegment = {
+  address: number,
+  length: number,
+  space: "main" | "aux" | "system",
+  auxBank?: number,
+}
+
+type MemoryView = {
+  address: number,
+  length: number,
+  requestedSpace: MemorySpace,
+  requestedAuxBank: number | null,
+  effectiveAuxBank: number | null,
+  effectiveSegments: MemoryViewSegment[],
+  mapping: MemoryMappingState,
+  bytes: Uint8Array,
 }
 
 type KeyboardState = {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -101,6 +101,7 @@ export enum MSG_MAIN {
   SLOT_CONFIG,
   RUN_BINARY,
   LOAD_BINARY,
+  GET_MEMORY_VIEW,
 }
 
 export const DEFAULT_SLOT_CONFIG: SlotConfig = {

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -66,6 +66,7 @@ import {
 } from "../devices/disk/driveprops"
 import { parseRemoteKeyboardState } from "./remotecontrol_input"
 import { captureRenderedScreen } from "./remotecontrol_screen"
+import { readRemoteMemory } from "./remotecontrol_memory"
 
 const CONNECT_RETRY_MS = 3000
 const HEARTBEAT_MS = 2000
@@ -404,6 +405,10 @@ export const executeCommand = async (action: string, payload: Record<string, unk
 
     case "getMemory":
       return collectMemory()
+
+    case "getMemoryView": {
+      return readRemoteMemory(payload)
+    }
 
     case "captureScreen":
       return captureRenderedScreen()

--- a/src/ui/api/remotecontrol_memory.test.ts
+++ b/src/ui/api/remotecontrol_memory.test.ts
@@ -1,0 +1,50 @@
+import { requestMemoryView } from "../main2worker"
+import { readRemoteMemory } from "./remotecontrol_memory"
+
+jest.mock("../main2worker", () => ({requestMemoryView: jest.fn()}))
+
+const mockRequestMemoryView = jest.mocked(requestMemoryView)
+
+test("returns the complete worker-owned memory view", async () => {
+  mockRequestMemoryView.mockResolvedValue({
+    address: 0x03A4,
+    length: 2,
+    requestedSpace: "aux",
+    requestedAuxBank: null,
+    effectiveAuxBank: 1,
+    effectiveSegments: [{address: 0x03A4, length: 2, space: "aux", auxBank: 1}],
+    mapping: {
+      RAMRD: true,
+      RAMWRT: false,
+      ALTZP: false,
+      "80STORE": false,
+      PAGE2: false,
+      HIRES: false,
+    },
+    bytes: Uint8Array.from([0x11, 0x22]),
+  })
+
+  await expect(readRemoteMemory({address: 0x03A4, length: 2, space: "aux"})).resolves.toEqual({
+    address: 0x03A4,
+    length: 2,
+    requestedSpace: "aux",
+    requestedAuxBank: null,
+    effectiveAuxBank: 1,
+    effectiveSegments: [{address: 0x03A4, length: 2, space: "aux", auxBank: 1}],
+    mapping: {
+      RAMRD: true,
+      RAMWRT: false,
+      ALTZP: false,
+      "80STORE": false,
+      PAGE2: false,
+      HIRES: false,
+    },
+    bytes: [0x11, 0x22],
+  })
+  expect(mockRequestMemoryView).toHaveBeenCalledWith({
+    address: 0x03A4,
+    length: 2,
+    space: "aux",
+    auxBank: undefined,
+  })
+})

--- a/src/ui/api/remotecontrol_memory.ts
+++ b/src/ui/api/remotecontrol_memory.ts
@@ -1,0 +1,12 @@
+import { requestMemoryView } from "../main2worker"
+
+export const readRemoteMemory = async (payload: Record<string, unknown>) => {
+  const request = {
+    address: Number(payload.address),
+    length: Number(payload.length),
+    space: payload.space as MemorySpace,
+    auxBank: payload.auxBank === undefined ? undefined : Number(payload.auxBank),
+  }
+  const view = await requestMemoryView(request)
+  return {...view, bytes: Array.from(view.bytes)}
+}

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -7,6 +7,7 @@ import {
   requestSetState6502,
   requestSetRunMode,
   requestSpeedMode,
+  requestMemoryView,
   setMain2Worker,
 } from "./main2worker"
 
@@ -32,11 +33,11 @@ const sendMachineState = (runMode: RUN_MODE) => {
   } as MessageEvent)
 }
 
-const sendOperationResult = (operationId: number, error?: string) => {
+const sendOperationResult = (operationId: number, error?: string, value?: MessagePayload) => {
   doOnMessage({
     data: {
       msg: MSG_WORKER.OPERATION_RESULT,
-      payload: { operationId, error },
+      payload: { operationId, error, value },
     },
   } as MessageEvent)
 }
@@ -103,6 +104,28 @@ describe("worker operations", () => {
 
     sendOperationResult(message.operationId)
     await expect(operation).resolves.toBeUndefined()
+  })
+
+  test("returns a worker-owned memory view", async () => {
+    const operation = requestMemoryView({address: 0x03A4, length: 1, space: "aux"})
+    const message = worker.postMessage.mock.calls.at(-1)[0]
+    const value = {
+      address: 0x03A4,
+      length: 1,
+      requestedSpace: "aux",
+      requestedAuxBank: null,
+      effectiveAuxBank: 0,
+      effectiveSegments: [{address: 0x03A4, length: 1, space: "aux", auxBank: 0}],
+      mapping: {RAMRD: false, RAMWRT: false, ALTZP: false, "80STORE": false, PAGE2: false, HIRES: false},
+      bytes: Uint8Array.from([0x42]),
+    } as MemoryView
+
+    expect(message).toEqual(expect.objectContaining({
+      msg: MSG_MAIN.GET_MEMORY_VIEW,
+      payload: {address: 0x03A4, length: 1, space: "aux"},
+    }))
+    sendOperationResult(message.operationId, undefined, value)
+    await expect(operation).resolves.toEqual(value)
   })
 
   test("sends CPU state changes as confirmed worker operations", async () => {

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -24,19 +24,19 @@ let bootCallback: (() => void) | null = null
 let serialConfigCallback: ((config: SerialConfig) => void) | null = null
 let nextWorkerOperationId = 0
 const pendingWorkerOperations = new Map<number, {
-  resolve: () => void,
+  resolve: (value: MessagePayload | undefined) => void,
   reject: (error: Error) => void,
   timeout: ReturnType<typeof setTimeout>,
 }>()
 
-const requestWorkerOperation = (
+const requestWorkerOperation = <T = void>(
   msg: MSG_MAIN,
   payload: MessagePayload,
   timeoutMs = 5000,
-): Promise<void> => new Promise((resolve, reject) => {
+): Promise<T> => new Promise((resolve, reject) => {
   const operationId = ++nextWorkerOperationId
   const operation = {
-    resolve,
+    resolve: (value: MessagePayload | undefined) => resolve(value as T),
     reject,
     timeout: setTimeout(() => {
       pendingWorkerOperations.delete(operationId)
@@ -47,7 +47,7 @@ const requestWorkerOperation = (
   doPostMessage(msg, payload, operationId)
 })
 
-const resolveWorkerOperation = ({ operationId, error }: WorkerOperationResult) => {
+const resolveWorkerOperation = ({ operationId, error, value }: WorkerOperationResult) => {
   const operation = pendingWorkerOperations.get(operationId)
   if (!operation) return
   clearTimeout(operation.timeout)
@@ -55,7 +55,7 @@ const resolveWorkerOperation = ({ operationId, error }: WorkerOperationResult) =
   if (error) {
     operation.reject(new Error(error))
   } else {
-    operation.resolve()
+    operation.resolve(value)
   }
 }
 
@@ -364,6 +364,11 @@ export const passSetTraceSettings = (traceSettings: TraceSettings) => {
 export const passRequestMemoryDump = () => {
   doPostMessage(MSG_MAIN.GET_MEMORY, true)
 }
+
+export const requestMemoryView = (
+  request: MemoryViewRequest,
+  timeoutMs = 5000,
+) => requestWorkerOperation<MemoryView>(MSG_MAIN.GET_MEMORY_VIEW, request, timeoutMs)
 
 // This is a cached memory dump, updated whenever the main requests a new one.
 // Currently only used by the AI Agent, since it may want to look at memory

--- a/src/worker/memory.test.ts
+++ b/src/worker/memory.test.ts
@@ -11,6 +11,9 @@ import {
   setRamWorks,
   setSlotDriver,
   loadMainMemoryBlock,
+  getMemoryView,
+  setAuxCardEnabled,
+  updateAddressTables,
 } from "./memory"
 import { hiresLineToAddress, RamWorksMemoryStart } from "../common/utility"
 import { setIsTesting } from "./worker2main"
@@ -415,6 +418,125 @@ test("test RamWorks", () => {
   }
 
   memSet(0xC008,0)
+})
+
+describe("side-effect-free memory views", () => {
+  const mappingSwitches = [
+    SWITCHES.RAMRD,
+    SWITCHES.RAMWRT,
+    SWITCHES.ALTZP,
+    SWITCHES.STORE80,
+    SWITCHES.PAGE2,
+    SWITCHES.HIRES,
+  ]
+
+  beforeEach(() => {
+    setAuxCardEnabled(true)
+    setRamWorks(128)
+    memoryReset()
+  })
+
+  afterEach(() => {
+    setAuxCardEnabled(true)
+    setRamWorks(64)
+    memoryReset()
+  })
+
+  test("reads main, selected auxiliary, and explicit RamWorks banks directly", () => {
+    memory[0x03A4] = 0x11
+    memory[RamWorksMemoryStart + 0x03A4] = 0x22
+    memory[RamWorksMemoryStart + 0x10000 + 0x03A4] = 0x33
+    memSet(0xC073, 1)
+    const beforeSwitches = mappingSwitches.map((softSwitch) => softSwitch.isSet)
+
+    expect(getMemoryView({address: 0x03A4, length: 1, space: "main"})).toMatchObject({
+      bytes: Uint8Array.from([0x11]),
+      requestedAuxBank: null,
+      effectiveAuxBank: null,
+      effectiveSegments: [{address: 0x03A4, length: 1, space: "main"}],
+    })
+    expect(getMemoryView({address: 0x03A4, length: 1, space: "aux"})).toMatchObject({
+      bytes: Uint8Array.from([0x33]),
+      requestedAuxBank: null,
+      effectiveAuxBank: 1,
+      effectiveSegments: [{address: 0x03A4, length: 1, space: "aux", auxBank: 1}],
+    })
+    expect(getMemoryView({address: 0x03A4, length: 1, space: "aux", auxBank: 0})).toMatchObject({
+      bytes: Uint8Array.from([0x22]),
+      requestedAuxBank: 0,
+      effectiveAuxBank: 0,
+    })
+    expect(memGetC000(0xC073)).toBe(1)
+    expect(mappingSwitches.map((softSwitch) => softSwitch.isSet)).toEqual(beforeSwitches)
+  })
+
+  test("reports active segments where mapping changes", () => {
+    SWITCHES.RAMRD.isSet = false
+    SWITCHES.STORE80.isSet = true
+    SWITCHES.PAGE2.isSet = true
+    updateAddressTables()
+
+    const view = getMemoryView({address: 0x03FF, length: 2, space: "active"})
+    expect(view.effectiveSegments).toEqual([
+      {address: 0x03FF, length: 1, space: "main"},
+      {address: 0x0400, length: 1, space: "aux", auxBank: 0},
+    ])
+    expect(view.effectiveAuxBank).toBe(0)
+    expect(view.mapping).toEqual({
+      RAMRD: false,
+      RAMWRT: false,
+      ALTZP: false,
+      "80STORE": true,
+      PAGE2: true,
+      HIRES: false,
+    })
+  })
+
+  test("rejects unavailable and out-of-range auxiliary banks", () => {
+    expect(() => getMemoryView({address: 0, length: 1, space: "active", auxBank: 0}))
+      .toThrow("Auxiliary bank is valid only for auxiliary memory")
+    expect(() => getMemoryView({address: 0, length: 1, space: "aux", auxBank: 2}))
+      .toThrow("Auxiliary bank must be between 0 and 1")
+    setAuxCardEnabled(false)
+    expect(() => getMemoryView({address: 0, length: 1, space: "aux"}))
+      .toThrow("Auxiliary memory is not configured")
+  })
+
+  test("keeps physical views below I/O and ROM", () => {
+    expect(getMemoryView({address: 0xBFFF, length: 1, space: "main"}).bytes).toHaveLength(1)
+    expect(() => getMemoryView({address: 0xC000, length: 1, space: "main"}))
+      .toThrow("Physical memory range must fit within $0000-$BFFF")
+    expect(() => getMemoryView({address: 0xBFFF, length: 2, space: "aux"}))
+      .toThrow("Physical memory range must fit within $0000-$BFFF")
+    expect(getMemoryView({address: 0xC000, length: 1, space: "active"}).effectiveSegments)
+      .toEqual([{address: 0xC000, length: 1, space: "system"}])
+  })
+
+  test("does not describe Language Card mappings as main or auxiliary physical RAM", () => {
+    const previous = {
+      ALTZP: SWITCHES.ALTZP.isSet,
+      BSRBANK2: SWITCHES.BSRBANK2.isSet,
+      BSRREADRAM: SWITCHES.BSRREADRAM.isSet,
+    }
+    try {
+      SWITCHES.BSRREADRAM.isSet = false
+      updateAddressTables()
+      expect(getMemoryView({address: 0xD000, length: 0x3000, space: "active"}).effectiveSegments)
+        .toEqual([{address: 0xD000, length: 0x3000, space: "system"}])
+
+      SWITCHES.BSRREADRAM.isSet = true
+      SWITCHES.BSRBANK2.isSet = false
+      SWITCHES.ALTZP.isSet = true
+      updateAddressTables()
+      expect(getMemoryView({address: 0xD000, length: 0x3000, space: "active"}).effectiveSegments)
+        .toEqual([{address: 0xD000, length: 0x3000, space: "system"}])
+    } finally {
+      SWITCHES.ALTZP.isSet = previous.ALTZP
+      SWITCHES.BSRBANK2.isSet = previous.BSRBANK2
+      SWITCHES.BSRREADRAM.isSet = previous.BSRREADRAM
+      updateAddressTables()
+    }
+  })
 })
 
 test("test RamWorks Save/Restore", () => {

--- a/src/worker/memory.ts
+++ b/src/worker/memory.ts
@@ -793,6 +793,108 @@ export const getMemoryDump = () => {
   return dump
 }
 
+const getBackingLocation = (address: number) => {
+  if (address >= 0xC000) return { space: "system" as const }
+  const offset = addressGetTable[address >>> 8] + (address & 0xFF)
+  if (offset < 0x10000) return { space: "main" as const }
+  if (offset >= RamWorksMemoryStart) {
+    return {
+      space: "aux" as const,
+      auxBank: Math.floor((offset - RamWorksMemoryStart) / 0x10000),
+    }
+  }
+  return { space: "system" as const }
+}
+
+const getEffectiveSegments = (
+  address: number,
+  length: number,
+  space: MemorySpace,
+  auxBank: number,
+) => {
+  const segments: MemoryViewSegment[] = []
+  for (let current = address; current < address + length; current++) {
+    const location = space === "active"
+      ? getBackingLocation(current)
+      : space === "aux"
+        ? { space, auxBank }
+        : { space }
+    const previous = segments.at(-1)
+    if (
+      previous
+      && previous.address + previous.length === current
+      && previous.space === location.space
+      && previous.auxBank === location.auxBank
+    ) {
+      previous.length++
+    } else {
+      segments.push({address: current, length: 1, ...location})
+    }
+  }
+  return segments
+}
+
+export const getMemoryView = (request: MemoryViewRequest): MemoryView => {
+  const {address, length, space} = request
+  if (!Number.isInteger(address) || address < 0 || address > 0xFFFF) {
+    throw new Error("Memory address must be between $0000 and $FFFF")
+  }
+  if (!Number.isInteger(length) || length < 1 || address + length > 0x10000) {
+    throw new Error("Memory range must fit within $0000-$FFFF")
+  }
+  if (!(["active", "main", "aux"] as MemorySpace[]).includes(space)) {
+    throw new Error("Unknown memory space")
+  }
+  if (request.auxBank !== undefined && space !== "aux") {
+    throw new Error("Auxiliary bank is valid only for auxiliary memory")
+  }
+  if (space !== "active" && address + length > 0xC000) {
+    throw new Error("Physical memory range must fit within $0000-$BFFF")
+  }
+  const selectedAuxBank = RamWorksBankGet()
+  const auxBank = request.auxBank ?? selectedAuxBank
+  if (space === "aux") {
+    if (!auxCardEnabled) throw new Error("Auxiliary memory is not configured")
+    if (!Number.isInteger(auxBank) || auxBank < 0 || auxBank > RamWorksMaxBank) {
+      throw new Error(`Auxiliary bank must be between 0 and ${RamWorksMaxBank}`)
+    }
+  }
+
+  let bytes: Uint8Array
+  if (space === "active") {
+    bytes = new Uint8Array(length)
+    for (let index = 0; index < length; index++) {
+      const current = address + index
+      const offset = addressGetTable[current >>> 8] + (current & 0xFF)
+      bytes[index] = memory[offset]
+    }
+  } else {
+    const offset = space === "main" ? address : RamWorksMemoryStart + auxBank * 0x10000 + address
+    bytes = memory.slice(offset, offset + length)
+  }
+
+  const effectiveSegments = getEffectiveSegments(address, length, space, auxBank)
+  return {
+    address,
+    length,
+    requestedSpace: space,
+    requestedAuxBank: request.auxBank ?? null,
+    effectiveAuxBank: effectiveSegments.some((segment) => segment.space === "aux")
+      ? auxBank
+      : null,
+    effectiveSegments,
+    mapping: {
+      RAMRD: SWITCHES.RAMRD.isSet,
+      RAMWRT: SWITCHES.RAMWRT.isSet,
+      ALTZP: SWITCHES.ALTZP.isSet,
+      "80STORE": SWITCHES.STORE80.isSet,
+      PAGE2: SWITCHES.PAGE2.isSet,
+      HIRES: SWITCHES.HIRES.isSet,
+    },
+    bytes,
+  }
+}
+
 export const getShr = (): Uint8Array => {
   if (!vidhd.enabled || !vidhd.active) {
     return new Uint8Array()

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -1,9 +1,9 @@
 import { BREAKPOINT_RESULT, breakpointMap, doSetBreakpoints, hitBreakpoint, processInstruction } from "./cpu6502"
-import { getHires, memGet, memory, updateAddressTables } from "./memory"
+import { getAuxCardEnabled, getHires, memGet, memory, setAuxCardEnabled, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
-import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, getExternalMachineState, resetCpuSpeedForTesting } from "./motherboard"
+import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, getExternalMachineState, getExternalMemoryView, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
@@ -15,6 +15,56 @@ import { getSiriusJoyport } from "./devices/sirius_joyport"
 test("debugMode", () => {
   expect(TEST_DEBUG).toEqual(false)
   expect(TEST_GRAPHICS).toEqual(false)
+})
+
+test("physical memory inspection requires a stable paused worker", () => {
+  setIsTesting()
+  doSetRunMode(RUN_MODE.PAUSED, false)
+  expect(getExternalMemoryView({address: 0, length: 1, space: "main"}).bytes).toHaveLength(1)
+  expect(() => getExternalMemoryView({address: 0, length: 1, space: "main", auxBank: 0}))
+    .toThrow("Auxiliary bank is valid only for auxiliary memory")
+
+  doSetRunMode(RUN_MODE.RUNNING, false)
+  expect(() => getExternalMemoryView({address: 0, length: 1, space: "active"}))
+    .toThrow("Memory is available only while the emulator is paused")
+  expect(() => getExternalMemoryView({address: 0, length: 1, space: "main"}))
+    .toThrow("Memory is available only while the emulator is paused")
+
+  doSetRunMode(RUN_MODE.PAUSED, false)
+  doSetRunMode(RUN_MODE.IDLE, false)
+})
+
+test("physical memory inspection preserves CPU and execution state", () => {
+  setIsTesting()
+  const previousCpu = {...s6502}
+  const previousRunMode = getExternalMachineState().runMode
+  const previousAuxCardEnabled = getAuxCardEnabled()
+
+  try {
+    Object.assign(s6502, {
+      PC: 0x4321,
+      Accum: 0x11,
+      XReg: 0x22,
+      YReg: 0x33,
+      StackPtr: 0x44,
+      PStatus: 0xA5,
+    })
+    doSetRunMode(RUN_MODE.PAUSED, false)
+    setAuxCardEnabled(true)
+    const expectedCpu = {...s6502}
+
+    getExternalMemoryView({address: 0x03A4, length: 1, space: "main"})
+    expect(s6502).toEqual(expectedCpu)
+    expect(getExternalMachineState().runMode).toEqual(RUN_MODE.PAUSED)
+
+    getExternalMemoryView({address: 0x03A4, length: 1, space: "aux", auxBank: 0})
+    expect(s6502).toEqual(expectedCpu)
+    expect(getExternalMachineState().runMode).toEqual(RUN_MODE.PAUSED)
+  } finally {
+    Object.assign(s6502, previousCpu)
+    doSetRunMode(previousRunMode, false)
+    setAuxCardEnabled(previousAuxCardEnabled)
+  }
 })
 
 describe("Sirius reset", () => {

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -22,6 +22,7 @@ import { memory, memGet, getTextPage, getHires, memoryReset,
   memSet,
   exportMemoryToHiresLine,
   getDataBlock,
+  getMemoryView,
   setSlotDriver,
   clearSlot} from "./memory"
 import { setButtonState, handleGamepads } from "./devices/joystick"
@@ -56,6 +57,14 @@ let showDebugTab = false
 let refreshTime = 16.6881 // = 17030 / 1020.488
 let cpuCyclesPerRefresh = 17030
 let cpuRunMode = RUN_MODE.IDLE
+export const getCpuRunMode = () => cpuRunMode
+
+export const getExternalMemoryView = (request: MemoryViewRequest) => {
+  if (cpuRunMode !== RUN_MODE.PAUSED) {
+    throw new Error("Memory is available only while the emulator is paused")
+  }
+  return getMemoryView(request)
+}
 let pendingRunModeOperation: number | undefined
 let cyclesToRun = 0
 let nextFrameTime = 0

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -12,7 +12,8 @@ import { doSetRunMode, doSetSpeedMode,
   doSetSiriusJoyport,
   setTracing,
   doExecuteBasicCommand,
-  doSetCyclesToRun} from "./motherboard"
+  doSetCyclesToRun,
+  getExternalMemoryView} from "./motherboard"
 import { doSetEmuDriveNewData, doSetEmuDriveProps, doSetProdosFloppy } from "./devices/drivestate"
 import { apple2KeyRelease, setKeyboardState, sendTextToEmulator } from "./devices/keyboard"
 import { pressAppleCommandKey, setGamepads, setReverseYAxis } from "./devices/joystick"
@@ -131,8 +132,15 @@ export const passSerialConfig = (config: SerialConfig) => {
   doPostMessage(MSG_WORKER.SERIAL_CONFIG_CHANGE, config)
 }
 
-export const passWorkerOperationResult = (operationId: number, error?: string) => {
-  doPostMessage(MSG_WORKER.OPERATION_RESULT, { operationId, error })
+export const passWorkerOperationResult = (
+  operationId: number,
+  error?: string,
+  value?: MessagePayload,
+) => {
+  doPostMessage(
+    MSG_WORKER.OPERATION_RESULT,
+    value === undefined ? {operationId, error} : {operationId, error, value},
+  )
 }
 
 // We do this weird check so we can safely run this code from the node.js
@@ -224,6 +232,20 @@ if (typeof self !== "undefined") {
         break
       case MSG_MAIN.GET_MEMORY:
         passMemory(getMemoryDump())
+        break
+      case MSG_MAIN.GET_MEMORY_VIEW:
+        try {
+          passWorkerOperationResult(
+            e.data.operationId,
+            undefined,
+            getExternalMemoryView(e.data.payload as MemoryViewRequest),
+          )
+        } catch (error) {
+          passWorkerOperationResult(
+            e.data.operationId,
+            error instanceof Error ? error.message : String(error),
+          )
+        }
         break
       case MSG_MAIN.GET_SAVE_STATE:
         passSaveState(doGetSaveState(true))


### PR DESCRIPTION
## Cross-repository change

This change will be paired with an Apple2TS Server change that exposes these views through the standard `read_memory` MCP tool.

## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per issue #218. This slice lets remote controllers inspect physical main and auxiliary RAM without changing the machine state being diagnosed.

## Motivation

The existing `getMemory` remote-control action exposes the active, currently mapped address space. That view follows what the CPU sees, but it cannot distinguish different bytes stored at the same address in main, auxiliary, or RamWorks memory.

Changing memory-selection switches before reading would alter the state being examined. Physical-memory inspection needs a side-effect-free path to the underlying RAM.

## What was implemented in this slice

- Added a worker-confirmed `getMemoryView` action for active, main, and auxiliary memory.
- Allowed auxiliary reads to select a RamWorks bank or use the currently selected bank.
- Reported the relevant mapping switches and the effective physical segments for the requested range.
- Kept physical reads within `$0000-$BFFF` and required the emulator to be paused.
- Preserved the existing `getMemory` behavior for callers that need the active mapped view.

The implementation reuses the existing worker control path. It reads backing RAM directly instead of changing soft switches, and it leaves Language Card, ROM, and I/O inspection on the active mapped path.

## Verification

- Main and auxiliary reads returned distinct bytes from the same address without changing CPU, mapping, bank, or execution state.
- Active ranges reported changes in effective backing memory across mapping boundaries.
- Invalid physical ranges and unavailable auxiliary banks were rejected.