### PR TITLE
feat(remote-control): add coherent emulator execution tracking

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -189,7 +189,7 @@ type MachineState = {
   cout: number,
   cpuSpeed: number,
   extraRamSize: number,
-  execution: ExecutionSnapshot,
+  execution?: ExecutionSnapshot,
   hires: Uint8Array,
   iTempState: number,
   isDebugging: boolean,
@@ -222,8 +222,7 @@ type ExecutionPauseReason =
   "breakpoint" |
   "watchpoint" |
   "step" |
-  "cycle-limit" |
-  "run-to-return"
+  "cycle-limit"
 
 type ExecutionStopDescriptor = {
   reason: Exclude<ExecutionPauseReason, "idle">,

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -189,6 +189,7 @@ type MachineState = {
   cout: number,
   cpuSpeed: number,
   extraRamSize: number,
+  execution: ExecutionSnapshot,
   hires: Uint8Array,
   iTempState: number,
   isDebugging: boolean,
@@ -213,6 +214,41 @@ type MachineState = {
   veraSlot: VERA_SLOT,
   vidhdActive?: boolean,
   zeroPage: Uint8Array
+}
+
+type ExecutionPauseReason =
+  "idle" |
+  "explicit" |
+  "breakpoint" |
+  "watchpoint" |
+  "step" |
+  "cycle-limit" |
+  "run-to-return"
+
+type ExecutionStopDescriptor = {
+  reason: Exclude<ExecutionPauseReason, "idle">,
+  breakpointAddress?: number,
+}
+
+type ExecutionSnapshot = {
+  executionSequence: number,
+  state: "running" | "paused",
+  pauseReason: ExecutionPauseReason | null,
+  breakpoint: {
+    breakpointId: string,
+    address: number,
+  } | null,
+  PC: number,
+  A: number,
+  X: number,
+  Y: number,
+  S: number,
+  PStatus: number,
+  machineName: MACHINE_NAME,
+  memoryConfiguration: {
+    slot3Card: SLOT_CARD_ID,
+    ramWorksKb: number,
+  },
 }
 
 type UIState = {

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -183,8 +183,11 @@ const getDriveSummary = () => {
   })
 }
 
+let statusSequence = 0
+
 const collectStatus = () => {
   return {
+    statusSequence: statusSequence++,
     timestamp: Date.now(),
     machine: {
       runMode: handleGetRunMode(),

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -5,6 +5,7 @@ import {
   handleCanGoBackward,
   handleCanGoForward,
   handleGetC800Slot,
+  handleGetExecution,
   handleGetIsDebugging,
   handleGetMachineName,
   handleGetMemSize,
@@ -42,6 +43,7 @@ import {
   passSetRunMode,
   requestSetRunMode,
   requestLoadBinary,
+  setExecutionStateCallback,
 } from "../main2worker"
 import { getBinaryLoadError, runBinary } from "../binaryload"
 import {
@@ -186,6 +188,7 @@ const collectStatus = () => {
     timestamp: Date.now(),
     machine: {
       runMode: handleGetRunMode(),
+      execution: handleGetExecution(),
       speedMode: handleGetSpeedMode(),
       machineName: handleGetMachineName(),
       ramWorksKb: handleGetMemSize(),
@@ -318,6 +321,10 @@ const postState = async () => {
     state: collectStatus(),
   }))
 }
+
+setExecutionStateCallback(() => {
+  void postState()
+})
 
 const postReply = async (commandId: string, ok: boolean, result: unknown, error = "") => {
   if (!clientId) return

--- a/src/ui/api/remotecontrol_media.test.ts
+++ b/src/ui/api/remotecontrol_media.test.ts
@@ -13,6 +13,20 @@ jest.mock("../main2worker", () => ({
   handleCanGoBackward: () => false,
   handleCanGoForward: () => false,
   handleGetC800Slot: () => 0,
+  handleGetExecution: () => ({
+    executionSequence: 0,
+    state: "paused",
+    pauseReason: "idle",
+    breakpoint: null,
+    PC: 0,
+    A: 0,
+    X: 0,
+    Y: 0,
+    S: 0,
+    PStatus: 0,
+    machineName: "APPLE2EE",
+    memoryConfiguration: {slot3Card: "aux", ramWorksKb: 64},
+  }),
   handleGetIsDebugging: () => false,
   handleGetMachineName: () => "APPLE2EE",
   handleGetMemSize: () => 64,
@@ -49,6 +63,7 @@ jest.mock("../main2worker", () => ({
   passSetRunMode: jest.fn(),
   requestSetRunMode: jest.fn(),
   requestLoadBinary: jest.fn(),
+  setExecutionStateCallback: jest.fn(),
 }))
 
 jest.mock("../localstorage", () => ({
@@ -88,6 +103,14 @@ const mockPassSetRunMode = jest.mocked(passSetRunMode)
 const mockRequestEjectDisk = jest.mocked(requestEjectDisk)
 const mockRequestSetDiskFromURL = jest.mocked(requestSetDiskFromURL)
 const mockRequestMountDiskFromBuffer = jest.mocked(requestMountDiskFromBuffer)
+
+test("remote-control status includes the worker execution snapshot", async () => {
+  await expect(executeCommand("getStatus", {})).resolves.toEqual(expect.objectContaining({
+    machine: expect.objectContaining({
+      execution: expect.objectContaining({executionSequence: 0, pauseReason: "idle"}),
+    }),
+  }))
+})
 
 describe("remote-control media confirmation", () => {
   beforeEach(() => jest.clearAllMocks())

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -188,7 +188,7 @@ describe("worker operations", () => {
 test("publishes only new worker-owned execution snapshots", () => {
   const snapshots: ExecutionSnapshot[] = []
   setExecutionStateCallback((execution) => snapshots.push(execution))
-  snapshots.length = 0
+  expect(snapshots).toEqual([])
   const execution = {
     executionSequence: 9,
     state: "paused",
@@ -209,5 +209,13 @@ test("publishes only new worker-owned execution snapshots", () => {
   doOnMessage({data: {msg: MSG_WORKER.MACHINE_STATE, payload: state}} as MessageEvent)
 
   expect(snapshots).toEqual([execution])
+
+  setMain2Worker({postMessage: jest.fn()} as unknown as Worker)
+  const replacement = {...execution, executionSequence: 0, PC: 0x7000}
+  const publishedReplacement = {...replacement, executionSequence: 10}
+  doOnMessage({
+    data: {msg: MSG_WORKER.MACHINE_STATE, payload: {...state, execution: replacement}},
+  } as MessageEvent)
+  expect(snapshots).toEqual([execution, publishedReplacement])
   setExecutionStateCallback(() => {})
 })

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -8,6 +8,7 @@ import {
   requestSetRunMode,
   requestSpeedMode,
   requestMemoryView,
+  setExecutionStateCallback,
   setMain2Worker,
 } from "./main2worker"
 
@@ -182,4 +183,31 @@ describe("worker operations", () => {
 
     await expect(operation).rejects.toThrow("Invalid disk image")
   })
+})
+
+test("publishes only new worker-owned execution snapshots", () => {
+  const snapshots: ExecutionSnapshot[] = []
+  setExecutionStateCallback((execution) => snapshots.push(execution))
+  snapshots.length = 0
+  const execution = {
+    executionSequence: 9,
+    state: "paused",
+    pauseReason: "explicit",
+    breakpoint: null,
+    PC: 0x6000,
+    A: 1,
+    X: 2,
+    Y: 3,
+    S: 0xFF,
+    PStatus: 0x24,
+    machineName: "APPLE2EE",
+    memoryConfiguration: {slot3Card: "aux", ramWorksKb: 64},
+  } as ExecutionSnapshot
+  const state = {runMode: RUN_MODE.PAUSED, speedMode: 0, cpuSpeed: 0, execution} as MachineState
+
+  doOnMessage({data: {msg: MSG_WORKER.MACHINE_STATE, payload: state}} as MessageEvent)
+  doOnMessage({data: {msg: MSG_WORKER.MACHINE_STATE, payload: state}} as MessageEvent)
+
+  expect(snapshots).toEqual([execution])
+  setExecutionStateCallback(() => {})
 })

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -22,6 +22,8 @@ let worker: Worker | null = null
 let saveStateCallback: (sState: EmulatorSaveState) => void
 let bootCallback: (() => void) | null = null
 let serialConfigCallback: ((config: SerialConfig) => void) | null = null
+let executionStateCallback: ((execution: ExecutionSnapshot) => void) | null = null
+let lastExecutionSequence = -1
 let nextWorkerOperationId = 0
 const pendingWorkerOperations = new Map<number, {
   resolve: (value: MessagePayload | undefined) => void,
@@ -69,6 +71,11 @@ export const setBootCallback = (callback: () => void) => {
 
 export const setSerialConfigCallback = (callback: (config: SerialConfig) => void) => {
   serialConfigCallback = callback
+}
+
+export const setExecutionStateCallback = (callback: (execution: ExecutionSnapshot) => void) => {
+  executionStateCallback = callback
+  if (machineState.execution) callback(machineState.execution)
 }
 
 const doPostMessage = (msg: MSG_MAIN, payload: MessagePayload, operationId?: number) => {
@@ -388,6 +395,20 @@ let machineState: MachineState = {
   cout: 0,
   cpuSpeed: 0,
   extraRamSize: 64,
+  execution: {
+    executionSequence: 0,
+    state: "paused",
+    pauseReason: "idle",
+    breakpoint: null,
+    PC: 0,
+    A: 0,
+    X: 0,
+    Y: 0,
+    S: 0,
+    PStatus: 0,
+    machineName: "APPLE2EE",
+    memoryConfiguration: {slot3Card: "aux", ramWorksKb: 64},
+  },
   hires: new Uint8Array(),
   isDebugging: TEST_DEBUG,
   isTracing: TEST_DEBUG,
@@ -423,6 +444,10 @@ export const doOnMessage = (e: MessageEvent): {speed: number, helptext: string} 
         emulatorSoundEnable(newState.runMode === RUN_MODE.RUNNING)
       }
       machineState = newState
+      if (newState.execution && newState.execution.executionSequence > lastExecutionSequence) {
+        lastExecutionSequence = newState.execution.executionSequence
+        executionStateCallback?.(newState.execution)
+      }
       const helpText = getHelpText()
       return {speed: machineState.cpuSpeed, helptext: helpText}
     }
@@ -574,6 +599,10 @@ export const handleGetShowDebugTab = () => {
 
 export const handleGetState6502 = () => {
   return machineState.s6502
+}
+
+export const handleGetExecution = () => {
+  return machineState.execution
 }
 
 export const handleGetTextPage = () => {

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -24,6 +24,8 @@ let bootCallback: (() => void) | null = null
 let serialConfigCallback: ((config: SerialConfig) => void) | null = null
 let executionStateCallback: ((execution: ExecutionSnapshot) => void) | null = null
 let lastExecutionSequence = -1
+let executionSequenceOffset = 0
+let resetExecutionSequence = false
 let nextWorkerOperationId = 0
 const pendingWorkerOperations = new Map<number, {
   resolve: (value: MessagePayload | undefined) => void,
@@ -62,7 +64,9 @@ const resolveWorkerOperation = ({ operationId, error, value }: WorkerOperationRe
 }
 
 export const setMain2Worker = (workerIn: Worker) => {
+  resetExecutionSequence = worker !== null && worker !== workerIn
   worker = workerIn
+  machineState.execution = undefined
 }
 
 export const setBootCallback = (callback: () => void) => {
@@ -395,20 +399,6 @@ let machineState: MachineState = {
   cout: 0,
   cpuSpeed: 0,
   extraRamSize: 64,
-  execution: {
-    executionSequence: 0,
-    state: "paused",
-    pauseReason: "idle",
-    breakpoint: null,
-    PC: 0,
-    A: 0,
-    X: 0,
-    Y: 0,
-    S: 0,
-    PStatus: 0,
-    machineName: "APPLE2EE",
-    memoryConfiguration: {slot3Card: "aux", ramWorksKb: 64},
-  },
   hires: new Uint8Array(),
   isDebugging: TEST_DEBUG,
   isTracing: TEST_DEBUG,
@@ -443,10 +433,21 @@ export const doOnMessage = (e: MessageEvent): {speed: number, helptext: string} 
         }
         emulatorSoundEnable(newState.runMode === RUN_MODE.RUNNING)
       }
-      machineState = newState
-      if (newState.execution && newState.execution.executionSequence > lastExecutionSequence) {
-        lastExecutionSequence = newState.execution.executionSequence
-        executionStateCallback?.(newState.execution)
+      let execution = newState.execution
+      if (execution) {
+        if (resetExecutionSequence) {
+          executionSequenceOffset = lastExecutionSequence + 1 - execution.executionSequence
+          resetExecutionSequence = false
+        }
+        execution = {
+          ...execution,
+          executionSequence: execution.executionSequence + executionSequenceOffset,
+        }
+      }
+      machineState = {...newState, execution}
+      if (execution && execution.executionSequence > lastExecutionSequence) {
+        lastExecutionSequence = execution.executionSequence
+        executionStateCallback?.(execution)
       }
       const helpText = getHelpText()
       return {speed: machineState.cpuSpeed, helptext: helpText}

--- a/src/worker/cpu6502.ts
+++ b/src/worker/cpu6502.ts
@@ -8,7 +8,9 @@ import { MEMORY_BANKS } from "../common/memorybanks"
 import { getInstructionString } from "../common/util_disassemble"
 
 let breakpointSkipOnce = false
-let doWatchpointBreak = false
+let pendingWatchpointAddress: number | null = null
+let lastBreakpointAddress: number | null = null
+let lastBreakpointReason: "breakpoint" | "watchpoint" = "breakpoint"
 export let breakpointMap: BreakpointMap = new BreakpointMap()
 let runToRTS = false
 
@@ -200,8 +202,8 @@ export const checkBreakpointExpression = (bp: Breakpoint) => {
   return passes2
 }
 
-export const setWatchpointBreak = () => {
-  doWatchpointBreak = true
+export const setWatchpointBreak = (address: number) => {
+  pendingWatchpointAddress ??= address
 }
 
 const printBreakpointToConsole = (vLo: number, vHi: number, code: PCodeInstr | null) => {
@@ -260,8 +262,12 @@ const processBreakpointActions = (bp: Breakpoint, vLo: number, vHi: number,
 
 // This is only exported for breakpoint testing
 export const hitBreakpoint = (instr = -1, vLo = 0, vHi = 0, code: PCodeInstr | null = null): BREAKPOINT_RESULT => {
-  if (doWatchpointBreak) {
-    doWatchpointBreak = false
+  lastBreakpointAddress = null
+  lastBreakpointReason = "breakpoint"
+  if (pendingWatchpointAddress !== null) {
+    lastBreakpointAddress = pendingWatchpointAddress
+    lastBreakpointReason = "watchpoint"
+    pendingWatchpointAddress = null
     return BREAKPOINT_RESULT.BREAK
   }
   if (breakpointMap.size === 0 || breakpointSkipOnce) return BREAKPOINT_RESULT.NO_BREAK
@@ -271,6 +277,7 @@ export const hitBreakpoint = (instr = -1, vLo = 0, vHi = 0, code: PCodeInstr | n
     const bp = breakpointMap.get(lineNum)
     if (bp?.basic && !bp.disabled) {
       if (bp.once) breakpointMap.delete(lineNum)
+      lastBreakpointAddress = bp.address
       return BREAKPOINT_RESULT.HIDDEN_BREAK
     }
   }
@@ -325,7 +332,11 @@ export const hitBreakpoint = (instr = -1, vLo = 0, vHi = 0, code: PCodeInstr | n
     return BREAKPOINT_RESULT.NO_BREAK
   }
   if (bp.once) breakpointMap.delete(breakpointKey)
-  return processBreakpointActions(bp, vLo, vHi, code)
+  const result = processBreakpointActions(bp, vLo, vHi, code)
+  if (result === BREAKPOINT_RESULT.BREAK || result === BREAKPOINT_RESULT.HIDDEN_BREAK) {
+    lastBreakpointAddress = bp.address
+  }
+  return result
 }
 
 export const processInstruction = (updateTrace: ((str: string) => void) | null = null) => {
@@ -342,7 +353,12 @@ export const processInstruction = (updateTrace: ((str: string) => void) | null =
   if (!runOnlyMode()) {
     const bpResult = hitBreakpoint(instr, vLo, vHi, code)
     if (bpResult === BREAKPOINT_RESULT.BREAK || bpResult === BREAKPOINT_RESULT.HIDDEN_BREAK) {
-      doSetRunMode(RUN_MODE.PAUSED, bpResult !== BREAKPOINT_RESULT.HIDDEN_BREAK)
+      doSetRunMode(
+        RUN_MODE.PAUSED,
+        bpResult !== BREAKPOINT_RESULT.HIDDEN_BREAK,
+        undefined,
+        {reason: lastBreakpointReason, breakpointAddress: lastBreakpointAddress ?? undefined},
+      )
       return -1
     } else if (bpResult === BREAKPOINT_RESULT.ACTION) {
       // If we had a breakpoint action that did not halt, we want to leave
@@ -413,7 +429,7 @@ export const processInstruction = (updateTrace: ((str: string) => void) | null =
   }
   if (runToRTS && code.pcode === 0x60) {
     runToRTS = false
-    doSetRunMode(RUN_MODE.PAUSED)
+    doSetRunMode(RUN_MODE.PAUSED, true, undefined, {reason: "run-to-return"})
     return -1
   }
   return cycles

--- a/src/worker/cpu6502.ts
+++ b/src/worker/cpu6502.ts
@@ -10,7 +10,7 @@ import { getInstructionString } from "../common/util_disassemble"
 let breakpointSkipOnce = false
 let pendingWatchpointAddress: number | null = null
 let lastBreakpointAddress: number | null = null
-let lastBreakpointReason: "breakpoint" | "watchpoint" = "breakpoint"
+let lastBreakpointReason: "breakpoint" | "watchpoint" | "step" = "breakpoint"
 export let breakpointMap: BreakpointMap = new BreakpointMap()
 let runToRTS = false
 

--- a/src/worker/cpu6502.ts
+++ b/src/worker/cpu6502.ts
@@ -277,7 +277,7 @@ export const hitBreakpoint = (instr = -1, vLo = 0, vHi = 0, code: PCodeInstr | n
     const bp = breakpointMap.get(lineNum)
     if (bp?.basic && !bp.disabled) {
       if (bp.once) breakpointMap.delete(lineNum)
-      lastBreakpointAddress = bp.address
+      lastBreakpointReason = "step"
       return BREAKPOINT_RESULT.HIDDEN_BREAK
     }
   }
@@ -333,8 +333,11 @@ export const hitBreakpoint = (instr = -1, vLo = 0, vHi = 0, code: PCodeInstr | n
   }
   if (bp.once) breakpointMap.delete(breakpointKey)
   const result = processBreakpointActions(bp, vLo, vHi, code)
-  if (result === BREAKPOINT_RESULT.BREAK || result === BREAKPOINT_RESULT.HIDDEN_BREAK) {
+  if (result === BREAKPOINT_RESULT.BREAK) {
     lastBreakpointAddress = bp.address
+  } else if (result === BREAKPOINT_RESULT.HIDDEN_BREAK) {
+    lastBreakpointReason = "step"
+    lastBreakpointAddress = null
   }
   return result
 }
@@ -429,7 +432,7 @@ export const processInstruction = (updateTrace: ((str: string) => void) | null =
   }
   if (runToRTS && code.pcode === 0x60) {
     runToRTS = false
-    doSetRunMode(RUN_MODE.PAUSED, true, undefined, {reason: "run-to-return"})
+    doSetRunMode(RUN_MODE.PAUSED)
     return -1
   }
   return cycles

--- a/src/worker/memory.ts
+++ b/src/worker/memory.ts
@@ -520,7 +520,7 @@ export const memGet = (addr: number, checkWatchpoints = true): number => {
     }
   }
   if (checkWatchpoints && isWatchpoint(addr, value, false)) {
-    setWatchpointBreak()
+    setWatchpointBreak(addr)
   }
   return value
 }
@@ -588,7 +588,7 @@ export const memSet = (addr: number, value: number) => {
     memory[shifted + (addr & 255)] = value
   }
   if (isWatchpoint(addr, value, true)) {
-    setWatchpointBreak()
+    setWatchpointBreak(addr)
   }
 }
 

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -11,6 +11,12 @@ import { getCurrentDriveState } from "./devices/drivestate"
 import * as worker2main from "./worker2main"
 import { getSiriusJoyport } from "./devices/sirius_joyport"
 
+const getExecutionSnapshot = () => {
+  const execution = getExternalMachineState().execution
+  if (!execution) throw new Error("Expected an execution snapshot")
+  return execution
+}
+
 // Make sure we don't accidentally leave debug mode on.
 test("debugMode", () => {
   expect(TEST_DEBUG).toEqual(false)
@@ -352,9 +358,9 @@ test("execution snapshots record transitions and the breakpoint that stopped exe
 
   try {
     doSetRunMode(RUN_MODE.PAUSED, false)
-    const initialSequence = getExternalMachineState().execution.executionSequence
+    const initialSequence = getExecutionSnapshot().executionSequence
     doSetRunMode(RUN_MODE.RUNNING, false)
-    const running = getExternalMachineState().execution
+    const running = getExecutionSnapshot()
     expect(running).toEqual(expect.objectContaining({
       executionSequence: initialSequence + 1,
       state: "running",
@@ -373,7 +379,7 @@ test("execution snapshots record transitions and the breakpoint that stopped exe
     expect(processInstruction()).toEqual(2)
     expect(processInstruction()).toEqual(-1)
 
-    const stopped = getExternalMachineState().execution
+    const stopped = getExecutionSnapshot()
     expect(stopped).toEqual(expect.objectContaining({
       executionSequence: running.executionSequence + 1,
       state: "paused",
@@ -392,7 +398,7 @@ test("execution snapshots record transitions and the breakpoint that stopped exe
     expect(breakpointMap.has(0x6002)).toBe(true)
 
     doSetRunMode(RUN_MODE.PAUSED, false)
-    expect(getExternalMachineState().execution.executionSequence).toEqual(stopped.executionSequence)
+    expect(getExecutionSnapshot().executionSequence).toEqual(stopped.executionSequence)
 
     doSetRunMode(RUN_MODE.NEED_BOOT, false)
     expect(getExternalMachineState().execution).toEqual(stopped)
@@ -405,11 +411,11 @@ test("execution snapshots record transitions and the breakpoint that stopped exe
       pauseReason: null,
     }))
 
-    const runningSequence = getExternalMachineState().execution.executionSequence
+    const runningSequence = getExecutionSnapshot().executionSequence
     doSetRunMode(RUN_MODE.NEED_BOOT, false)
     doSetRunMode(RUN_MODE.NEED_RESET, false)
     doSetRunMode(RUN_MODE.RUNNING, false)
-    expect(getExternalMachineState().execution.executionSequence).toEqual(runningSequence)
+    expect(getExecutionSnapshot().executionSequence).toEqual(runningSequence)
 
   } finally {
     doSetBreakpoints(new BreakpointMap())
@@ -428,9 +434,9 @@ test("media-driven idle transitions publish one authoritative idle stop", () => 
 
   try {
     doSetRunMode(RUN_MODE.RUNNING, false)
-    const runningSequence = getExternalMachineState().execution.executionSequence
+    const runningSequence = getExecutionSnapshot().executionSequence
     doSetRunMode(RUN_MODE.IDLE, false)
-    const idle = getExternalMachineState().execution
+    const idle = getExecutionSnapshot()
     expect(idle).toEqual(expect.objectContaining({
       executionSequence: runningSequence + 1,
       state: "paused",

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -3,7 +3,7 @@ import { getAuxCardEnabled, getHires, memGet, memSet, memory, setAuxCardEnabled,
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
-import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, getExternalMachineState, getExternalMemoryView, resetCpuSpeedForTesting } from "./motherboard"
+import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, doStepOver, getExternalMachineState, getExternalMemoryView, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
@@ -457,6 +457,7 @@ test("execution snapshots identify the watchpoint that stopped execution", () =>
   setIsTesting()
   const watchpointAddress = 0x03A4
   const previousByte = memGet(watchpointAddress, false)
+  const previousProgram = memory.slice(0x6000, 0x6003)
   const watchpoints = new BreakpointMap()
   const watchpoint = BreakpointNew()
   watchpoint.address = watchpointAddress
@@ -466,8 +467,10 @@ test("execution snapshots identify the watchpoint that stopped execution", () =>
   try {
     doSetBreakpoints(watchpoints)
     doSetRunMode(RUN_MODE.RUNNING, false)
+    memory.set([0x20, 0x00, 0x60], 0x6000)
+    setPC(0x6000)
     memSet(watchpointAddress, 0x5A)
-    expect(processInstruction()).toEqual(-1)
+    doStepOver()
     expect(getExternalMachineState().execution).toEqual(expect.objectContaining({
       state: "paused",
       pauseReason: "watchpoint",
@@ -475,8 +478,46 @@ test("execution snapshots identify the watchpoint that stopped execution", () =>
     }))
   } finally {
     doSetBreakpoints(new BreakpointMap())
+    memory.set(previousProgram, 0x6000)
     memSet(watchpointAddress, previousByte)
     doSetRunMode(RUN_MODE.PAUSED, false)
+    resetCpuSpeedForTesting()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  }
+})
+
+test("execution snapshots report hidden stepping traps as steps", () => {
+  jest.useFakeTimers()
+  setIsTesting()
+  const previousState = getExternalMachineState()
+  const previousBytes = memory.slice(0x6000, 0x6003)
+  const breakpoints = new BreakpointMap()
+  const stepTrap = BreakpointNew()
+  stepTrap.address = 0x6002
+  stepTrap.hidden = true
+  stepTrap.once = true
+  breakpoints.set(stepTrap.address, stepTrap)
+
+  try {
+    doSetBreakpoints(breakpoints)
+    doSetRunMode(RUN_MODE.RUNNING, false)
+    memory.set([0xA9, 0x00, 0xEA], 0x6000)
+    setPC(0x6000)
+    expect(processInstruction()).toEqual(2)
+    expect(s6502.PC).toEqual(0x6002)
+    expect(breakpointMap.has(0x6002)).toEqual(true)
+    expect(processInstruction()).toEqual(-1)
+    expect(getExternalMachineState().execution).toEqual(expect.objectContaining({
+      state: "paused",
+      pauseReason: "step",
+      breakpoint: null,
+      PC: 0x6002,
+    }))
+  } finally {
+    doSetBreakpoints(new BreakpointMap())
+    memory.set(previousBytes, 0x6000)
+    doSetRunMode(previousState.runMode, false)
     resetCpuSpeedForTesting()
     jest.clearAllTimers()
     jest.useRealTimers()

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -1,5 +1,5 @@
 import { BREAKPOINT_RESULT, breakpointMap, doSetBreakpoints, hitBreakpoint, processInstruction } from "./cpu6502"
-import { getAuxCardEnabled, getHires, memGet, memory, setAuxCardEnabled, updateAddressTables } from "./memory"
+import { getAuxCardEnabled, getHires, memGet, memSet, memory, setAuxCardEnabled, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
@@ -333,6 +333,121 @@ test("run changes complete after publishing their state", () => {
     passMachineState.mockRestore()
     passOperationResult.mockRestore()
     doSetRunMode(previousState.runMode)
+  }
+})
+
+test("execution snapshots record transitions and the breakpoint that stopped execution", () => {
+  jest.useFakeTimers()
+  setIsTesting()
+  const previousState = getExternalMachineState()
+  const previousBytes = memory.slice(0x6000, 0x6002)
+  const breakpoints = new BreakpointMap()
+  const breakpoint = BreakpointNew()
+  breakpoint.address = 0x6001
+  breakpoint.once = true
+  breakpoints.set(breakpoint.address, breakpoint)
+  const failureBreakpoint = BreakpointNew()
+  failureBreakpoint.address = 0x6002
+  breakpoints.set(failureBreakpoint.address, failureBreakpoint)
+
+  try {
+    doSetRunMode(RUN_MODE.PAUSED, false)
+    const initialSequence = getExternalMachineState().execution.executionSequence
+    doSetRunMode(RUN_MODE.RUNNING, false)
+    const running = getExternalMachineState().execution
+    expect(running).toEqual(expect.objectContaining({
+      executionSequence: initialSequence + 1,
+      state: "running",
+      pauseReason: null,
+      breakpoint: null,
+    }))
+
+    memory.set([0xEA, 0xEA], 0x6000)
+    setPC(0x6000)
+    s6502.Accum = 0x41
+    s6502.XReg = 0x42
+    s6502.YReg = 0x43
+    s6502.StackPtr = 0xF0
+    s6502.PStatus = 0x24
+    doSetBreakpoints(breakpoints)
+    expect(processInstruction()).toEqual(2)
+    expect(processInstruction()).toEqual(-1)
+
+    const stopped = getExternalMachineState().execution
+    expect(stopped).toEqual(expect.objectContaining({
+      executionSequence: running.executionSequence + 1,
+      state: "paused",
+      pauseReason: "breakpoint",
+      breakpoint: {breakpointId: "bp:24577", address: 0x6001},
+      PC: 0x6001,
+      A: 0x41,
+      X: 0x42,
+      Y: 0x43,
+      S: 0xF0,
+      PStatus: 0x24,
+      machineName: previousState.machineName,
+      memoryConfiguration: expect.objectContaining({ramWorksKb: previousState.extraRamSize}),
+    }))
+    expect(breakpointMap.has(0x6001)).toBe(false)
+    expect(breakpointMap.has(0x6002)).toBe(true)
+
+    doSetRunMode(RUN_MODE.PAUSED, false)
+    expect(getExternalMachineState().execution.executionSequence).toEqual(stopped.executionSequence)
+
+    doSetRunMode(RUN_MODE.NEED_BOOT, false)
+    expect(getExternalMachineState().execution).toEqual(stopped)
+    doSetRunMode(RUN_MODE.NEED_RESET, false)
+    expect(getExternalMachineState().execution).toEqual(stopped)
+    doSetRunMode(RUN_MODE.RUNNING, false)
+    expect(getExternalMachineState().execution).toEqual(expect.objectContaining({
+      executionSequence: stopped.executionSequence + 1,
+      state: "running",
+      pauseReason: null,
+    }))
+
+    const runningSequence = getExternalMachineState().execution.executionSequence
+    doSetRunMode(RUN_MODE.NEED_BOOT, false)
+    doSetRunMode(RUN_MODE.NEED_RESET, false)
+    doSetRunMode(RUN_MODE.RUNNING, false)
+    expect(getExternalMachineState().execution.executionSequence).toEqual(runningSequence)
+  } finally {
+    doSetBreakpoints(new BreakpointMap())
+    memory.set(previousBytes, 0x6000)
+    doSetRunMode(previousState.runMode, false)
+    resetCpuSpeedForTesting()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  }
+})
+
+test("execution snapshots identify the watchpoint that stopped execution", () => {
+  jest.useFakeTimers()
+  setIsTesting()
+  const watchpointAddress = 0x03A4
+  const previousByte = memGet(watchpointAddress, false)
+  const watchpoints = new BreakpointMap()
+  const watchpoint = BreakpointNew()
+  watchpoint.address = watchpointAddress
+  watchpoint.watchpoint = true
+  watchpoints.set(watchpointAddress, watchpoint)
+
+  try {
+    doSetBreakpoints(watchpoints)
+    doSetRunMode(RUN_MODE.RUNNING, false)
+    memSet(watchpointAddress, 0x5A)
+    expect(processInstruction()).toEqual(-1)
+    expect(getExternalMachineState().execution).toEqual(expect.objectContaining({
+      state: "paused",
+      pauseReason: "watchpoint",
+      breakpoint: {breakpointId: `bp:${watchpointAddress}`, address: watchpointAddress},
+    }))
+  } finally {
+    doSetBreakpoints(new BreakpointMap())
+    memSet(watchpointAddress, previousByte)
+    doSetRunMode(RUN_MODE.PAUSED, false)
+    resetCpuSpeedForTesting()
+    jest.clearAllTimers()
+    jest.useRealTimers()
   }
 })
 

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -410,10 +410,42 @@ test("execution snapshots record transitions and the breakpoint that stopped exe
     doSetRunMode(RUN_MODE.NEED_RESET, false)
     doSetRunMode(RUN_MODE.RUNNING, false)
     expect(getExternalMachineState().execution.executionSequence).toEqual(runningSequence)
+
   } finally {
     doSetBreakpoints(new BreakpointMap())
     memory.set(previousBytes, 0x6000)
     doSetRunMode(previousState.runMode, false)
+    resetCpuSpeedForTesting()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  }
+})
+
+test("media-driven idle transitions publish one authoritative idle stop", () => {
+  jest.useFakeTimers()
+  setIsTesting()
+  const previousRunMode = getExternalMachineState().runMode
+
+  try {
+    doSetRunMode(RUN_MODE.RUNNING, false)
+    const runningSequence = getExternalMachineState().execution.executionSequence
+    doSetRunMode(RUN_MODE.IDLE, false)
+    const idle = getExternalMachineState().execution
+    expect(idle).toEqual(expect.objectContaining({
+      executionSequence: runningSequence + 1,
+      state: "paused",
+      pauseReason: "idle",
+      breakpoint: null,
+    }))
+
+    doSetRunMode(RUN_MODE.IDLE, false)
+    expect(getExternalMachineState().execution).toEqual(idle)
+    doSetRunMode(RUN_MODE.NEED_BOOT, false)
+    expect(getExternalMachineState().execution).toEqual(idle)
+    doSetRunMode(RUN_MODE.NEED_RESET, false)
+    expect(getExternalMachineState().execution).toEqual(idle)
+  } finally {
+    doSetRunMode(previousRunMode, false)
     resetCpuSpeedForTesting()
     jest.clearAllTimers()
     jest.useRealTimers()

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -61,6 +61,10 @@ export const getCpuRunMode = () => cpuRunMode
 
 let pendingRunModeOperation: number | undefined
 let cyclesToRun = 0
+let executionSequence = 0
+let executionState: "running" | "paused" = "paused"
+let executionPauseReason: ExecutionPauseReason | null = "idle"
+let executionBreakpointAddress: number | null = null
 let nextFrameTime = 0
 let machineName: MACHINE_NAME = "APPLE2EE"
 let veraSlot: VERA_SLOT = 0
@@ -551,7 +555,7 @@ export const doStepInto = () => {
   // Remove all tracelog values if we are no longer tracing.
   if (!tracing) clearTracelog()
   processInstruction(tracing ? updateTrace : null)
-  doSetRunMode(RUN_MODE.PAUSED)
+  doSetRunMode(RUN_MODE.PAUSED, true, undefined, {reason: "step"})
 }
 
 export const doStepOver = () => {
@@ -591,6 +595,7 @@ export const doSetRunMode = (
   cpuRunModeIn: RUN_MODE,
   doShowDebugTab = true,
   operationId?: number,
+  stop?: ExecutionStopDescriptor,
 ) => {
   if (pendingRunModeOperation !== undefined && pendingRunModeOperation !== operationId) {
     passWorkerOperationResult(pendingRunModeOperation, "Worker operation was superseded")
@@ -602,6 +607,20 @@ export const doSetRunMode = (
     showDebugTab = true
   }
   cpuRunMode = cpuRunModeIn
+  if (cpuRunMode === RUN_MODE.RUNNING && executionState !== "running") {
+    executionSequence++
+    executionState = "running"
+    executionPauseReason = null
+    executionBreakpointAddress = null
+  } else if (
+    cpuRunMode === RUN_MODE.PAUSED
+    && (executionState !== "paused" || stop !== undefined)
+  ) {
+    executionSequence++
+    executionState = "paused"
+    executionPauseReason = stop?.reason ?? "explicit"
+    executionBreakpointAddress = stop?.breakpointAddress ?? null
+  }
   if (cpuRunMode === RUN_MODE.PAUSED) {
     syncSoftSwitchStatusFlags()
     if (gameSetupTimerID) {
@@ -737,6 +756,26 @@ export const getExternalMachineState = () => {
     cout: memGet(0x0039, false) << 8 | memGet(0x0038, false),
     cpuSpeed: cpuSpeed,
     extraRamSize: 64 * (RamWorksMaxBank + 1),
+    execution: {
+      executionSequence,
+      state: executionState,
+      pauseReason: executionPauseReason,
+      breakpoint: executionBreakpointAddress === null ? null : {
+        breakpointId: `bp:${executionBreakpointAddress}`,
+        address: executionBreakpointAddress,
+      },
+      PC: s6502.PC,
+      A: s6502.Accum,
+      X: s6502.XReg,
+      Y: s6502.YReg,
+      S: s6502.StackPtr,
+      PStatus: s6502.PStatus,
+      machineName,
+      memoryConfiguration: {
+        slot3Card: currentSlotConfig[3],
+        ramWorksKb: 64 * (RamWorksMaxBank + 1),
+      },
+    },
     hires: getHires(),
     iTempState: getTempStateIndex(),
     isDebugging: isDebugging,
@@ -853,7 +892,7 @@ const doAdvance6502 = () => {
     }
     if (cyclesToRun > 0 && (s6502.cycleCount - cycleToRunStart) >= cyclesToRun) {
       cyclesToRun = 0
-      doSetRunMode(RUN_MODE.PAUSED)
+      doSetRunMode(RUN_MODE.PAUSED, true, undefined, {reason: "cycle-limit"})
       break
     }
     if (cycleTotal >= cpuCyclesPerRefresh) {

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -554,8 +554,9 @@ export const doStepInto = () => {
   }
   // Remove all tracelog values if we are no longer tracing.
   if (!tracing) clearTracelog()
-  processInstruction(tracing ? updateTrace : null)
-  doSetRunMode(RUN_MODE.PAUSED, true, undefined, {reason: "step"})
+  if (processInstruction(tracing ? updateTrace : null) !== -1) {
+    doSetRunMode(RUN_MODE.PAUSED, true, undefined, {reason: "step"})
+  }
 }
 
 export const doStepOver = () => {
@@ -568,8 +569,7 @@ export const doStepOver = () => {
     // Remove all tracelog values if we are no longer tracing.
     if (!tracing) clearTracelog()
     // If we're at a JSR then briefly step in, then step out.
-    processInstruction(tracing ? updateTrace : null)
-    doStepOut()
+    if (processInstruction(tracing ? updateTrace : null) !== -1) doStepOut()
   } else {
     // Otherwise just do a single step.
     doStepInto()

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -620,6 +620,14 @@ export const doSetRunMode = (
     executionState = "paused"
     executionPauseReason = stop?.reason ?? "explicit"
     executionBreakpointAddress = stop?.breakpointAddress ?? null
+  } else if (
+    cpuRunMode === RUN_MODE.IDLE
+    && (executionState !== "paused" || executionPauseReason !== "idle")
+  ) {
+    executionSequence++
+    executionState = "paused"
+    executionPauseReason = "idle"
+    executionBreakpointAddress = null
   }
   if (cpuRunMode === RUN_MODE.PAUSED) {
     syncSoftSwitchStatusFlags()


### PR DESCRIPTION
## Cross-repository change

This change will be paired with an Apple2TS Server change that exposes the execution snapshot and allows MCP clients to wait for a subsequent stop.

## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per issue #218.

This change gives remote controllers a coherent conversation with the emulator about execution: they can start or resume it, then receive one worker-confirmed account of when, where, and why it stopped.

It intentionally reuses existing worker paths for run-state transitions, breakpoint and watchpoint detection, CPU state, and machine-state publication. It efficiently bundles those facts into one coherent snapshot when execution changes and routes it through the existing remote-control path used by MCP.

## What was implemented in this slice

- Publish a coherent execution snapshot when worker execution changes.
- Identify explicit pauses, idle state, breakpoints, watchpoints, stepping, and cycle-limit stops.
- Include the causal breakpoint or watchpoint, CPU registers, machine model, and memory configuration.
- Maintain a monotonic execution sequence across worker replacement within one renderer.
- Preserve causal stops when stepping encounters a breakpoint or watchpoint.

## Verification

- Covered execution transitions, stop causes, worker replacement, and remote-control publication.
- The complete Apple2TS test suite passes.