### PR TITLE
fix(ui): fit monitor bezel to display

### DIFF
--- a/src/ui/canvas.css
+++ b/src/ui/canvas.css
@@ -4,6 +4,7 @@
   vertical-align: middle;
   padding-bottom: 0px;
   position: relative;
+  width: max-content;
 }
 
 .canvas-text::before {


### PR DESCRIPTION
Size the monitor wrapper to its canvas so the foreground bezel keeps the same dimensions as the Apple II display when the Info panel moves below it.

Fixes #434.