### PR TITLE
feat(remote-control): confirm mapped memory writes

### DIFF
--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -101,6 +101,7 @@ export enum MSG_MAIN {
   RUN_BINARY,
   LOAD_BINARY,
   GET_MEMORY_VIEW,
+  WRITE_MEMORY,
 }
 
 export const DEFAULT_SLOT_CONFIG: SlotConfig = {

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -32,6 +32,7 @@ import {
   passSetBinaryBlock,
   requestSetState6502,
   passSetMemory,
+  requestWriteMemory,
   passSetSoftSwitches,
   passStepInto,
   passStepOut,
@@ -501,6 +502,13 @@ export const executeCommand = async (action: string, payload: Record<string, unk
 
     case "setMemory":
       passSetMemory(Number(payload.address), Number(payload.value))
+      return collectStatus()
+
+    case "writeMemory":
+      await requestWriteMemory(
+        Number(payload.address),
+        Uint8Array.from(payload.data as number[]),
+      )
       return collectStatus()
 
     case "setCpuState":

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -9,6 +9,7 @@ import {
   requestSpeedMode,
   requestMemoryView,
   setExecutionStateCallback,
+  requestWriteMemory,
   setMain2Worker,
 } from "./main2worker"
 
@@ -136,6 +137,19 @@ describe("worker operations", () => {
     expect(message).toEqual(expect.objectContaining({
       msg: MSG_MAIN.STATE6502,
       payload: state,
+    }))
+
+    sendOperationResult(message.operationId)
+    await expect(operation).resolves.toBeUndefined()
+  })
+
+  test("sends mapped memory writes as confirmed worker operations", async () => {
+    const data = Uint8Array.from([0x42, 0x43])
+    const operation = requestWriteMemory(0x0200, data)
+    const message = worker.postMessage.mock.calls.at(-1)[0]
+    expect(message).toEqual(expect.objectContaining({
+      msg: MSG_MAIN.WRITE_MEMORY,
+      payload: {address: 0x0200, data},
     }))
 
     sendOperationResult(message.operationId)

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -285,6 +285,10 @@ export const passSetMemory = (address: number, value: number) => {
   doPostMessage(MSG_MAIN.SET_MEMORY, {address, value})
 }
 
+export const requestWriteMemory = (address: number, data: Uint8Array, timeoutMs = 5000) => {
+  return requestWorkerOperation(MSG_MAIN.WRITE_MEMORY, {address, data}, timeoutMs)
+}
+
 export const passRxCommData = (data: Uint8Array) => {
   doPostMessage(MSG_MAIN.COMM_DATA, data)
 }

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -3,7 +3,7 @@ import { getAuxCardEnabled, getHires, memGet, memSet, memory, setAuxCardEnabled,
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
-import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, doStepOver, getExternalMachineState, getExternalMemoryView, resetCpuSpeedForTesting } from "./motherboard"
+import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, doStepOver, doWriteMemory, getExternalMachineState, getExternalMemoryView, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
@@ -549,6 +549,73 @@ test("CPU state changes complete after publishing their state", () => {
     passMachineState.mockRestore()
     passOperationResult.mockRestore()
     doSetState6502(previousState)
+  }
+})
+
+test("mapped memory writes use active soft switches before completing", () => {
+  setIsTesting()
+  const address = 0x0200
+  const auxAddress = RamWorksMemoryStart + address
+  const previousMain = memory[address]
+  const previousAux = memory[auxAddress]
+  const previousRamWrite = SWITCHES.RAMWRT.isSet
+  const passMachineState = jest.spyOn(worker2main, "passMachineState")
+  const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
+
+  try {
+    SWITCHES.RAMWRT.isSet = false
+    updateAddressTables()
+    memory[address] = 0x11
+    memory[auxAddress] = 0x22
+
+    doWriteMemory(0xC005, Uint8Array.of(0), 12)
+    expect(SWITCHES.RAMWRT.isSet).toEqual(true)
+    expect(passOperationResult).toHaveBeenCalledWith(12)
+    passMachineState.mockClear()
+    passOperationResult.mockClear()
+
+    doWriteMemory(address, Uint8Array.of(0x42), 13)
+    expect(memory[address]).toEqual(0x11)
+    expect(memory[auxAddress]).toEqual(0x42)
+    expect(passOperationResult).toHaveBeenCalledWith(13)
+    expect(passMachineState.mock.invocationCallOrder[0]).toBeLessThan(
+      passOperationResult.mock.invocationCallOrder[0],
+    )
+  } finally {
+    SWITCHES.RAMWRT.isSet = previousRamWrite
+    updateAddressTables()
+    memory[address] = previousMain
+    memory[auxAddress] = previousAux
+    passMachineState.mockRestore()
+    passOperationResult.mockRestore()
+  }
+})
+
+test("mapped memory writes report worker errors", () => {
+  setIsTesting()
+  const passOperationResult = jest.spyOn(worker2main, "passWorkerOperationResult")
+  const oldState = SWITCHES.RAMWRT.isSet
+
+  try {
+    Object.defineProperty(SWITCHES.RAMWRT, "isSet", {
+      configurable: true,
+      get: () => oldState,
+      set: () => { throw new Error("switch failed") },
+    })
+
+    doWriteMemory(0xC005, Uint8Array.of(0), 14)
+    expect(passOperationResult).toHaveBeenCalledWith(
+      14,
+      "Memory write processed 0 of 1 bytes; the next byte and earlier writes may have taken effect. switch failed",
+    )
+  } finally {
+    Object.defineProperty(SWITCHES.RAMWRT, "isSet", {
+      configurable: true,
+      writable: true,
+      value: oldState,
+    })
+    updateAddressTables()
+    passOperationResult.mockRestore()
   }
 })
 

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -438,6 +438,24 @@ export const doSetMemory = (addr: number, value: number) => {
   updateExternalMachineState()
 }
 
+export const doWriteMemory = (addr: number, data: Uint8Array, operationId?: number) => {
+  let bytesProcessed = 0
+  try {
+    for (const value of data) {
+      memSet(addr + bytesProcessed, value)
+      bytesProcessed += 1
+    }
+    refreshMemoryBlock(addr, data.length)
+    if (operationId !== undefined) passWorkerOperationResult(operationId)
+  } catch (error) {
+    if (operationId === undefined) throw error
+    passWorkerOperationResult(
+      operationId,
+      `Memory write processed ${bytesProcessed} of ${data.length} bytes; the next byte and earlier writes may have taken effect. ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
 const refreshMemoryBlock = (addr: number, length: number) => {
   if (cpuRunMode === RUN_MODE.PAUSED) {
     const hiresLines = new Set<number>()

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -2,6 +2,7 @@ import { doSetRunMode, doSetSpeedMode,
   doStepInto, doStepOver, doStepOut, doSetBinaryBlock, doLoadBinary, doRunBinary, doSetIsDebugging, doSetState6502, doTakeSnapshot, doSetPastedText, forceSoftSwitches,
   forceVideo7Override,
   doSetMemory,
+  doWriteMemory,
   doSetMachineName,
   doSetRamWorks,
   doSetVeraSlot,
@@ -301,6 +302,11 @@ if (typeof self !== "undefined") {
       case MSG_MAIN.SET_MEMORY: {
         const setmem = e.data.payload
         doSetMemory(setmem.address, setmem.value)
+        break
+      }
+      case MSG_MAIN.WRITE_MEMORY: {
+        const setmem = e.data.payload
+        doWriteMemory(setmem.address, setmem.data, e.data.operationId)
         break
       }
       case MSG_MAIN.COMM_DATA:


### PR DESCRIPTION
## Cross-repository change

This change will be paired with Apple2TS Server PR ct6502/apple2ts-server#14, which exposes bounded CPU-visible memory writes through MCP.

## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per issue #218.

This change gives remote controllers a confirmed way to apply a small block through the emulator's active memory mapping.

## What was implemented in this slice

- Added a block-oriented `writeMemory` remote-control action using the existing confirmed worker-operation path.
- Processed each address in order through the existing CPU-visible memory path, preserving bank selection and I/O or soft-switch effects.
- Published the resulting machine state before confirming completion.
- Reported how many bytes were processed if an operation stopped after partial effects.
