### PR TITLE
feat(demozoo): self-contained DemoZoo snapshot & multi-tiered direct download support (PURE GITHUB PAGE NOW!)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,19 @@
 - Support MC6845 CRTC hardware scrolling (R12/R13 start address) and cursor positioning (R14/R15) for CP/M and terminal software.
 - Enable full ASCII lowercase support in 80-column mode on Apple II+ models.
 - Support genuine Videx card identification signatures in Slot 3 ROM ($C30B=0x01, $C30C=0x82) for peripheral card detectors (such as Card Cat) and Microsoft Z80 CP/M BIOS.
+- Add self-contained DemoZoo catalog snapshot bundled in `public/data/demozoo_snapshot.json` with pre-fetched direct download links, enabling DemoZoo catalog browsing and search on GitHub Pages and static web hosts with zero proxy server configuration.
+- Display snapshot creation date badge (`Snapshot at YYYY/MM/DD`) in the DemoZoo dialog header.
+- Add generic Wayback Machine raw stream fallback (`web.archive.org/web/0id_/`) for offline or broken external disk image download links.
+- Add dedicated Internet Archive `archive.org/cors/` endpoint fallback for IA disk downloads to ensure permissive CORS headers across all global storage nodes.
+- Add a 2-second "Unable to Download!" notification badge in the DemoZoo dialog header when all download sources fail.
 
 **Fixed bugs:**
 
 - Fix ProDOS boot freeze on Apple II+ with Slot 3 cards by preventing premature I/O activation and avoiding slot scan conflicts with disk controller firmware.
 - Fix CP/M 80-column screen corruption and solid white attribute boxes caused by inverted ASCII character rendering.
+- Eliminate external `pages.dev` proxy runtime dependencies on static deployments.
+- Filter out non-disk media links (.mp4, .mov, .webm, etc.) from DemoZoo download candidates.
+- Automatically normalize upstream scene.org download URLs and fix typos (e.g., `marqueedesign_`).
 
 ## [v3.5.2](https://github.com/ct6502/apple2ts/tree/v3.5.2) (2026-08-06)
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ Apple2TS uses its built-in software synthesizer by default. Selecting **Enable E
 
 ### DemoZoo Testing
 
-The Cloudflare Pages workflow is opt-in and requires the following repository configuration:
+DemoZoo uses a bundled pre-fetched snapshot (`public/data/demozoo_snapshot.json`) with pre-resolved direct download links, allowing DemoZoo catalog browsing, searching, and downloads to work out of the box on static hosts (such as GitHub Pages) and Cloudflare Pages without requiring external proxy configuration.
+
+The optional Cloudflare Pages workflow is opt-in and requires the following repository configuration:
 
 - **Required repository variable:** `CLOUDFLARE_PAGES_ENABLED=true`
 - **Required repository secret:** `CLOUDFLARE_API_TOKEN`, containing a Cloudflare API token that can deploy to Pages
@@ -212,17 +214,12 @@ The Cloudflare Pages workflow is opt-in and requires the following repository co
 
 The Cloudflare Pages project must be created in the specified Cloudflare account before the workflow runs. The API token and account ID are configured in GitHub under **Settings → Secrets and variables → Actions**. The enable flag and project name are repository variables; the API token and account ID are repository secrets. Repositories that do not set `CLOUDFLARE_PAGES_ENABLED=true` skip the Cloudflare deployment and are unaffected.
 
-1. On the Cloudflare Pages deployment, refresh the browser, click on hard drive 1, choose _Load Disk from DemoZoo_, and verify that the DemoZoo production list opens with screenshots and page navigation.
-1. Use the type filters (Demo, Game, Intro, Cracktro, and Music), then open a production and verify that its disk image loads and boots.
+1. Refresh the browser, click on floppy/hard drive, choose _Load Disk from DemoZoo_, and verify that the DemoZoo production list opens immediately with screenshots, page navigation, and a `Snapshot at YYYY/MM/DD` badge in the header.
+1. Use the type filters (All, Demo, Intro, Cracktro, and Music) or search query, then open a production and verify that its disk image loads and boots.
 1. Open a production with only a YouTube link and verify that the confirmation dialog opens a new browser tab when accepted.
-1. Open a production whose DemoZoo download link is an external project page, such as Brutal Deluxe or another provider, and verify that the direct `.dsk`, `.woz`, `.po`, or `.zip` image is discovered and loaded.
-1. Test a production with multiple download links where the first source is unavailable, and verify that the next working disk-image link is tried automatically.
-1. Refresh the browser and repeat the test with another production to verify that the disk is replaced and the new production boots.
-1. On a GitHub Pages deployment, DemoZoo can be enabled with an external proxy. Set these repository variables under **Settings → Secrets and variables → Actions → Variables**:
-   - `VITE_DEMOZOO_ENABLED=true`
-   - `VITE_DEMOZOO_PROXY_URL=https://<your-proxy-project>.pages.dev`
-   The proxy project must expose the DemoZoo and disk proxy endpoints used by Apple2TS. The frontend then routes DemoZoo/API, external download-page, and disk-image requests through that proxy, avoiding browser CORS restrictions.
-2. On the Cloudflare Pages deployment, DemoZoo uses the same-origin Pages Functions and does not require `VITE_DEMOZOO_PROXY_URL`. Verify that the DemoZoo production list opens with screenshots and page navigation.
+1. Open a production whose DemoZoo download link is an external project page (e.g., scene.org, Brutal Deluxe) and verify that the direct `.dsk`, `.woz`, `.po`, or `.zip` image is discovered and loaded.
+1. Test a production with multiple download links or broken historical links, and verify that fallback candidates (including Internet Archive `/cors/` endpoint and Wayback Machine snapshots `web.archive.org/web/0id_/`) are tried automatically.
+1. Test an unavailable production without valid disk images, and verify that the header displays an `Unable to Download!` warning badge for 2 seconds before returning to the catalog view.
 
 
 ## Localhost Certificates

--- a/public/data/demozoo_snapshot.json
+++ b/public/data/demozoo_snapshot.json
@@ -1,6 +1,6 @@
 {
   "source": "https://demozoo.org/productions/?platform=67&production_type=",
-  "generatedAt": "2026-08-22T16:29:07.248Z",
+  "generatedAt": "2026-09-04T14:27:27.432Z",
   "pageSize": 50,
   "pageCount": 23,
   "pages": [
@@ -17,7 +17,12 @@
           "year": "2026",
           "screenshotUrl": "https://media.demozoo.org/screens/t/72/05/ceb5.386482.jpg",
           "demozooUrl": "https://demozoo.org/productions/394848/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://marqueedesign.demoscene.com/releases/marqueedesign_visor.zip",
+          "downloadUrls": [
+            "https://marqueedesign.demoscene.com/releases/marqueedesign_visor.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=eFasZGmAmQI"
         },
         {
           "id": 391658,
@@ -29,7 +34,13 @@
           "year": "2026",
           "screenshotUrl": "https://media.demozoo.org/screens/t/97/be/93ae.381666.jpg",
           "demozooUrl": "https://demozoo.org/productions/391658/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://deater.net/weave/vmwprod/outline_2026/hectic_small.zip",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/outline_2026/hectic_small.zip",
+            "https://archive.scene.org/pub/parties/2026/outline26/256_byte_intro_oldskool/hectic.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=EckNqHRYa8I"
         },
         {
           "id": 385104,
@@ -41,7 +52,13 @@
           "year": "2026",
           "screenshotUrl": "https://media.demozoo.org/screens/t/39/df/d5e8.375402.jpg",
           "demozooUrl": "https://demozoo.org/productions/385104/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/rain/rain.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/rain/rain.dsk",
+            "https://archive.scene.org/pub/demos/groups/vmw/rain.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=DGcj_Xp9E70"
         },
         {
           "id": 383971,
@@ -53,7 +70,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/00/ad/a57b.374731.jpg",
           "demozooUrl": "https://demozoo.org/productions/383971/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/circfruit_appleii_graforth_449b_vc3-2025.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/circfruit_appleii_graforth_449b_vc3-2025.zip"
+          ]
         },
         {
           "id": 384032,
@@ -65,7 +86,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d0/ba/b39a.374749.jpg",
           "demozooUrl": "https://demozoo.org/productions/384032/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/circfruit_appleii_cc65_760b_vc3-2025.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/circfruit_appleii_cc65_760b_vc3-2025.zip"
+          ]
         },
         {
           "id": 383903,
@@ -77,7 +102,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7f/ed/fb4d.374664.jpg",
           "demozooUrl": "https://demozoo.org/productions/383903/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/mmphosis_appleii_applesoft_148b_vc3-2025.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/mmphosis_appleii_applesoft_148b_vc3-2025.zip"
+          ]
         },
         {
           "id": 383842,
@@ -89,7 +118,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ef/e9/f34f.374603.png",
           "demozooUrl": "https://demozoo.org/productions/383842/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/kgjenkins_appleii_6502assembler_82b_vc3-2025.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/kgjenkins_appleii_6502assembler_82b_vc3-2025.zip"
+          ]
         },
         {
           "id": 383848,
@@ -101,7 +134,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9a/74/bea2.374609.jpg",
           "demozooUrl": "https://demozoo.org/productions/383848/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/jerrypenner_appleii_6502assembler_87b_vc3-2025.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/jerrypenner_appleii_6502assembler_87b_vc3-2025.zip"
+          ]
         },
         {
           "id": 383826,
@@ -113,7 +150,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/64/5d/47bc.374472.jpg",
           "demozooUrl": "https://demozoo.org/productions/383826/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/colinleroy-mira_appleii_6502assemblerca65_73b_vc3-2025.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/vccc25/christmas_challenge/colinleroy-mira_appleii_6502assemblerca65_73b_vc3-2025.zip"
+          ]
         },
         {
           "id": 379796,
@@ -125,7 +166,12 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/86/58/c98e.368745.jpg",
           "demozooUrl": "https://demozoo.org/productions/379796/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/demosplash25/retro_demo/monster_splash.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/demosplash25/retro_demo/monster_splash.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=2cab1ovvzq8"
         },
         {
           "id": 377643,
@@ -137,7 +183,12 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/48/da/3637.366357.jpg",
           "demozooUrl": "https://demozoo.org/productions/377643/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/t0ad25/oldschool_demo/applestigation-lethargy-.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/t0ad25/oldschool_demo/applestigation-lethargy-.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=sBV7pFpnks8"
         },
         {
           "id": 374879,
@@ -149,7 +200,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/16/72/2143.363903.jpg",
           "demozooUrl": "https://demozoo.org/productions/374879/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://marqueedesign.demoscene.com/releases/marqueedesign_interlaced.zip",
+          "downloadUrls": [
+            "https://marqueedesign.demoscene.com/releases/marqueedesign_interlaced.zip"
+          ]
         },
         {
           "id": 372875,
@@ -161,7 +216,12 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/fa/c4/a538.361715.jpg",
           "demozooUrl": "https://demozoo.org/productions/372875/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/outline25/demo_oldskool/a2_scroll_block.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/outline25/demo_oldskool/a2_scroll_block.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=f14JTiWg_2M"
         },
         {
           "id": 372858,
@@ -173,7 +233,13 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f7/89/0caa.361714.jpg",
           "demozooUrl": "https://demozoo.org/productions/372858/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/outline25/256_byte_intro_oldskool/a2_starpath.7z",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/outline25/256_byte_intro_oldskool/a2_starpath.7z",
+            "https://archive.scene.org/pub/parties/2025/outline25/256_byte_intro_oldskool/a2_starpath.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=iTF9aoQKhhc"
         },
         {
           "id": 379921,
@@ -185,7 +251,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/fe/4b/2e6b.368854.jpg",
           "demozooUrl": "https://demozoo.org/productions/379921/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/kontrabant2/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/kontrabant2/"
+          ]
         },
         {
           "id": 379922,
@@ -197,7 +267,11 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8f/69/974d.368855.jpg",
           "demozooUrl": "https://demozoo.org/productions/379922/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/kontrabant/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/kontrabant/"
+          ]
         },
         {
           "id": 384173,
@@ -209,7 +283,12 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/74/1e/4f50.375039.jpg",
           "demozooUrl": "https://demozoo.org/productions/384173/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://deater.net/weave/vmwprod/starpath/starpath.dsk",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/starpath/starpath.dsk",
+            "https://archive.scene.org/pub/demos/groups/vmw/starpath.zip"
+          ]
         },
         {
           "id": 367668,
@@ -221,7 +300,13 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ac/fe/6921.357669.jpg",
           "demozooUrl": "https://demozoo.org/productions/367668/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/rev-cycle.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/rev-cycle.zip",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/rev-cycle-video.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=JJ2YcnnkJMQ&t=818"
         },
         {
           "id": 367691,
@@ -233,7 +318,14 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8f/a6/44fb.357555.jpg",
           "demozooUrl": "https://demozoo.org/productions/367691/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lovebyte_2025/blackhole_64.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lovebyte_2025/blackhole_64.dsk",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/64_byte_intro_oldschool/blackhole_64.zip",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/64_byte_intro_oldschool/blackhole_64_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=5_2k9QqxFqU"
         },
         {
           "id": 367724,
@@ -245,7 +337,14 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/70/3d/3e87.357556.jpg",
           "demozooUrl": "https://demozoo.org/productions/367724/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lovebyte_2025/tri_scroll.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lovebyte_2025/tri_scroll.dsk",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/128_byte_intro_oldschool/tri_scroll.zip",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/128_byte_intro_oldschool/tri_scroll_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=FiX5XqFo8EM"
         },
         {
           "id": 367672,
@@ -257,7 +356,14 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/24/ad/e799.357554.jpg",
           "demozooUrl": "https://demozoo.org/productions/367672/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lovebyte_2025/mad_compute_31.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lovebyte_2025/mad_compute_31.dsk",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/mad_compute_31.zip",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/mad_compute_31_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=aHlEyVuVM2w"
         },
         {
           "id": 367755,
@@ -269,7 +375,14 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a6/9c/3632.357553.jpg",
           "demozooUrl": "https://demozoo.org/productions/367755/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lovebyte_2025/heartbeat.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lovebyte_2025/heartbeat.dsk",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/256_byte_intro_oldschool/heartbeat256.zip",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/256_byte_intro_oldschool/heartbeat_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=N96xqFQUqH4"
         },
         {
           "id": 367667,
@@ -281,7 +394,13 @@
           "year": "2025",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5f/d5/d858.357670.png",
           "demozooUrl": "https://demozoo.org/productions/367667/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/litany-of-errors.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/litany-of-errors.zip",
+            "https://archive.scene.org/pub/parties/2025/lovebyte25/32_byte_intro_oldschool/litany-of-errors-video.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=JJ2YcnnkJMQ&t=59"
         },
         {
           "id": 364274,
@@ -293,7 +412,11 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/cc/29/7d15.355587.jpg",
           "demozooUrl": "https://demozoo.org/productions/364274/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/circfruit_apple%5D%5B_cc65_754b_vc3-2024.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/circfruit_apple%5D%5B_cc65_754b_vc3-2024.zip"
+          ]
         },
         {
           "id": 364275,
@@ -303,9 +426,13 @@
           "author": "circfruit",
           "dateStr": "Dec 2024",
           "year": "2024",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c4/96/8383.355590.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/fb/14/757e.355589.jpg",
           "demozooUrl": "https://demozoo.org/productions/364275/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/circfruit_apple2_lisp_552b_vc3-2024.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/circfruit_apple2_lisp_552b_vc3-2024.zip"
+          ]
         },
         {
           "id": 364264,
@@ -317,7 +444,11 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5c/d6/55bd.355572.jpg",
           "demozooUrl": "https://demozoo.org/productions/364264/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/billm_appleii_applesoft_232b_vc3-2024.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/billm_appleii_applesoft_232b_vc3-2024.zip"
+          ]
         },
         {
           "id": 364246,
@@ -329,7 +460,11 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3d/3b/eabe.355534.png",
           "demozooUrl": "https://demozoo.org/productions/364246/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/daspider_apple2_basic_149b_vc3-2024.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/daspider_apple2_basic_149b_vc3-2024.zip"
+          ]
         },
         {
           "id": 364242,
@@ -341,7 +476,11 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/92/d5/770c.355528.jpg",
           "demozooUrl": "https://demozoo.org/productions/364242/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/circfruit_apple2_ca65_146b_vc3-2024.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/vccc24/christmas_challenge/circfruit_apple2_ca65_146b_vc3-2024.zip"
+          ]
         },
         {
           "id": 361608,
@@ -353,7 +492,14 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7e/cd/b2c3.353227.jpg",
           "demozooUrl": "https://demozoo.org/productions/361608/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://deater.net/weave/vmwprod/driven/driven.dsk",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/driven/driven.dsk",
+            "https://archive.scene.org/pub/parties/2024/demosplash24/demo/driven.zip",
+            "https://archive.scene.org/pub/parties/2024/demosplash24/demo/driven_demo_for_apple_iie__q6i0-fsvzbe_.mkv"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Q6I0-FSVzBE"
         },
         {
           "id": 361607,
@@ -365,7 +511,14 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9c/f6/ed1a.353189.jpg",
           "demozooUrl": "https://demozoo.org/productions/361607/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://github.com/Fr3nchT0uch/DIX/releases/download/v1.0/DIX.zip",
+          "downloadUrls": [
+            "https://github.com/Fr3nchT0uch/DIX/releases/download/v1.0/DIX.zip",
+            "https://archive.scene.org/pub/parties/2024/demosplash24/demo/dix.zip",
+            "https://archive.scene.org/pub/parties/2024/demosplash24/demo/dix-1080p-hls.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=g4apr_G3Tbw"
         },
         {
           "id": 379929,
@@ -375,9 +528,13 @@
           "author": "Brutal Deluxe",
           "dateStr": "Nov 2024",
           "year": "2024",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4f/21/6997.368861.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/03/09/91f7.368860.jpg",
           "demozooUrl": "https://demozoo.org/productions/379929/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/encounter/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/encounter/"
+          ]
         },
         {
           "id": 379893,
@@ -387,9 +544,13 @@
           "author": "Brutal Deluxe",
           "dateStr": "Nov 2024",
           "year": "2024",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/2d/c0/ad7a.368865.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/2c/52/ae9a.368863.jpg",
           "demozooUrl": "https://demozoo.org/productions/379893/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/cdiie/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/cdiie/"
+          ]
         },
         {
           "id": 353818,
@@ -401,7 +562,12 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/40/2f/7d2f.347733.jpg",
           "demozooUrl": "https://demozoo.org/productions/353818/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_datura.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_datura.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=pJ5XZ8oIVi4"
         },
         {
           "id": 348985,
@@ -413,7 +579,13 @@
           "year": "2024",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/348985/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://deater.net/weave/vmwprod/riven/riven_hgr.dsk",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/riven/riven_hgr.dsk",
+            "https://archive.scene.org/pub/demos/groups/vmw/riven_hgr.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=9xvp84A3ilA"
         },
         {
           "id": 346716,
@@ -425,7 +597,12 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/55/81/f4c7.344566.jpg",
           "demozooUrl": "https://demozoo.org/productions/346716/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://github.com/Fr3nchT0uch/Digidream_2/releases/download/v0.8/DD2.woz",
+          "downloadUrls": [
+            "https://github.com/Fr3nchT0uch/Digidream_2/releases/download/v0.8/DD2.woz"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=2xmHE7zrExg"
         },
         {
           "id": 345910,
@@ -437,7 +614,12 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/92/53/8e1a.343744.jpg",
           "demozooUrl": "https://demozoo.org/productions/345910/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/outline24/256_byte_intro_oldskool/dancing_blobs_by_deater.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/outline24/256_byte_intro_oldskool/dancing_blobs_by_deater.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Km6M9VfcSlM&t=300"
         },
         {
           "id": 345908,
@@ -449,7 +631,12 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/20/3b/6499.343742.jpg",
           "demozooUrl": "https://demozoo.org/productions/345908/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/outline24/256_byte_intro_oldskool/cosmic_fish_by_deater.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/outline24/256_byte_intro_oldskool/cosmic_fish_by_deater.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Km6M9VfcSlM&t=90"
         },
         {
           "id": 363412,
@@ -461,7 +648,13 @@
           "year": "2024",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/363412/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "http://deater.net/weave/vmwprod/bubble/bubble.dsk",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/bubble/bubble.dsk",
+            "http://deater.net/weave/vmwprod/bubble/"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=4Vl9sxtBhE0"
         },
         {
           "id": 338156,
@@ -473,7 +666,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d9/df/f36f.339546.png",
           "demozooUrl": "https://demozoo.org/productions/338156/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/256_byte_intro_oldschool/sonus-romanus.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/256_byte_intro_oldschool/sonus-romanus.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/256_byte_intro_oldschool/sonus-romanus.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=lVi7rHmM6QA&t=11"
         },
         {
           "id": 338142,
@@ -485,7 +684,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b1/63/01a7.338966.jpg",
           "demozooUrl": "https://demozoo.org/productions/338142/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/1024_byte_intro_oldschool/plasma_mask_1k.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/1024_byte_intro_oldschool/plasma_mask_1k.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/1024_byte_intro_oldschool/plasma_mask_1k_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=0Cl8RpdFEyI&t=271"
         },
         {
           "id": 338139,
@@ -497,7 +702,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/94/ef/abf8.338965.jpg",
           "demozooUrl": "https://demozoo.org/productions/338139/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/1024_byte_intro_oldschool/dtv_1k.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/1024_byte_intro_oldschool/dtv_1k.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/1024_byte_intro_oldschool/dtv_1k_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=0Cl8RpdFEyI&t=96"
         },
         {
           "id": 338160,
@@ -509,7 +720,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/cf/53/2ba0.338978.jpg",
           "demozooUrl": "https://demozoo.org/productions/338160/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/256_byte_intro_oldschool/dsr_wires.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/256_byte_intro_oldschool/dsr_wires.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/256_byte_intro_oldschool/dsr_wires_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=NBZdGSmsJMo"
         },
         {
           "id": 338009,
@@ -521,7 +738,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/35/da/6355.338956.jpg",
           "demozooUrl": "https://demozoo.org/productions/338009/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/16_byte_intro_oldschool/hhhh_16.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/16_byte_intro_oldschool/hhhh_16.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/16_byte_intro_oldschool/hhhh_16_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=CLyJEjGxz4o&t=1387"
         },
         {
           "id": 337767,
@@ -533,7 +756,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c1/9f/5bfc.338800.jpg",
           "demozooUrl": "https://demozoo.org/productions/337767/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/32_byte_intro_oldschool/spiral_32.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/32_byte_intro_oldschool/spiral_32.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/32_byte_intro_oldschool/spiral_32_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=-pbPeGJ_mMA"
         },
         {
           "id": 337755,
@@ -545,7 +774,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/60/cd/8579.338801.jpg",
           "demozooUrl": "https://demozoo.org/productions/337755/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/32_byte_intro_oldschool/sawblade.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/32_byte_intro_oldschool/sawblade.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/32_byte_intro_oldschool/sawblade_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Zsbe8h24hT8&t=12"
         },
         {
           "id": 337787,
@@ -557,7 +792,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/be/cd/ebd5.339563.png",
           "demozooUrl": "https://demozoo.org/productions/337787/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/64_byte_intro_oldschool/roman-scroll.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/64_byte_intro_oldschool/roman-scroll.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/64_byte_intro_oldschool/roman-scroll.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=hfwIHeOOpLU&t=556"
         },
         {
           "id": 337812,
@@ -569,7 +810,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/af/6b/92af.338813.jpg",
           "demozooUrl": "https://demozoo.org/productions/337812/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/128_byte_intro_oldschool/rainbow_squares.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/128_byte_intro_oldschool/rainbow_squares.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/128_byte_intro_oldschool/rainbow_squares_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=BMFxgKP2p60"
         },
         {
           "id": 337700,
@@ -581,7 +828,12 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0b/b3/1b97.339089.png",
           "demozooUrl": "https://demozoo.org/productions/337700/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/8_byte_showcase/prbyte7b.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/8_byte_showcase/prbyte7b.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=rokYaiuZwpM&t=512"
         },
         {
           "id": 337791,
@@ -593,7 +845,13 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/75/d8/eff9.338802.jpg",
           "demozooUrl": "https://demozoo.org/productions/337791/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/64_byte_intro_oldschool/box_entropy.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/64_byte_intro_oldschool/box_entropy.zip",
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/64_byte_intro_oldschool/box_entropy_720p.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=hfwIHeOOpLU&t=832"
         },
         {
           "id": 337880,
@@ -605,7 +863,12 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c4/a3/323e.338846.jpg",
           "demozooUrl": "https://demozoo.org/productions/337880/",
-          "page": 1
+          "page": 1,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/lovebyte24/info/lovebyte24invite_40days.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/lovebyte24/info/lovebyte24invite_40days.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/playlist?list=PLr4JCYhdWe8mAYlORA2gvyR9eLaKxye7V"
         }
       ]
     },
@@ -622,7 +885,12 @@
           "year": "2024",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/348986/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/trogdor/trogdor.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/trogdor/trogdor.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=1Yt9iA3Qi60"
         },
         {
           "id": 337906,
@@ -634,7 +902,8 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0d/7d/1d43.339026.jpg",
           "demozooUrl": "https://demozoo.org/productions/337906/",
-          "page": 2
+          "page": 2,
+          "youtubeUrl": "https://www.youtube.com/watch?v=iu97-liBYw8"
         },
         {
           "id": 336631,
@@ -646,7 +915,12 @@
           "year": "2024",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ef/d8/7f57.337699.png",
           "demozooUrl": "https://demozoo.org/productions/336631/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2024/gerp24/other_platform_demo/ffp_gerp_2024_apple_ii_europlus.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2024/gerp24/other_platform_demo/ffp_gerp_2024_apple_ii_europlus.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Pxlzqz8Lcpg"
         },
         {
           "id": 379920,
@@ -656,9 +930,13 @@
           "author": "Brutal Deluxe",
           "dateStr": "Jan 2024",
           "year": "2024",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/64/92/c845.368876.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/42/a5/5084.368878.png",
           "demozooUrl": "https://demozoo.org/productions/379920/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/kikekankoi/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/kikekankoi/"
+          ]
         },
         {
           "id": 335218,
@@ -668,9 +946,13 @@
           "author": "resman",
           "dateStr": "Dec 2023",
           "year": "2023",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/2e/f5/962f.337015.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e8/e9/b17f.337016.png",
           "demozooUrl": "https://demozoo.org/productions/335218/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/vccc23/christmas-diamonds/dschmenk_apple2_plasma_vc3-2023.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/vccc23/christmas-diamonds/dschmenk_apple2_plasma_vc3-2023.zip"
+          ]
         },
         {
           "id": 335185,
@@ -680,9 +962,13 @@
           "author": "DaSpider",
           "dateStr": "Dec 2023",
           "year": "2023",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/de/88/7c7a.336940.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e1/1d/41e2.336941.jpg",
           "demozooUrl": "https://demozoo.org/productions/335185/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/vccc23/christmas-diamonds/daspider_appleii_applesoft_vc3-2023.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/vccc23/christmas-diamonds/daspider_appleii_applesoft_vc3-2023.zip"
+          ]
         },
         {
           "id": 334833,
@@ -694,7 +980,13 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/93/ab/2e1f.336278.jpg",
           "demozooUrl": "https://demozoo.org/productions/334833/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_seasonsgreetings.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_seasonsgreetings.zip",
+            "https://archive.scene.org/pub/parties/2023/tillagefx23/combined_showcase/marqueedesign_seasonsgreetings.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Ym_3wRYX2tw"
         },
         {
           "id": 379926,
@@ -704,9 +996,13 @@
           "author": "Brutal Deluxe",
           "dateStr": "Dec 2023",
           "year": "2023",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/19/01/d796.368880.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/71/c2/9192.368882.png",
           "demozooUrl": "https://demozoo.org/productions/379926/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/cauchemarhouse/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/cauchemarhouse/"
+          ]
         },
         {
           "id": 379927,
@@ -716,9 +1012,13 @@
           "author": "Brutal Deluxe",
           "dateStr": "Dec 2023",
           "year": "2023",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9c/73/49be.368884.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/bf/c0/1b96.368887.jpg",
           "demozooUrl": "https://demozoo.org/productions/379927/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/prfolibus/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/prfolibus/"
+          ]
         },
         {
           "id": 379928,
@@ -728,9 +1028,13 @@
           "author": "Brutal Deluxe",
           "dateStr": "Dec 2023",
           "year": "2023",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/5b/07/4a73.368928.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/cb/51/2d1c.368927.jpg",
           "demozooUrl": "https://demozoo.org/productions/379928/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/drgenius/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/drgenius/"
+          ]
         },
         {
           "id": 335364,
@@ -742,7 +1046,13 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6f/7d/2b67.339140.jpg",
           "demozooUrl": "https://demozoo.org/productions/335364/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://deater.net/weave/vmwprod/xmas23/xmas_2023.dsk",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/xmas23/xmas_2023.dsk",
+            "http://deater.net/weave/vmwprod/xmas23/"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=ivujNEkaRCg"
         },
         {
           "id": 333521,
@@ -754,7 +1064,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b8/de/9d59.334835.jpg",
           "demozooUrl": "https://demozoo.org/productions/333521/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_gash.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_gash.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=_p9PF6NPvMs"
         },
         {
           "id": 332971,
@@ -766,7 +1081,14 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/70/f1/14aa.334462.jpg",
           "demozooUrl": "https://demozoo.org/productions/332971/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://deater.net/weave/vmwprod/second/a2_reality.zip",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/second/a2_reality.zip",
+            "https://archive.scene.org/pub/parties/2023/demosplash23/retro_demo/a2_reality.zip",
+            "https://archive.scene.org/pub/parties/2023/demosplash23/retro_demo/second_reality_for_apple_ii__rnoqu4vcdto_.webm"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=RNOqu4vcDto"
         },
         {
           "id": 326393,
@@ -778,7 +1100,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e1/47/751a.329507.jpg",
           "demozooUrl": "https://demozoo.org/productions/326393/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_overboard.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/marqueedesign/marqueedesign_overboard.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=T2FAIhntJYU"
         },
         {
           "id": 324263,
@@ -790,7 +1117,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/98/03/7926.327015.jpg",
           "demozooUrl": "https://demozoo.org/productions/324263/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/outline23/intro256_oldskool/deater_midline.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/outline23/intro256_oldskool/deater_midline.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=iWq57yeu4gQ"
         },
         {
           "id": 324260,
@@ -802,7 +1134,11 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/79/d0/0727.329417.png",
           "demozooUrl": "https://demozoo.org/productions/324260/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/outline23/intro256_oldskool/qkumba_clock.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/outline23/intro256_oldskool/qkumba_clock.zip"
+          ]
         },
         {
           "id": 335369,
@@ -814,7 +1150,13 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7e/d9/595c.339141.jpg",
           "demozooUrl": "https://demozoo.org/productions/335369/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://deater.net/weave/vmwprod/mode_switch/double.dsk",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/mode_switch/double.dsk",
+            "http://deater.net/weave/vmwprod/mode_switch/"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=bXj2Wkcgjcs"
         },
         {
           "id": 318933,
@@ -826,7 +1168,13 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/bf/7b/352e.320322.png",
           "demozooUrl": "https://demozoo.org/productions/318933/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/8_byte_showcase/tiny_hgr8.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/8_byte_showcase/tiny_hgr8.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/8_byte_showcase/tiny_hgr8.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=8QYezzXC9PA"
         },
         {
           "id": 319014,
@@ -838,7 +1186,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/36/75/76a9.320756.jpg",
           "demozooUrl": "https://demozoo.org/productions/319014/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/64_byte_intro_oldschool/pied64.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/64_byte_intro_oldschool/pied64.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/64_byte_intro_oldschool/pied64.mp4"
+          ]
         },
         {
           "id": 318980,
@@ -850,7 +1203,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c1/25/08fa.320754.jpg",
           "demozooUrl": "https://demozoo.org/productions/318980/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/32_byte_intro_oldschool/ooze32.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/32_byte_intro_oldschool/ooze32.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/32_byte_intro_oldschool/ooze32.mp4"
+          ]
         },
         {
           "id": 319221,
@@ -862,7 +1220,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2e/d2/9acd.320758.jpg",
           "demozooUrl": "https://demozoo.org/productions/319221/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/16_byte_intro_oldschool/weave15.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/16_byte_intro_oldschool/weave15.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/16_byte_intro_oldschool/weave15.mp4"
+          ]
         },
         {
           "id": 319124,
@@ -872,9 +1235,15 @@
           "author": "Deater / Desire",
           "dateStr": "Feb 2023",
           "year": "2023",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/b9/ae/933c.320757.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f3/a0/626a.320759.jpg",
           "demozooUrl": "https://demozoo.org/productions/319124/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/512_byte_intro_oldschool/love_duck.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/512_byte_intro_oldschool/love_duck.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/512_byte_intro_oldschool/love_duck.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=1jWXp3RDs8c"
         },
         {
           "id": 319079,
@@ -886,7 +1255,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9b/33/e20b.320755.jpg",
           "demozooUrl": "https://demozoo.org/productions/319079/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/128_byte_intro_oldschool/parallax128.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/128_byte_intro_oldschool/parallax128.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/128_byte_intro_oldschool/parallax128.mp4"
+          ]
         },
         {
           "id": 319329,
@@ -898,7 +1272,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/38/6a/2d50.320753.png",
           "demozooUrl": "https://demozoo.org/productions/319329/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/256_byte_intro_oldschool/lemm256.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/256_byte_intro_oldschool/lemm256.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/256_byte_intro_oldschool/lemm256.mp4"
+          ]
         },
         {
           "id": 319066,
@@ -910,7 +1289,13 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/25/e1/5759.320751.png",
           "demozooUrl": "https://demozoo.org/productions/319066/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/128_byte_intro_oldschool/gears128.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/128_byte_intro_oldschool/gears128.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/128_byte_intro_oldschool/gears128.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=r_OSSrHhXeY"
         },
         {
           "id": 319233,
@@ -922,7 +1307,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/fa/06/196f.320750.jpg",
           "demozooUrl": "https://demozoo.org/productions/319233/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/16_byte_intro_oldschool/field16.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/16_byte_intro_oldschool/field16.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/16_byte_intro_oldschool/field16.mp4"
+          ]
         },
         {
           "id": 319313,
@@ -934,7 +1324,13 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/33/b4/4000.320749.jpg",
           "demozooUrl": "https://demozoo.org/productions/319313/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/1k_intro_oldschool/blue_flame.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/1k_intro_oldschool/blue_flame.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/1k_intro_oldschool/blue_flame.mp4"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=T6iG3AiOURQ"
         },
         {
           "id": 318989,
@@ -946,7 +1342,12 @@
           "year": "2023",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5c/8c/944e.320748.jpg",
           "demozooUrl": "https://demozoo.org/productions/318989/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2023/lovebyte23/32_byte_intro_oldschool/agony17.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/32_byte_intro_oldschool/agony17.zip",
+            "https://archive.scene.org/pub/parties/2023/lovebyte23/32_byte_intro_oldschool/agony17.mp4"
+          ]
         },
         {
           "id": 317119,
@@ -958,7 +1359,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b9/d3/a49f.318245.jpg",
           "demozooUrl": "https://demozoo.org/productions/317119/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/vccc22/christmas_star_challenge/frankrodiii_appleiic_applesoftbasic_vc3-2022.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/vccc22/christmas_star_challenge/frankrodiii_appleiic_applesoftbasic_vc3-2022.zip"
+          ]
         },
         {
           "id": 316939,
@@ -970,7 +1375,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/df/23/abc8.318085.png",
           "demozooUrl": "https://demozoo.org/productions/316939/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/vccc22/christmas_star_challenge/schmenk_apple2_plasma_vc3-2022.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/vccc22/christmas_star_challenge/schmenk_apple2_plasma_vc3-2022.zip"
+          ]
         },
         {
           "id": 316922,
@@ -982,7 +1391,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/08/57/d677.318071.png",
           "demozooUrl": "https://demozoo.org/productions/316922/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/vccc22/christmas_star_challenge/init-hello_appleii_basic_vc3-2022.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/vccc22/christmas_star_challenge/init-hello_appleii_basic_vc3-2022.zip"
+          ]
         },
         {
           "id": 315678,
@@ -994,7 +1407,13 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/99/a0/839b.316312.jpg",
           "demozooUrl": "https://demozoo.org/productions/315678/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://www.demosplash.org/2022/compo_entries/small_demo/Apple2_Desire/apple2_desire.zip",
+          "downloadUrls": [
+            "https://www.demosplash.org/2022/compo_entries/small_demo/Apple2_Desire/apple2_desire.zip",
+            "https://archive.scene.org/pub/parties/2022/demosplash22/small_demo/apple2_desire.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Kz7LdY0JqQM"
         },
         {
           "id": 311741,
@@ -1006,7 +1425,12 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/87/a3/54e0.311831.jpg",
           "demozooUrl": "https://demozoo.org/productions/311741/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://files.zxdemo.org/extra/lovebyteturbo/planet256.zip",
+          "downloadUrls": [
+            "https://files.zxdemo.org/extra/lovebyteturbo/planet256.zip",
+            "https://archive.scene.org/pub/parties/2022/lovebyte_turbo22/tiny_intro_oldschool/planet256.zip"
+          ]
         },
         {
           "id": 308577,
@@ -1018,7 +1442,13 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0c/6f/3882.308654.jpg",
           "demozooUrl": "https://demozoo.org/productions/308577/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/outline_2022/dsrscroll_small.zip",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/outline_2022/dsrscroll_small.zip",
+            "https://archive.scene.org/pub/parties/2022/outline22/256b_intro/dsrscroll_small.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=utztCwB8jm8"
         },
         {
           "id": 348988,
@@ -1030,7 +1460,12 @@
           "year": "2022",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/348988/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lemm/lemm.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lemm/lemm.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=6P3zubc53bw"
         },
         {
           "id": 305457,
@@ -1042,7 +1477,12 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/dd/13/4326.305630.jpg",
           "demozooUrl": "https://demozoo.org/productions/305457/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/16_byte_intro_oldschool/xdraw_wave16.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/16_byte_intro_oldschool/xdraw_wave16.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=V0ThN3SRsQc"
         },
         {
           "id": 305640,
@@ -1054,7 +1494,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/31/37/eee7.305634.jpg",
           "demozooUrl": "https://demozoo.org/productions/305640/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/256_byte_intro_oldschool/orb_256.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/256_byte_intro_oldschool/orb_256.zip"
+          ]
         },
         {
           "id": 305559,
@@ -1066,7 +1510,12 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/09/d3/a5de.305635.jpg",
           "demozooUrl": "https://demozoo.org/productions/305559/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/32_byte_intro_oldschool/fuzzball32.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/32_byte_intro_oldschool/fuzzball32.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=_87rEku8fWo"
         },
         {
           "id": 305461,
@@ -1078,7 +1527,12 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/85/fa/c69d.305636.jpg",
           "demozooUrl": "https://demozoo.org/productions/305461/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/16_byte_intro_oldschool/xdraw_diamond16.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/16_byte_intro_oldschool/xdraw_diamond16.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=qPm7fMMr8Nk"
         },
         {
           "id": 305633,
@@ -1090,7 +1544,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/35/ac/e715.305637.jpg",
           "demozooUrl": "https://demozoo.org/productions/305633/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/256_byte_intro_oldschool/cometsong256.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/256_byte_intro_oldschool/cometsong256.zip"
+          ]
         },
         {
           "id": 305318,
@@ -1102,7 +1560,12 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/27/65/779e.305642.jpg",
           "demozooUrl": "https://demozoo.org/productions/305318/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/64_byte_intro_oldschool/dsr64.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/64_byte_intro_oldschool/dsr64.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=EYER9QaD_f0"
         },
         {
           "id": 305408,
@@ -1114,7 +1577,12 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a9/a2/42eb.305629.jpg",
           "demozooUrl": "https://demozoo.org/productions/305408/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/misc/8_byte_intro_showcase/tiny_gr8.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/misc/8_byte_intro_showcase/tiny_gr8.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=otYrCb8MU2s"
         },
         {
           "id": 305305,
@@ -1126,7 +1594,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3c/4b/c87c.305638.jpg",
           "demozooUrl": "https://demozoo.org/productions/305305/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/64_byte_intro_oldschool/thick_sine64.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/64_byte_intro_oldschool/thick_sine64.zip"
+          ]
         },
         {
           "id": 305363,
@@ -1138,7 +1610,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/48/62/4ab8.305639.jpg",
           "demozooUrl": "https://demozoo.org/productions/305363/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/128_byte_intro_oldschool/stargate_128.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/128_byte_intro_oldschool/stargate_128.zip"
+          ]
         },
         {
           "id": 305361,
@@ -1150,7 +1626,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/db/cf/5b1e.305640.jpg",
           "demozooUrl": "https://demozoo.org/productions/305361/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://deater.net/weave/vmwprod/lovebyte_2022/rotate.dsk",
+          "downloadUrls": [
+            "http://deater.net/weave/vmwprod/lovebyte_2022/rotate.dsk"
+          ]
         },
         {
           "id": 305379,
@@ -1162,7 +1642,11 @@
           "year": "2022",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e6/da/be1c.305641.jpg",
           "demozooUrl": "https://demozoo.org/productions/305379/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2022/lovebyte22/512_byte_intro_oldschool/flyer512.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2022/lovebyte22/512_byte_intro_oldschool/flyer512.zip"
+          ]
         },
         {
           "id": 302339,
@@ -1174,7 +1658,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5d/a9/7a1c.301003.jpg",
           "demozooUrl": "https://demozoo.org/productions/302339/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/demosplash21/demo/logo_demo.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/demosplash21/demo/logo_demo.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=ayLM2_cINiw"
         },
         {
           "id": 302345,
@@ -1186,7 +1675,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/82/45/c561.305643.jpg",
           "demozooUrl": "https://demozoo.org/productions/302345/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/demosplash21/small_demo/hgr_d2_1k.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/demosplash21/small_demo/hgr_d2_1k.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=rSEvrRrzaG0"
         },
         {
           "id": 343784,
@@ -1198,7 +1692,13 @@
           "year": "2021",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/343784/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/8-bit-shack/xmas2021_rc3.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/8-bit-shack/xmas2021_rc3.dsk",
+            "http://www.golombeck.eu/index.php?id=56&L=1"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=lZy4HQUf_VE"
         },
         {
           "id": 302142,
@@ -1210,7 +1710,14 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/11/16/e6e3.300734.jpg",
           "demozooUrl": "https://demozoo.org/productions/302142/",
-          "page": 2
+          "page": 2,
+          "downloadUrl": "http://aminet.net/game/text/darkest-hour.i386-aros.lha",
+          "downloadUrls": [
+            "http://aminet.net/game/text/darkest-hour.i386-aros.lha",
+            "http://aminet.net/game/text/darkest-hour.lha",
+            "http://aminet.net/game/text/darkest-hour_OS4.lha",
+            "http://www.os4depot.net/share/game/adventure/darkest-hour.lha"
+          ]
         }
       ]
     },
@@ -1227,7 +1734,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/4c/6b/e4b8.305648.jpg",
           "demozooUrl": "https://demozoo.org/productions/300257/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/thinking/cracking.woz",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/thinking/cracking.woz"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=cJxfDDWSkKU"
         },
         {
           "id": 294968,
@@ -1239,7 +1751,15 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5f/19/b798.292636.png",
           "demozooUrl": "https://demozoo.org/productions/294968/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://apweld.com/dkt/smr-stevie.woz",
+          "downloadUrls": [
+            "http://apweld.com/dkt/smr-stevie.woz",
+            "https://archive.scene.org/pub/demos/compilations/lost_found_and_more/apple_2/samar_productions_stevie.zip",
+            "http://apweld.com/dkt/Samar%20Productions%20-%20Stevie.mkv",
+            "http://apweld.com/dkt/readme.txt"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=H8JfwR7x-6k"
         },
         {
           "id": 294784,
@@ -1251,7 +1771,13 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/34/f0/8599.292361.jpg",
           "demozooUrl": "https://demozoo.org/productions/294784/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/shadow_party21/old_school_intro/oldskool.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/shadow_party21/old_school_intro/oldskool.zip",
+            "https://github.com/Fr3nchT0uch/Oldskool_Fort_Et_Vert/releases"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=YB05u2RKfTM"
         },
         {
           "id": 294496,
@@ -1263,7 +1789,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7b/e8/d863.293737.jpg",
           "demozooUrl": "https://demozoo.org/productions/294496/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/outline21/low_end_128_byte_intro/xdraw128_submit.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/outline21/low_end_128_byte_intro/xdraw128_submit.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=qHsdARXhuz8"
         },
         {
           "id": 294513,
@@ -1275,7 +1806,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1c/dd/d38e.293738.jpg",
           "demozooUrl": "https://demozoo.org/productions/294513/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/outline21/demo/outline2021_island.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/outline21/demo/outline2021_island.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=UYda97Cazd4"
         },
         {
           "id": 292516,
@@ -1287,7 +1823,13 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5b/d8/cef7.288796.png",
           "demozooUrl": "https://demozoo.org/productions/292516/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://github.com/Fr3nchT0uch/Terra_Nova/releases/download/v0.10/TerraNova.zip",
+          "downloadUrls": [
+            "https://github.com/Fr3nchT0uch/Terra_Nova/releases/download/v0.10/TerraNova.zip",
+            "https://archive.scene.org/pub/parties/2021/revision21/oldskool-intro/terranova.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=y9-rXiyR240"
         },
         {
           "id": 292317,
@@ -1299,7 +1841,13 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d9/6f/5459.289169.png",
           "demozooUrl": "https://demozoo.org/productions/292317/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/revision21/oldskool-demo/lowtech.woz",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/revision21/oldskool-demo/lowtech.woz",
+            "https://github.com/wiz21b/lowtech/releases"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=z4Fj2vihAKA"
         },
         {
           "id": 295675,
@@ -1311,7 +1859,13 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f1/5b/c935.293736.jpg",
           "demozooUrl": "https://demozoo.org/productions/295675/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lovebyte_2021/tiny_xdraw16.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lovebyte_2021/tiny_xdraw16.dsk",
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/misc/16_byte_intro_showcase/xdraw16.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=rZcfJRi1tck&t=785"
         },
         {
           "id": 295674,
@@ -1323,7 +1877,13 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/18/20/5ddf.293735.jpg",
           "demozooUrl": "https://demozoo.org/productions/295674/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lovebyte_2021/tiny_pastel16.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lovebyte_2021/tiny_pastel16.dsk",
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/misc/16_byte_intro_showcase/pastel16.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=rZcfJRi1tck&t=401"
         },
         {
           "id": 295627,
@@ -1335,7 +1895,11 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c2/a7/2966.305645.png",
           "demozooUrl": "https://demozoo.org/productions/295627/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/misc/8_byte_intro_showcase/text8.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/misc/8_byte_intro_showcase/text8.zip"
+          ]
         },
         {
           "id": 291248,
@@ -1347,7 +1911,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/57/b0/de57.293641.jpg",
           "demozooUrl": "https://demozoo.org/productions/291248/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/32_byte_intro/tiny32.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/32_byte_intro/tiny32.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=2rjLUg5USWE"
         },
         {
           "id": 291322,
@@ -1359,7 +1928,11 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e6/93/fe5f.293626.jpg",
           "demozooUrl": "https://demozoo.org/productions/291322/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/64_byte_intro/pipes64.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/64_byte_intro/pipes64.zip"
+          ]
         },
         {
           "id": 291218,
@@ -1371,7 +1944,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c5/16/5212.293545.jpg",
           "demozooUrl": "https://demozoo.org/productions/291218/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_128_byte_intro/sierzoom128.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_128_byte_intro/sierzoom128.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=aSMjYdhPWrc"
         },
         {
           "id": 291319,
@@ -1383,7 +1961,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c8/75/9948.293620.jpg",
           "demozooUrl": "https://demozoo.org/productions/291319/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/64_byte_intro/sier64.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/64_byte_intro/sier64.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=t6i-xiwiCp0"
         },
         {
           "id": 291220,
@@ -1395,7 +1978,11 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d9/66/4507.293547.png",
           "demozooUrl": "https://demozoo.org/productions/291220/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_128_byte_intro/notamoon128.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_128_byte_intro/notamoon128.zip"
+          ]
         },
         {
           "id": 291398,
@@ -1407,7 +1994,13 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ae/91/61e0.293550.jpg",
           "demozooUrl": "https://demozoo.org/productions/291398/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/lovebyte_2021/rr.woz.zip",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/lovebyte_2021/rr.woz.zip",
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_256_byte_intro/rr256.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=gc5Bl5pW79U"
         },
         {
           "id": 291225,
@@ -1419,7 +2012,11 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/90/26/1f0c.293543.jpg",
           "demozooUrl": "https://demozoo.org/productions/291225/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_128_byte_intro/fakepal128.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_128_byte_intro/fakepal128.zip"
+          ]
         },
         {
           "id": 291255,
@@ -1431,7 +2028,12 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b5/27/0290.293645.jpg",
           "demozooUrl": "https://demozoo.org/productions/291255/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/32_byte_intro/checkers32.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/32_byte_intro/checkers32.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=yolBXhZ-EjU"
         },
         {
           "id": 291402,
@@ -1443,7 +2045,11 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6d/49/e322.293616.jpg",
           "demozooUrl": "https://demozoo.org/productions/291402/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_256_byte_intro/a2_inside256.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2021/lovebyte21/low_end_256_byte_intro/a2_inside256.zip"
+          ]
         },
         {
           "id": 290630,
@@ -1455,7 +2061,13 @@
           "year": "2021",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9d/34/2bb2.286710.png",
           "demozooUrl": "https://demozoo.org/productions/290630/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://github.com/Fr3nchT0uch/fastloader/releases/download/v0.9/fastloader.woz",
+          "downloadUrls": [
+            "https://github.com/Fr3nchT0uch/fastloader/releases/download/v0.9/fastloader.woz",
+            "https://archive.scene.org/pub/demos/groups/french_touch/fastloader.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=HtGhfb4_yAE"
         },
         {
           "id": 343783,
@@ -1467,7 +2079,13 @@
           "year": "2021",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/343783/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/8-bit-shack/fire_rc1.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/8-bit-shack/fire_rc1.dsk",
+            "http://www.golombeck.eu/index.php?id=51&L=1"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=oE-gM4IsdTM"
         },
         {
           "id": 288456,
@@ -1479,7 +2097,12 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9f/2f/d489.301712.jpg",
           "demozooUrl": "https://demozoo.org/productions/288456/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2020/hogmanay20/128bytes/hires128b-apple2-.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2020/hogmanay20/128bytes/hires128b-apple2-.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Jwn6cDmlPaY"
         },
         {
           "id": 287989,
@@ -1491,7 +2114,12 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ed/55/8e2f.331191.jpg",
           "demozooUrl": "https://demozoo.org/productions/287989/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.golombeck.eu/fileadmin/downloads/XMAS2020.dsk",
+          "downloadUrls": [
+            "http://www.golombeck.eu/fileadmin/downloads/XMAS2020.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=5vUACfRfPaw"
         },
         {
           "id": 287252,
@@ -1503,7 +2131,12 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/64/9a/bdde.305649.jpg",
           "demozooUrl": "https://demozoo.org/productions/287252/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2020/demosplash20/retro_demo/bot_demo.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2020/demosplash20/retro_demo/bot_demo.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=iVDgdfKe9eQ"
         },
         {
           "id": 348990,
@@ -1515,7 +2148,13 @@
           "year": "2020",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/348990/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/duke/duke.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/duke/duke.dsk",
+            "http://www.deater.net/weave/vmwprod/duke/"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=gAW1Sq5_cEY"
         },
         {
           "id": 348989,
@@ -1527,7 +2166,13 @@
           "year": "2020",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/348989/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/monkey/monkey.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/monkey/monkey.dsk",
+            "http://www.deater.net/weave/vmwprod/monkey/"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=_KXncYyl2Mo"
         },
         {
           "id": 281947,
@@ -1539,7 +2184,13 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/26/12/32df.275659.png",
           "demozooUrl": "https://demozoo.org/productions/281947/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://github.com/Fr3nchT0uch/shadow/releases/download/0.41/shadow.dsk",
+          "downloadUrls": [
+            "https://github.com/Fr3nchT0uch/shadow/releases/download/0.41/shadow.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/shadow.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=1hHdt4o4kTg"
         },
         {
           "id": 348991,
@@ -1551,7 +2202,12 @@
           "year": "2020",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/348991/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/anothermyst/am.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/anothermyst/am.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=BgbhIC-U454"
         },
         {
           "id": 279185,
@@ -1563,7 +2219,12 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1e/8c/9724.305650.jpg",
           "demozooUrl": "https://demozoo.org/productions/279185/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2020/atparty20/256_byte_intro/shapetable_party.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2020/atparty20/256_byte_intro/shapetable_party.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=B2gq7d9rzHM"
         },
         {
           "id": 278613,
@@ -1575,7 +2236,13 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/84/97/9303.268625.jpg",
           "demozooUrl": "https://demozoo.org/productions/278613/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/seasons_demo/seasons.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/seasons_demo/seasons.dsk",
+            "https://archive.scene.org/pub/parties/2020/outline20/128_byte_intro/apple2_seasons.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=QxCthi-KxMU"
         },
         {
           "id": 278608,
@@ -1587,7 +2254,12 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/fa/4b/64da.268631.jpg",
           "demozooUrl": "https://demozoo.org/productions/278608/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2020/outline20/128_byte_intro/hireswalk-128b-by-g0blinish.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2020/outline20/128_byte_intro/hireswalk-128b-by-g0blinish.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=HeDKuktrFIY"
         },
         {
           "id": 293160,
@@ -1599,7 +2271,15 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/15/40/9647.290030.png",
           "demozooUrl": "https://demozoo.org/productions/293160/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://csdb.dk/getinternalfile.php/196524/LogiTrumps%20[C64%2080].7z",
+          "downloadUrls": [
+            "https://csdb.dk/getinternalfile.php/196524/LogiTrumps%20[C64%2080].7z",
+            "https://csdb.dk/getinternalfile.php/196525/LogiTrumps%20[C128%2080].7z",
+            "https://csdb.dk/getinternalfile.php/196526/LogiTrumps%20VS%20[C128%2080].7z",
+            "http://plus4world.powweb.com/dl/games/l/logitrumps_c16.prg",
+            "https://gkanold.wixsite.com/homeputerium/downloads"
+          ]
         },
         {
           "id": 279170,
@@ -1611,7 +2291,13 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f9/57/ddde.310230.jpg",
           "demozooUrl": "https://demozoo.org/productions/279170/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://rmda.world/dae353b-party.zip",
+          "downloadUrls": [
+            "https://rmda.world/dae353b-party.zip",
+            "https://archive.scene.org/pub/demos/groups/rmda/dae353b-party.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=lcQ58VM9s2A"
         },
         {
           "id": 275425,
@@ -1623,7 +2309,11 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/64/23/cf72.305657.jpg",
           "demozooUrl": "https://demozoo.org/productions/275425/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/mist/mist.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/mist/mist.dsk"
+          ]
         },
         {
           "id": 275128,
@@ -1635,7 +2325,14 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f6/ac/98fc.260750.png",
           "demozooUrl": "https://demozoo.org/productions/275128/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://github.com/Fr3nchT0uch/digidream/releases/download/v0.6/DD.dsk",
+          "downloadUrls": [
+            "https://github.com/Fr3nchT0uch/digidream/releases/download/v0.6/DD.dsk",
+            "https://archive.scene.org/pub/demos/compilations/lost_found_and_more/apple_2/digidream.zip",
+            "https://archive.scene.org/pub/demos/groups/french_touch/digidream.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=FIbJkYVO6Kk"
         },
         {
           "id": 273822,
@@ -1647,7 +2344,14 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3a/8a/04b6.258922.png",
           "demozooUrl": "https://demozoo.org/productions/273822/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/MAD3/MAD3.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/MAD3/MAD3.dsk",
+            "http://fr3nch.t0uch.free.fr/MAD3/MAD3_150120.zip",
+            "https://archive.scene.org/pub/demos/groups/french_touch/mad3.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=jkn9m9lV1ig"
         },
         {
           "id": 273103,
@@ -1659,7 +2363,12 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/07/44/6cf9.258177.png",
           "demozooUrl": "https://demozoo.org/productions/273103/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2020/magfest20/executable/intro256b_g0blinish_acid%28a2%29.7z",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2020/magfest20/executable/intro256b_g0blinish_acid%28a2%29.7z"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=p6tw19T3K3k"
         },
         {
           "id": 273025,
@@ -1671,7 +2380,14 @@
           "year": "2020",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3f/fb/5c1f.331197.png",
           "demozooUrl": "https://demozoo.org/productions/273025/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/TRIBU/TRIBU.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/TRIBU/TRIBU.dsk",
+            "http://fr3nch.t0uch.free.fr/TRIBU/TRIBU_030120.zip",
+            "https://archive.scene.org/pub/demos/compilations/lost_found_and_more/apple_2/unreeeal_superhero_3_tribute.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=uDOrVCssdfQ"
         },
         {
           "id": 272461,
@@ -1683,7 +2399,13 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/41/f6/85a6.305651.jpg",
           "demozooUrl": "https://demozoo.org/productions/272461/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/xmas19/xmas2019.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/xmas19/xmas2019.dsk",
+            "https://github.com/deater/dos33fsprogs/raw/master/xmas_2019/xmas2019.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=7bQJ7gdZLUc"
         },
         {
           "id": 272201,
@@ -1695,7 +2417,12 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5b/15/2512.331192.jpg",
           "demozooUrl": "https://demozoo.org/productions/272201/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://www.golombeck.eu/fileadmin/downloads/XMAS2019_RC3.dsk",
+          "downloadUrls": [
+            "https://www.golombeck.eu/fileadmin/downloads/XMAS2019_RC3.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=ta3Tg2QuCZ0"
         },
         {
           "id": 270168,
@@ -1707,7 +2434,12 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/05/e7/e910.305653.jpg",
           "demozooUrl": "https://demozoo.org/productions/270168/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2019/demosplash19/retro_demo/demosplash_safe.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2019/demosplash19/retro_demo/demosplash_safe.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=FJhJnBENT-w"
         },
         {
           "id": 269657,
@@ -1719,7 +2451,13 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6b/ce/0438.195719.jpg",
           "demozooUrl": "https://demozoo.org/productions/269657/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/MAD2/MAD2.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/MAD2/MAD2.dsk",
+            "http://fr3nch.t0uch.free.fr/MAD2/MAD2_EMU.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Vcjs8883Gkw"
         },
         {
           "id": 268394,
@@ -1731,7 +2469,13 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/21/e6/6e3b.194222.png",
           "demozooUrl": "https://demozoo.org/productions/268394/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/MADEF/MADEF.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/MADEF/MADEF.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/madef.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=vHoO42GOqhs"
         },
         {
           "id": 267379,
@@ -1743,7 +2487,13 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/54/f7/3737.192996.jpg",
           "demozooUrl": "https://demozoo.org/productions/267379/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/CHP/CHP.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/CHP/CHP.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/chip.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=BUbYN89c0t0"
         },
         {
           "id": 272472,
@@ -1755,7 +2505,12 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/75/f6/96f3.331196.jpg",
           "demozooUrl": "https://demozoo.org/productions/272472/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/ootw/ootw.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/ootw/ootw.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=aamuYh_xMpI"
         },
         {
           "id": 266860,
@@ -1767,7 +2522,13 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/74/dd/7815.192384.png",
           "demozooUrl": "https://demozoo.org/productions/266860/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/FKF/FKF_030819.zip",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/FKF/FKF_030819.zip",
+            "https://archive.scene.org/pub/demos/groups/french_touch/fakeoff.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=N1UoIqVy-eI"
         },
         {
           "id": 270553,
@@ -1779,7 +2540,12 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3b/4d/8499.331193.jpg",
           "demozooUrl": "https://demozoo.org/productions/270553/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/8-bit-shack/engine3d_110rc3.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/8-bit-shack/engine3d_110rc3.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=juXlFqhKrEM"
         },
         {
           "id": 269636,
@@ -1789,9 +2555,13 @@
           "author": "Deater",
           "dateStr": "Aug 2019",
           "year": "2019",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/63/33/c448.195688.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/22/34/c8fa.195687.jpg",
           "demozooUrl": "https://demozoo.org/productions/269636/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/ootw/ootw.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/ootw/ootw.dsk"
+          ]
         },
         {
           "id": 266861,
@@ -1803,7 +2573,13 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/05/83/a1fd.192383.png",
           "demozooUrl": "https://demozoo.org/productions/266861/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/OMT/OMT.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/OMT/OMT.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/onemoretime.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=rD9yGx396Ek"
         },
         {
           "id": 269635,
@@ -1815,7 +2591,12 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2f/85/621c.195684.jpg",
           "demozooUrl": "https://demozoo.org/productions/269635/",
-          "page": 3
+          "page": 3,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/pt3_player/pt3_player.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/pt3_player/pt3_player.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=bdAxNCj_s6I"
         }
       ]
     },
@@ -1830,9 +2611,15 @@
           "author": "Fenarinarsa",
           "dateStr": "Apr 2019",
           "year": "2019",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/f4/8c/a931.184572.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/72/e2/dd59.184570.jpg",
           "demozooUrl": "https://demozoo.org/productions/202476/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://fenarinarsa.com/demos/latecomer_final.zip",
+          "downloadUrls": [
+            "https://fenarinarsa.com/demos/latecomer_final.zip",
+            "https://archive.scene.org/pub/parties/2019/revision19/oldskool-demo/latecomer_partyversion.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=qTsfvtCmsl4"
         },
         {
           "id": 202951,
@@ -1844,7 +2631,12 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/78/6a/fe09.185293.jpg",
           "demozooUrl": "https://demozoo.org/productions/202951/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://github.com/wiz21b/badapple/releases/download/1.0/BadApple.zip",
+          "downloadUrls": [
+            "https://github.com/wiz21b/badapple/releases/download/1.0/BadApple.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=R0IRxsmlBH0"
         },
         {
           "id": 285364,
@@ -1856,7 +2648,11 @@
           "year": "2019",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/285364/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2019/nomam19/nomam2019.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2019/nomam19/nomam2019.zip"
+          ]
         },
         {
           "id": 202088,
@@ -1866,9 +2662,15 @@
           "author": "8-Bit-Shack / French Touch",
           "dateStr": "Apr 2019",
           "year": "2019",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/18/72/8fde.183662.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/54/7e/cf51.183660.jpg",
           "demozooUrl": "https://demozoo.org/productions/202088/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.golombeck.eu/fileadmin/downloads/The_matrIIx.dsk",
+          "downloadUrls": [
+            "http://www.golombeck.eu/fileadmin/downloads/The_matrIIx.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/the_matrix.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=L62Hz2BorfM"
         },
         {
           "id": 356616,
@@ -1880,7 +2682,12 @@
           "year": "2019",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/356616/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://g0blinish.ucoz.ru/demo3/psg.zip",
+          "downloadUrls": [
+            "http://g0blinish.ucoz.ru/demo3/psg.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Xdf8hVhnxF0"
         },
         {
           "id": 200105,
@@ -1892,7 +2699,11 @@
           "year": "2019",
           "screenshotUrl": "https://media.demozoo.org/screens/t/89/0f/f833.195693.jpg",
           "demozooUrl": "https://demozoo.org/productions/200105/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/apple2_fire/fire.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/apple2_fire/fire.dsk"
+          ]
         },
         {
           "id": 200106,
@@ -1904,7 +2715,12 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/80/6f/3a2d.195695.jpg",
           "demozooUrl": "https://demozoo.org/productions/200106/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/xmas18/xmas2018.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/xmas18/xmas2018.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=gzleTKih0GY"
         },
         {
           "id": 269784,
@@ -1916,7 +2732,12 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/00/67/f3d2.331194.jpg",
           "demozooUrl": "https://demozoo.org/productions/269784/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.golombeck.eu/fileadmin/downloads/XMAS-DEMO_2018_AutoDetect.dsk",
+          "downloadUrls": [
+            "http://www.golombeck.eu/fileadmin/downloads/XMAS-DEMO_2018_AutoDetect.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Ssk4Y6ordlE"
         },
         {
           "id": 195467,
@@ -1926,9 +2747,14 @@
           "author": "VMW Software Production",
           "dateStr": "Nov 2018",
           "year": "2018",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/69/fc/7140.195701.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f6/ea/5cbc.195698.jpg",
           "demozooUrl": "https://demozoo.org/productions/195467/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2018/demosplash18/retro_demo/appleii-megademo.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2018/demosplash18/retro_demo/appleii-megademo.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=McKAcKVTIQs"
         },
         {
           "id": 275335,
@@ -1940,7 +2766,12 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/04/ab/a9e7.260939.png",
           "demozooUrl": "https://demozoo.org/productions/275335/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://www.fenarinarsa.com/demos/fenarinarsa_apple2_greyscreenwithnomusic.zip",
+          "downloadUrls": [
+            "https://www.fenarinarsa.com/demos/fenarinarsa_apple2_greyscreenwithnomusic.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=5EcXsCeuJU4"
         },
         {
           "id": 326034,
@@ -1952,7 +2783,12 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ee/3a/4fda.328978.jpg",
           "demozooUrl": "https://demozoo.org/productions/326034/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/kfest18/kfest18.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/kfest18/kfest18.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=iqAYvZl2iIE"
         },
         {
           "id": 326196,
@@ -1964,7 +2800,11 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/fc/56/bef6.329077.jpg",
           "demozooUrl": "https://demozoo.org/productions/326196/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://github.com/option8/rain/blob/master/RAIN.dsk",
+          "downloadUrls": [
+            "https://github.com/option8/rain/blob/master/RAIN.dsk"
+          ]
         },
         {
           "id": 338735,
@@ -1976,7 +2816,18 @@
           "year": "2018",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/338735/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://os4depot.net/share/game/adventure/reverteris.zip",
+          "downloadUrls": [
+            "http://os4depot.net/share/game/adventure/reverteris.zip",
+            "http://yerzmyey.i-demo.pl/In_Nihilum_Reverteris_PL_ATARI_XE.zip",
+            "http://yerzmyey.i-demo.pl/In_Nihilum_Reverteris_ZX.zip",
+            "http://yerzmyey.i-demo.pl/in-nihilum-reverteris_APPLE_Version_ENG.zip",
+            "http://yerzmyey.i-demo.pl/nihilum-rpi3-eng.zip",
+            "http://yerzmyey.i-demo.pl/nihilum_ZX81_eng.zip",
+            "http://yerzmyey.i-demo.pl/nihilum_st/nihilum.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=xMne69jCHnY"
         },
         {
           "id": 375159,
@@ -1988,7 +2839,12 @@
           "year": "2018",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/375159/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/still_alive/still_alive.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/still_alive/still_alive.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=QJrZ4W-29A4"
         },
         {
           "id": 186776,
@@ -2000,7 +2856,11 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5d/1c/de2d.171825.jpg",
           "demozooUrl": "https://demozoo.org/productions/186776/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2018/outline18/128b/dummytest.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2018/outline18/128b/dummytest.zip"
+          ]
         },
         {
           "id": 187653,
@@ -2010,9 +2870,14 @@
           "author": "Deater",
           "dateStr": "May 2018",
           "year": "2018",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4d/7d/6fbe.195705.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/1e/b2/fcff.195706.jpg",
           "demozooUrl": "https://demozoo.org/productions/187653/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/entropy_demo/entropy.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/entropy_demo/entropy.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=XhubfZx5IGI"
         },
         {
           "id": 185645,
@@ -2022,9 +2887,14 @@
           "author": "8-Bit-Shack",
           "dateStr": "Apr 2018",
           "year": "2018",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/88/89/ca75.160607.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7b/6e/a656.160605.jpg",
           "demozooUrl": "https://demozoo.org/productions/185645/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/8-bit-shack/starfield3d.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/8-bit-shack/starfield3d.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=3kbhdqV-VUE"
         },
         {
           "id": 184826,
@@ -2036,7 +2906,12 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/41/a3/3ebc.195708.jpg",
           "demozooUrl": "https://demozoo.org/productions/184826/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/mode7_demo/mode7_demo.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/mode7_demo/mode7_demo.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=o8427JsfGwk"
         },
         {
           "id": 183914,
@@ -2048,7 +2923,12 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/93/92/0256.157278.jpg",
           "demozooUrl": "https://demozoo.org/productions/183914/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/8-bit-shack/3d-demo.dsk",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/8-bit-shack/3d-demo.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=goNGzdJIVAI"
         },
         {
           "id": 183618,
@@ -2060,7 +2940,13 @@
           "year": "2018",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5d/a5/7885.156648.jpg",
           "demozooUrl": "https://demozoo.org/productions/183618/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://apple2.gs/downloads/KF2018_3.5.po",
+          "downloadUrls": [
+            "https://apple2.gs/downloads/KF2018_3.5.po",
+            "https://apple2.gs/downloads/KF2018_5.25.po"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=ak3ttFAIEU8"
         },
         {
           "id": 184190,
@@ -2070,9 +2956,14 @@
           "author": "VMW Software Production",
           "dateStr": "Feb 2018",
           "year": "2018",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/fb/21/eccc.195711.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/57/95/9899.195710.jpg",
           "demozooUrl": "https://demozoo.org/productions/184190/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://www.deater.net/weave/vmwprod/chiptune/chiptune_player.dsk",
+          "downloadUrls": [
+            "http://www.deater.net/weave/vmwprod/chiptune/chiptune_player.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=t4xxyrWEeio"
         },
         {
           "id": 379895,
@@ -2084,7 +2975,11 @@
           "year": "2017",
           "screenshotUrl": "https://media.demozoo.org/screens/t/be/cb/e1a2.368919.png",
           "demozooUrl": "https://demozoo.org/productions/379895/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://www.brutaldeluxe.fr/store/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/store/"
+          ]
         },
         {
           "id": 175681,
@@ -2096,7 +2991,11 @@
           "year": "2017",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6f/ad/5275.331195.png",
           "demozooUrl": "https://demozoo.org/productions/175681/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://github.com/Pixinn/gameoflife-appleii/raw/master/disk.dsk",
+          "downloadUrls": [
+            "https://github.com/Pixinn/gameoflife-appleii/raw/master/disk.dsk"
+          ]
         },
         {
           "id": 167042,
@@ -2108,7 +3007,12 @@
           "year": "2017",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0d/8c/e7e8.151842.png",
           "demozooUrl": "https://demozoo.org/productions/167042/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2017/dihalt17lite/lowend_256b/g0blinish-hello_dihalt.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2017/dihalt17lite/lowend_256b/g0blinish-hello_dihalt.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=xWsQ1Avgcac"
         },
         {
           "id": 266862,
@@ -2120,7 +3024,13 @@
           "year": "2016",
           "screenshotUrl": "https://media.demozoo.org/screens/t/19/95/a2a3.192386.png",
           "demozooUrl": "https://demozoo.org/productions/266862/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/TLB3/TLB3.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/TLB3/TLB3.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/tlb3.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=CakhaPBEA_U"
         },
         {
           "id": 266863,
@@ -2132,7 +3042,13 @@
           "year": "2016",
           "screenshotUrl": "https://media.demozoo.org/screens/t/dc/0d/8ade.192387.png",
           "demozooUrl": "https://demozoo.org/productions/266863/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/TLB2/TLB2v12.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/TLB2/TLB2v12.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/tl2v12.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=bsv1F29M-w8"
         },
         {
           "id": 157758,
@@ -2144,7 +3060,12 @@
           "year": "2016",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c1/96/7292.107573.png",
           "demozooUrl": "https://demozoo.org/productions/157758/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/c64cd/f15-dgamma-clone.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/c64cd/f15-dgamma-clone.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=pDqHS80n4WI"
         },
         {
           "id": 266873,
@@ -2156,7 +3077,13 @@
           "year": "2016",
           "screenshotUrl": "https://media.demozoo.org/screens/t/12/71/a912.192399.png",
           "demozooUrl": "https://demozoo.org/productions/266873/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/TLB1/TLB1.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/TLB1/TLB1.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/tl1_1.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=SMAgGYiAo7E"
         },
         {
           "id": 157312,
@@ -2168,7 +3095,12 @@
           "year": "2016",
           "screenshotUrl": "https://media.demozoo.org/screens/t/87/fb/42e9.192388.png",
           "demozooUrl": "https://demozoo.org/productions/157312/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/french_tour/pn11.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/french_tour/pn11.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=xDdqV9Gtq4w"
         },
         {
           "id": 266864,
@@ -2180,7 +3112,14 @@
           "year": "2016",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c2/2e/6eff.192389.png",
           "demozooUrl": "https://demozoo.org/productions/266864/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/CCII/CCII.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/CCII/CCII.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/cc2.zip",
+            "https://archive.scene.org/pub/demos/groups/french_touch/cc2c65c02.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=1pufxVBVUwU"
         },
         {
           "id": 151516,
@@ -2192,7 +3131,14 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/06/4b/ee85.99788.png",
           "demozooUrl": "https://demozoo.org/productions/151516/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://cosine.org.uk/files/a2/septic.zip",
+          "downloadUrls": [
+            "http://cosine.org.uk/files/a2/septic.zip",
+            "https://github.com/magic-roundabout/septic-a2/blob/master/septic.do",
+            "https://archive.scene.org/pub/demos/groups/cosine/apple-ii/septic.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=DUqpbku-Dfk"
         },
         {
           "id": 266865,
@@ -2204,7 +3150,13 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/bf/c7/df88.192385.png",
           "demozooUrl": "https://demozoo.org/productions/266865/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/RB/RB.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/RB/RB.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/rb.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=5ONTBCnlNt8"
         },
         {
           "id": 147036,
@@ -2216,7 +3168,13 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/cc/d5/6448.192390.png",
           "demozooUrl": "https://demozoo.org/productions/147036/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/PLS/PLS.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/PLS/PLS.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_tour/plasmag.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=7AsXOuvAawM"
         },
         {
           "id": 147037,
@@ -2228,7 +3186,14 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5d/61/c44a.192391.png",
           "demozooUrl": "https://demozoo.org/productions/147037/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/NSCT/NSCT.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/NSCT/NSCT.dsk",
+            "http://fr3nch.t0uch.free.fr/NSCT/NSCT_IIGS_Friendly.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_tour/nsct.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=KOtXepnIioE"
         },
         {
           "id": 266866,
@@ -2240,7 +3205,13 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/29/7c/c9ad.192392.png",
           "demozooUrl": "https://demozoo.org/productions/266866/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/AQOF/AQOF.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/AQOF/AQOF.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/aqof.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=CLXWld7gK7o"
         },
         {
           "id": 266872,
@@ -2252,7 +3223,13 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2e/a1/3b09.192393.png",
           "demozooUrl": "https://demozoo.org/productions/266872/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/IBZII/IBZII.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/IBZII/IBZII.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/ibiza_ii.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=jAzphUHoEe8"
         },
         {
           "id": 266867,
@@ -2264,7 +3241,13 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f3/9d/d6fa.192394.png",
           "demozooUrl": "https://demozoo.org/productions/266867/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/CC/CC.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/CC/CC.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/cc.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=PD3qGShEYsE"
         },
         {
           "id": 147039,
@@ -2276,7 +3259,12 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/72/61/abe4.328985.png",
           "demozooUrl": "https://demozoo.org/productions/147039/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/demos/artists/g0blinish/lordv.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/artists/g0blinish/lordv.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=BJhl9mBeBWA"
         },
         {
           "id": 147040,
@@ -2288,7 +3276,12 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d1/33/98a8.328984.png",
           "demozooUrl": "https://demozoo.org/productions/147040/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/demos/artists/g0blinish/darthlamer.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/artists/g0blinish/darthlamer.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=mDyH7G0Kpvs"
         },
         {
           "id": 266868,
@@ -2300,7 +3293,13 @@
           "year": "2015",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7a/78/424b.192395.png",
           "demozooUrl": "https://demozoo.org/productions/266868/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/SSS/SSS.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/SSS/SSS.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/sss.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=KD6ocf_0Bkw"
         },
         {
           "id": 147038,
@@ -2312,7 +3311,13 @@
           "year": "2014",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8d/57/b610.192396.png",
           "demozooUrl": "https://demozoo.org/productions/147038/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/BOBS/BOBS.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/BOBS/BOBS.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_tour/bobs.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Ut9BuRuoy-A"
         },
         {
           "id": 266871,
@@ -2324,7 +3329,14 @@
           "year": "2014",
           "screenshotUrl": "https://media.demozoo.org/screens/t/15/6e/5b2b.192397.png",
           "demozooUrl": "https://demozoo.org/productions/266871/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/IBZ/IBZ.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/IBZ/IBZ.dsk",
+            "http://fr3nch.t0uch.free.fr/IBZ/IBZ_2014.zip",
+            "https://archive.scene.org/pub/demos/groups/french_touch/ibiza.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=7J2eErdAVr8"
         },
         {
           "id": 266870,
@@ -2336,7 +3348,15 @@
           "year": "2014",
           "screenshotUrl": "https://media.demozoo.org/screens/t/cf/af/64ed.192398.png",
           "demozooUrl": "https://demozoo.org/productions/266870/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/AS/AS-S1.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/AS/AS-S1.dsk",
+            "http://fr3nch.t0uch.free.fr/AS/AS-S2.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/as-s1.zip",
+            "https://archive.scene.org/pub/demos/groups/french_touch/as-s2.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=FZ5BKKAkGsU"
         },
         {
           "id": 266869,
@@ -2348,7 +3368,15 @@
           "year": "2014",
           "screenshotUrl": "https://media.demozoo.org/screens/t/fb/b6/468f.331198.png",
           "demozooUrl": "https://demozoo.org/productions/266869/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "http://fr3nch.t0uch.free.fr/BAA/BAA-S1.dsk",
+          "downloadUrls": [
+            "http://fr3nch.t0uch.free.fr/BAA/BAA-S1.dsk",
+            "http://fr3nch.t0uch.free.fr/BAA/BAA-S2.dsk",
+            "https://archive.scene.org/pub/demos/groups/french_touch/baa-s1.zip",
+            "https://archive.scene.org/pub/demos/groups/french_touch/baa-s2.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=FZ5BKKAkGsU"
         },
         {
           "id": 175678,
@@ -2360,7 +3388,8 @@
           "year": "2014",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d3/b3/03d2.328983.png",
           "demozooUrl": "https://demozoo.org/productions/175678/",
-          "page": 4
+          "page": 4,
+          "youtubeUrl": "https://www.youtube.com/watch?v=n0FpmAZ4hFA"
         },
         {
           "id": 64989,
@@ -2372,7 +3401,11 @@
           "year": "2013",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ec/8a/bb7a.328982.jpg",
           "demozooUrl": "https://demozoo.org/productions/64989/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2013/pixeljam13/glitch_artware/pixeljam2013_krue_artware.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2013/pixeljam13/glitch_artware/pixeljam2013_krue_artware.zip"
+          ]
         },
         {
           "id": 270396,
@@ -2384,7 +3417,11 @@
           "year": "2013",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/270396/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2012/retrospectiva12/games/thedeadlyorbs.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2012/retrospectiva12/games/thedeadlyorbs.zip"
+          ]
         },
         {
           "id": 270399,
@@ -2396,7 +3433,11 @@
           "year": "2013",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/270399/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2012/retrospectiva12/games/surfshooter.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2012/retrospectiva12/games/surfshooter.zip"
+          ]
         },
         {
           "id": 270389,
@@ -2408,7 +3449,11 @@
           "year": "2013",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/270389/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2012/retrospectiva12/games/doubledeadlyorbs.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2012/retrospectiva12/games/doubledeadlyorbs.zip"
+          ]
         },
         {
           "id": 379930,
@@ -2420,7 +3465,12 @@
           "year": "2013",
           "screenshotUrl": "https://media.demozoo.org/screens/t/64/66/7672.368918.png",
           "demozooUrl": "https://demozoo.org/productions/379930/",
-          "page": 4
+          "page": 4,
+          "downloadUrl": "https://www.brutaldeluxe.fr/2013/",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/2013/",
+            "https://www.brutaldeluxe.fr/store/zephyr.html"
+          ]
         }
       ]
     },
@@ -2437,7 +3487,12 @@
           "year": "2012",
           "screenshotUrl": "https://media.demozoo.org/screens/t/34/2c/1de0.143007.png",
           "demozooUrl": "https://demozoo.org/productions/147041/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://github.com/digarok/festro/blob/master/FESTRO.dsk",
+          "downloadUrls": [
+            "https://github.com/digarok/festro/blob/master/FESTRO.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=hidSzEinqao"
         },
         {
           "id": 147042,
@@ -2449,7 +3504,11 @@
           "year": "2012",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e0/64/2d2f.143009.png",
           "demozooUrl": "https://demozoo.org/productions/147042/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://krue.net/prods/glitch_mantra.po",
+          "downloadUrls": [
+            "http://krue.net/prods/glitch_mantra.po"
+          ]
         },
         {
           "id": 50036,
@@ -2459,9 +3518,13 @@
           "author": "Brutal Deluxe / Krüe",
           "dateStr": "Apr 2012",
           "year": "2012",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/37/88/0152.368916.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/21/d7/0559.368917.png",
           "demozooUrl": "https://demozoo.org/productions/50036/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://krue.net/prods/drift.po",
+          "downloadUrls": [
+            "http://krue.net/prods/drift.po"
+          ]
         },
         {
           "id": 147084,
@@ -2473,7 +3536,12 @@
           "year": "2012",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0d/e7/1535.328981.png",
           "demozooUrl": "https://demozoo.org/productions/147084/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://g0blinish.ucoz.ru/demo/ForestFire.zip",
+          "downloadUrls": [
+            "http://g0blinish.ucoz.ru/demo/ForestFire.zip",
+            "https://archive.scene.org/pub/demos/artists/mmphosis/forestfire.zip"
+          ]
         },
         {
           "id": 20866,
@@ -2485,7 +3553,13 @@
           "year": "2011",
           "screenshotUrl": "https://media.demozoo.org/screens/t/54/d6/1035.143006.jpg",
           "demozooUrl": "https://demozoo.org/productions/20866/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.kansasfest.org/wp-content/uploads/2011-kruszyna-squares.po",
+          "downloadUrls": [
+            "https://www.kansasfest.org/wp-content/uploads/2011-kruszyna-squares.po",
+            "http://krue.net/prods/SQUARES.BXY",
+            "https://www.kansasfest.org/wp-content/uploads/2011-kruszyna-squares.bxy"
+          ]
         },
         {
           "id": 5231,
@@ -2497,7 +3571,11 @@
           "year": "2011",
           "screenshotUrl": "https://media.demozoo.org/screens/t/82/78/19fe.143008.png",
           "demozooUrl": "https://demozoo.org/productions/5231/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://archive.scene.org/pub/parties/2011/pixeljam11/oldskool_demo/artwhere.bxy",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/parties/2011/pixeljam11/oldskool_demo/artwhere.bxy"
+          ]
         },
         {
           "id": 174574,
@@ -2509,7 +3587,8 @@
           "year": "2008",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5d/40/7f32.141936.jpg",
           "demozooUrl": "https://demozoo.org/productions/174574/",
-          "page": 5
+          "page": 5,
+          "youtubeUrl": "https://www.youtube.com/watch?v=qzDl4fjtFMg"
         },
         {
           "id": 298183,
@@ -2521,7 +3600,11 @@
           "year": "2004",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/298183/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://web.archive.org/web/20050830144241/http://starbase.globalpc.net/minidir/GAMES/MazezaM/MazezaM.zip",
+          "downloadUrls": [
+            "https://web.archive.org/web/20050830144241/http://starbase.globalpc.net/minidir/GAMES/MazezaM/MazezaM.zip"
+          ]
         },
         {
           "id": 147043,
@@ -2533,7 +3616,12 @@
           "year": "2004",
           "screenshotUrl": "https://media.demozoo.org/screens/t/66/7f/4499.328980.png",
           "demozooUrl": "https://demozoo.org/productions/147043/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://g0blinish.ucoz.ru/demo/KAL2.ZIP",
+          "downloadUrls": [
+            "http://g0blinish.ucoz.ru/demo/KAL2.ZIP"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=LI0WLjyET1c"
         },
         {
           "id": 269235,
@@ -2581,7 +3669,13 @@
           "year": "1992",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a2/ff/8d39.331200.png",
           "demozooUrl": "https://demozoo.org/productions/147045/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/labyrinthe_intro_logo.do",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/labyrinthe_intro_logo.do",
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/LABYRINTHE.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Ri86_XH_FBU"
         },
         {
           "id": 147044,
@@ -2593,7 +3687,13 @@
           "year": "1992",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ee/8c/2704.331199.png",
           "demozooUrl": "https://demozoo.org/productions/147044/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/brazil_intro_logo.do",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/brazil_intro_logo.do",
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BRAZIL.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=CSXj0N-_iPA"
         },
         {
           "id": 379897,
@@ -2605,7 +3705,11 @@
           "year": "1991",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6b/b0/28bd.368891.png",
           "demozooUrl": "https://demozoo.org/productions/379897/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/brazil.html",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/brazil.html"
+          ]
         },
         {
           "id": 379896,
@@ -2617,7 +3721,11 @@
           "year": "1991",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/379896/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/brazil.html",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/brazil.html"
+          ]
         },
         {
           "id": 157909,
@@ -2629,7 +3737,12 @@
           "year": "1990",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d5/6a/c217.107937.png",
           "demozooUrl": "https://demozoo.org/productions/157909/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.03A.DSK",
+          "downloadUrls": [
+            "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.03A.DSK",
+            "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.03B.DSK"
+          ]
         },
         {
           "id": 157908,
@@ -2639,9 +3752,14 @@
           "author": "Fred & Co. / HackerForce / Jack / Lo44 / Smoothy",
           "dateStr": "Oct 1990",
           "year": "1990",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c3/64/25ea.107935.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/65/38/d0db.107936.png",
           "demozooUrl": "https://demozoo.org/productions/157908/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.02A.DSK",
+          "downloadUrls": [
+            "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.02A.DSK",
+            "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.02B.DSK"
+          ]
         },
         {
           "id": 157907,
@@ -2653,7 +3771,12 @@
           "year": "1990",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7f/17/bd76.107933.png",
           "demozooUrl": "https://demozoo.org/productions/157907/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.01A.DSK",
+          "downloadUrls": [
+            "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.01A.DSK",
+            "https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/LOCS.01B.DSK"
+          ]
         },
         {
           "id": 194726,
@@ -2725,7 +3848,11 @@
           "year": "1990",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/175691/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/Targui_Logo.dsk",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/Targui_Logo.dsk"
+          ]
         },
         {
           "id": 175689,
@@ -2737,7 +3864,12 @@
           "year": "1990",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/175689/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/Court_Circuit_f1.dsk",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/Court_Circuit_f1.dsk",
+            "https://www.brutaldeluxe.fr/products/apple2/Court_Circuit_f2.dsk"
+          ]
         },
         {
           "id": 175675,
@@ -2747,9 +3879,15 @@
           "author": "Brutal Deluxe",
           "dateStr": "1990",
           "year": "1990",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/85/98/4c7a.368890.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7a/60/b335.368889.jpg",
           "demozooUrl": "https://demozoo.org/productions/175675/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/LoGo_Anim_Disk1.dsk",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/LoGo_Anim_Disk1.dsk",
+            "https://www.brutaldeluxe.fr/products/apple2/LoGo_Anim_Disk2.dsk",
+            "https://www.brutaldeluxe.fr/products/apple2/LoGo_Anim_Disk3.dsk"
+          ]
         },
         {
           "id": 194759,
@@ -2773,7 +3911,11 @@
           "year": "1989",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ef/d0/738e.286814.png",
           "demozooUrl": "https://demozoo.org/productions/290764/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://archive.org/download/173a_The_Legend_of_Blacksilver_Side_1/173a_The_Legend_of_Blacksilver_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/173a_The_Legend_of_Blacksilver_Side_1/173a_The_Legend_of_Blacksilver_Side_1.dsk"
+          ]
         },
         {
           "id": 292783,
@@ -2783,9 +3925,13 @@
           "author": "Soft-Sect",
           "dateStr": "Jul 1989",
           "year": "1989",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/76/2c/e395.289559.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e2/dd/2fd1.371366.png",
           "demozooUrl": "https://demozoo.org/productions/292783/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://archive.org/download/228a_Earl_Weaver_Baseball_Side_2/228a_Earl_Weaver_Baseball_Side_2.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/228a_Earl_Weaver_Baseball_Side_2/228a_Earl_Weaver_Baseball_Side_2.dsk"
+          ]
         },
         {
           "id": 381870,
@@ -2795,7 +3941,7 @@
           "author": "Soft-Sect",
           "dateStr": "Jul 1989",
           "year": "1989",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/40/e7/4310.372190.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8d/1a/7b0f.372189.png",
           "demozooUrl": "https://demozoo.org/productions/381870/",
           "page": 5
         },
@@ -2809,7 +3955,12 @@
           "year": "1989",
           "screenshotUrl": "https://media.demozoo.org/screens/t/71/70/dc50.331201.jpg",
           "demozooUrl": "https://demozoo.org/productions/147046/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://www.virtualapple.org/apple2/TetrisII.zip",
+          "downloadUrls": [
+            "http://www.virtualapple.org/apple2/TetrisII.zip",
+            "https://archive.scene.org/pub/demos/groups/the_brain_trust/tetrisii.zip"
+          ]
         },
         {
           "id": 381913,
@@ -2819,7 +3970,7 @@
           "author": "Coast To Coast",
           "dateStr": "1989",
           "year": "1989",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1b/c9/ec58.372270.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/cd/23/f998.372271.png",
           "demozooUrl": "https://demozoo.org/productions/381913/",
           "page": 5
         },
@@ -2831,7 +3982,7 @@
           "author": "Soft-Sect",
           "dateStr": "1989",
           "year": "1989",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/37/9b/319d.371122.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/16/c9/c283.371121.png",
           "demozooUrl": "https://demozoo.org/productions/381144/",
           "page": 5
         },
@@ -2843,7 +3994,7 @@
           "author": "Byte Bastards",
           "dateStr": "1989",
           "year": "1989",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/86/9a/825d.172384.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/76/39/060e.371120.png",
           "demozooUrl": "https://demozoo.org/productions/194760/",
           "page": 5
         },
@@ -2855,9 +4006,15 @@
           "author": "Bones",
           "dateStr": "1989",
           "year": "1989",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a6/c4/8f0d.107939.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/98/e4/898c.107943.png",
           "demozooUrl": "https://demozoo.org/productions/157910/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://www.brutaldeluxe.fr/products/underground/bones/bones_slideshow_1_v1.DSK",
+          "downloadUrls": [
+            "http://www.brutaldeluxe.fr/products/underground/bones/bones_slideshow_1_v1.DSK",
+            "http://www.brutaldeluxe.fr/products/underground/bones/bones_slideshow_1_v2.DSK",
+            "https://archive.scene.org/pub/demos/groups/bones/bones_slideshow_1.zip"
+          ]
         },
         {
           "id": 293267,
@@ -2869,7 +4026,11 @@
           "year": "1989",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b3/d1/4a38.290226.png",
           "demozooUrl": "https://demozoo.org/productions/293267/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://archive.org/download/251a_Heavy_Barrell/251a_Heavy_Barrell.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/251a_Heavy_Barrell/251a_Heavy_Barrell.dsk"
+          ]
         },
         {
           "id": 175690,
@@ -2881,7 +4042,11 @@
           "year": "1989",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/175690/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://www.brutaldeluxe.fr/products/apple2/HF_Columns.dsk",
+          "downloadUrls": [
+            "https://www.brutaldeluxe.fr/products/apple2/HF_Columns.dsk"
+          ]
         },
         {
           "id": 381878,
@@ -2905,7 +4070,11 @@
           "year": "1989",
           "screenshotUrl": "https://media.demozoo.org/screens/t/55/64/3785.285612.png",
           "demozooUrl": "https://demozoo.org/productions/289680/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://archive.org/download/099a_Bubble_Bobble_Side_1/099a_Bubble_Bobble_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/099a_Bubble_Bobble_Side_1/099a_Bubble_Bobble_Side_1.dsk"
+          ]
         },
         {
           "id": 194764,
@@ -2917,7 +4086,12 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2f/93/0e1d.172388.png",
           "demozooUrl": "https://demozoo.org/productions/194764/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://boutillon.free.fr/Underground/Magazines/Sygmapple/Sygmapple2/Disks/Sygmapple2_f1.dsk.gz",
+          "downloadUrls": [
+            "http://boutillon.free.fr/Underground/Magazines/Sygmapple/Sygmapple2/Disks/Sygmapple2_f1.dsk.gz",
+            "http://boutillon.free.fr/Underground/Magazines/Sygmapple/Sygmapple2/Disks/Sygmapple2_f2.dsk.gz"
+          ]
         },
         {
           "id": 194765,
@@ -2929,7 +4103,12 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2f/05/5257.172389.png",
           "demozooUrl": "https://demozoo.org/productions/194765/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "http://boutillon.free.fr/Underground/Magazines/Sygmapple/Sygmapple1/Disks/Sygmapple1_f1.dsk.gz",
+          "downloadUrls": [
+            "http://boutillon.free.fr/Underground/Magazines/Sygmapple/Sygmapple1/Disks/Sygmapple1_f1.dsk.gz",
+            "http://boutillon.free.fr/Underground/Magazines/Sygmapple/Sygmapple1/Disks/Sygmapple1_f2.dsk.gz"
+          ]
         },
         {
           "id": 381214,
@@ -2977,7 +4156,11 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e3/85/d918.283731.png",
           "demozooUrl": "https://demozoo.org/productions/288302/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://archive.org/download/015a_Summer_Games_Side_1/015a_Summer_Games_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/015a_Summer_Games_Side_1/015a_Summer_Games_Side_1.dsk"
+          ]
         },
         {
           "id": 381921,
@@ -2987,7 +4170,7 @@
           "author": "Circle K",
           "dateStr": "1988",
           "year": "1988",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/49/b2/06a1.372283.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8c/1e/ba74.372282.png",
           "demozooUrl": "https://demozoo.org/productions/381921/",
           "page": 5
         },
@@ -3001,7 +4184,11 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/48/2e/a9b0.284011.png",
           "demozooUrl": "https://demozoo.org/productions/288515/",
-          "page": 5
+          "page": 5,
+          "downloadUrl": "https://archive.org/download/075a_Police_Quest_Side_1/075a_Police_Quest_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/075a_Police_Quest_Side_1/075a_Police_Quest_Side_1.dsk"
+          ]
         },
         {
           "id": 381894,
@@ -3042,7 +4229,11 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e5/4b/151c.285761.png",
           "demozooUrl": "https://demozoo.org/productions/289795/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/106a_LA_Crackdown_Side_1/106a_LA_Crackdown_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/106a_LA_Crackdown_Side_1/106a_LA_Crackdown_Side_1.dsk"
+          ]
         },
         {
           "id": 291938,
@@ -3054,7 +4245,11 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ba/72/49ae.288109.png",
           "demozooUrl": "https://demozoo.org/productions/291938/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/208a_Gauntlet_Side_1/208a_Gauntlet_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/208a_Gauntlet_Side_1/208a_Gauntlet_Side_1.dsk"
+          ]
         },
         {
           "id": 288299,
@@ -3076,7 +4271,7 @@
           "author": "First Class",
           "dateStr": "1988",
           "year": "1988",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/89/c7/e0e4.370588.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8e/a4/f6f2.370587.png",
           "demozooUrl": "https://demozoo.org/productions/380843/",
           "page": 6
         },
@@ -3090,7 +4285,11 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d9/8f/965d.285094.png",
           "demozooUrl": "https://demozoo.org/productions/289457/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/3d0g_096a_Crossbow_Side_1/096a_Crossbow_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_096a_Crossbow_Side_1/096a_Crossbow_Side_1.dsk"
+          ]
         },
         {
           "id": 292814,
@@ -3100,9 +4299,13 @@
           "author": "Coast To Coast",
           "dateStr": "1988",
           "year": "1988",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/58/69/2b4b.371356.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b2/1e/6371.289598.png",
           "demozooUrl": "https://demozoo.org/productions/292814/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/242a_Bad_Dudes_Disk_1/242a_Bad_Dudes_Disk_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/242a_Bad_Dudes_Disk_1/242a_Bad_Dudes_Disk_1.dsk"
+          ]
         },
         {
           "id": 288310,
@@ -3126,7 +4329,12 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5a/de/a0df.328979.png",
           "demozooUrl": "https://demozoo.org/productions/147047/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "http://www.freetoolsassociation.com/fta/img/acsanim.zip",
+          "downloadUrls": [
+            "http://www.freetoolsassociation.com/fta/img/acsanim.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=wkQJla_NYbw"
         },
         {
           "id": 288314,
@@ -3138,7 +4346,11 @@
           "year": "1988",
           "screenshotUrl": "https://media.demozoo.org/screens/t/27/03/e1ee.283759.png",
           "demozooUrl": "https://demozoo.org/productions/288314/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/024a_Ancient_Art_of_War_at_Sea_Side_1/024a_Ancient_Art_of_War_at_Sea_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/024a_Ancient_Art_of_War_at_Sea_Side_1/024a_Ancient_Art_of_War_at_Sea_Side_1.dsk"
+          ]
         },
         {
           "id": 293796,
@@ -3150,7 +4362,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/be/d4/9ea1.370977.png",
           "demozooUrl": "https://demozoo.org/productions/293796/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/272a_Kid_Nikki/272a_Kid_Nikki.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/272a_Kid_Nikki/272a_Kid_Nikki.dsk"
+          ]
         },
         {
           "id": 381964,
@@ -3186,7 +4402,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a7/f2/80a2.284000.png",
           "demozooUrl": "https://demozoo.org/productions/288508/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/066b_Bards_Tale_II_Solution/066b_Bards_Tale_II_Solution.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/066b_Bards_Tale_II_Solution/066b_Bards_Tale_II_Solution.dsk"
+          ]
         },
         {
           "id": 381877,
@@ -3208,7 +4428,7 @@
           "author": "Coast To Coast",
           "dateStr": "Aug 1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bc/27/e4c4.371132.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ea/fb/1ec1.371133.png",
           "demozooUrl": "https://demozoo.org/productions/381152/",
           "page": 6
         },
@@ -3222,7 +4442,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/20/ec/0ba1.293463.png",
           "demozooUrl": "https://demozoo.org/productions/295551/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/286_Cheat_Maker/286_Cheat_Maker.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/286_Cheat_Maker/286_Cheat_Maker.dsk"
+          ]
         },
         {
           "id": 288372,
@@ -3234,7 +4458,12 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/48/80/c495.283854.png",
           "demozooUrl": "https://demozoo.org/productions/288372/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/059_South_Pacific_Quest/059_South_Pacific_Quest.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/059_South_Pacific_Quest/059_South_Pacific_Quest.dsk",
+            "https://archive.org/download/301_South_Pacific_Quest/301_South_Pacific_Quest.dsk"
+          ]
         },
         {
           "id": 381137,
@@ -3258,7 +4487,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/80/52/3656.290227.png",
           "demozooUrl": "https://demozoo.org/productions/293268/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/252_Targets/252_Targets.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/252_Targets/252_Targets.dsk"
+          ]
         },
         {
           "id": 381138,
@@ -3282,7 +4515,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ae/eb/df84.156936.png",
           "demozooUrl": "https://demozoo.org/productions/183740/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "ftp://ftp.apple.asimov.net/pub/apple_II/images/demos/Boing!%20(amiga%20demo).zip",
+          "downloadUrls": [
+            "ftp://ftp.apple.asimov.net/pub/apple_II/images/demos/Boing!%20(amiga%20demo).zip"
+          ]
         },
         {
           "id": 288316,
@@ -3294,7 +4531,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/95/49/d9dd.371429.png",
           "demozooUrl": "https://demozoo.org/productions/288316/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/026_Speed_Demon/026_Speed_Demon.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/026_Speed_Demon/026_Speed_Demon.dsk"
+          ]
         },
         {
           "id": 147048,
@@ -3318,7 +4559,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/83/4a/2ddb.285908.png",
           "demozooUrl": "https://demozoo.org/productions/289900/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/121a_World_Games_Side_1/121a_World_Games_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/121a_World_Games_Side_1/121a_World_Games_Side_1.dsk"
+          ]
         },
         {
           "id": 381209,
@@ -3328,7 +4573,7 @@
           "author": "Dark Logic",
           "dateStr": "Jan 1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c7/b3/37ee.371275.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/42/08/2c21.371274.png",
           "demozooUrl": "https://demozoo.org/productions/381209/",
           "page": 6
         },
@@ -3388,7 +4633,7 @@
           "author": "Digital Gang",
           "dateStr": "1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/06/74/eb32.372330.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/25/6a/df86.372331.png",
           "demozooUrl": "https://demozoo.org/productions/381949/",
           "page": 6
         },
@@ -3414,7 +4659,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ac/f9/deb4.290923.png",
           "demozooUrl": "https://demozoo.org/productions/293794/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/267a_Thexder_Side_1/267a_Thexder_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/267a_Thexder_Side_1/267a_Thexder_Side_1.dsk"
+          ]
         },
         {
           "id": 381164,
@@ -3426,7 +4675,11 @@
           "year": "1987",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/381164/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/scoop.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/scoop.gif"
+          ]
         },
         {
           "id": 293264,
@@ -3438,7 +4691,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3d/d9/dc2b.290224.png",
           "demozooUrl": "https://demozoo.org/productions/293264/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/249a_SuperStar_Hockey_Side_1/249a_SuperStar_Hockey_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/249a_SuperStar_Hockey_Side_1/249a_SuperStar_Hockey_Side_1.dsk"
+          ]
         },
         {
           "id": 307093,
@@ -3462,7 +4719,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f5/2e/a113.285610.png",
           "demozooUrl": "https://demozoo.org/productions/289678/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/098a_Strike_Fleet_Side_1/098a_Strike_Fleet_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/098a_Strike_Fleet_Side_1/098a_Strike_Fleet_Side_1.dsk"
+          ]
         },
         {
           "id": 381957,
@@ -3486,7 +4747,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d0/58/c92d.283994.png",
           "demozooUrl": "https://demozoo.org/productions/288502/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/059a_Space_Quest_II_Side_1/059a_Space_Quest_II_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/059a_Space_Quest_II_Side_1/059a_Space_Quest_II_Side_1.dsk"
+          ]
         },
         {
           "id": 381955,
@@ -3510,7 +4775,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/69/17/a9b0.283783.png",
           "demozooUrl": "https://demozoo.org/productions/288327/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/036a_Platoon_Side_1/036a_Platoon_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/036a_Platoon_Side_1/036a_Platoon_Side_1.dsk"
+          ]
         },
         {
           "id": 381895,
@@ -3532,7 +4801,7 @@
           "author": "Miami Sound Machine",
           "dateStr": "1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4d/85/9361.372263.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ae/88/4e4e.372264.png",
           "demozooUrl": "https://demozoo.org/productions/381908/",
           "page": 6
         },
@@ -3544,7 +4813,7 @@
           "author": "Coast To Coast",
           "dateStr": "1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/15/8c/5a42.370989.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/0d/22/9492.370988.png",
           "demozooUrl": "https://demozoo.org/productions/381069/",
           "page": 6
         },
@@ -3570,7 +4839,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/74/7c/55e8.283785.png",
           "demozooUrl": "https://demozoo.org/productions/288329/",
-          "page": 6
+          "page": 6,
+          "downloadUrl": "https://archive.org/download/037a_Land_of_the_Lounge_Lizards/037a_Land_of_the_Lounge_Lizards.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/037a_Land_of_the_Lounge_Lizards/037a_Land_of_the_Lounge_Lizards.dsk"
+          ]
         },
         {
           "id": 381959,
@@ -3616,7 +4889,7 @@
           "author": "Digital Gang",
           "dateStr": "1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/2e/1b/d226.370703.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/2d/2e/c156.370702.png",
           "demozooUrl": "https://demozoo.org/productions/380896/",
           "page": 6
         },
@@ -3628,7 +4901,7 @@
           "author": "Dark Logic",
           "dateStr": "1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/64/1b/0a1a.372174.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a0/ab/9b9c.372173.png",
           "demozooUrl": "https://demozoo.org/productions/381861/",
           "page": 6
         }
@@ -3647,7 +4920,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2e/68/0074.285496.png",
           "demozooUrl": "https://demozoo.org/productions/289596/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/076_GFL_Championship_Football/076_GFL_Championship_Football.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/076_GFL_Championship_Football/076_GFL_Championship_Football.dsk"
+          ]
         },
         {
           "id": 293274,
@@ -3659,7 +4936,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b9/da/083e.290919.png",
           "demozooUrl": "https://demozoo.org/productions/293274/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/259b_Force_7/259b_Force_7.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/259b_Force_7/259b_Force_7.dsk"
+          ]
         },
         {
           "id": 295555,
@@ -3671,7 +4952,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/58/e8/6424.293467.png",
           "demozooUrl": "https://demozoo.org/productions/295555/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/294_EOS_Earth_Orbit_Station/294_EOS_Earth_Orbit_Station.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/294_EOS_Earth_Orbit_Station/294_EOS_Earth_Orbit_Station.dsk"
+          ]
         },
         {
           "id": 288371,
@@ -3683,7 +4968,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/79/56/269d.283853.png",
           "demozooUrl": "https://demozoo.org/productions/288371/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/057_Dragon_Fire_II/057_Dragon_Fire_II.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/057_Dragon_Fire_II/057_Dragon_Fire_II.dsk"
+          ]
         },
         {
           "id": 381915,
@@ -3731,7 +5020,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f4/ce/aea0.293466.png",
           "demozooUrl": "https://demozoo.org/productions/295554/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/293_Boulder_Dash_Construction_Set/293_Boulder_Dash_Construction_Set.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/293_Boulder_Dash_Construction_Set/293_Boulder_Dash_Construction_Set.dsk"
+          ]
         },
         {
           "id": 381938,
@@ -3779,7 +5072,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/54/65/7cbf.290922.png",
           "demozooUrl": "https://demozoo.org/productions/293793/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/266b_Aliens_Side_2/266b_Aliens_Side_2.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/266b_Aliens_Side_2/266b_Aliens_Side_2.dsk"
+          ]
         },
         {
           "id": 381947,
@@ -3789,7 +5086,7 @@
           "author": "Digital Gang",
           "dateStr": "1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9e/b7/f326.372329.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/1c/f8/99ba.372328.png",
           "demozooUrl": "https://demozoo.org/productions/381947/",
           "page": 7
         },
@@ -3803,7 +5100,11 @@
           "year": "1987",
           "screenshotUrl": "https://media.demozoo.org/screens/t/63/9d/cba8.283996.png",
           "demozooUrl": "https://demozoo.org/productions/288504/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/061_AE_Fone_Book/061_AE_Fone_Book.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/061_AE_Fone_Book/061_AE_Fone_Book.dsk"
+          ]
         },
         {
           "id": 288350,
@@ -3813,9 +5114,13 @@
           "author": "Digital Gang",
           "dateStr": "1987",
           "year": "1987",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/cf/7b/c6f1.370976.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a1/56/528a.283837.png",
           "demozooUrl": "https://demozoo.org/productions/288350/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/052_2400_A.D./052_2400_A.D..dsk",
+          "downloadUrls": [
+            "https://archive.org/download/052_2400_A.D./052_2400_A.D..dsk"
+          ]
         },
         {
           "id": 381104,
@@ -3825,7 +5130,7 @@
           "author": "First Class",
           "dateStr": "Dec 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/07/27/23a1.371047.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/90/9d/3079.371046.png",
           "demozooUrl": "https://demozoo.org/productions/381104/",
           "page": 7
         },
@@ -3849,9 +5154,14 @@
           "author": "Prime Source",
           "dateStr": "Dec 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ed/db/3db9.371426.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/79/5f/ad25.295237.png",
           "demozooUrl": "https://demozoo.org/productions/296789/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/321_Beagle_Compiler/321_Beagle_Compiler.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/321_Beagle_Compiler/321_Beagle_Compiler.dsk",
+            "https://archive.org/download/356_Compiler/356_Compiler.dsk"
+          ]
         },
         {
           "id": 381161,
@@ -3909,7 +5219,7 @@
           "author": "Miami Sound Machine",
           "dateStr": "Sep 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/35/94/17ce.372259.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/41/e2/1c9e.372260.png",
           "demozooUrl": "https://demozoo.org/productions/381907/",
           "page": 7
         },
@@ -3935,7 +5245,12 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b6/06/9038.286098.png",
           "demozooUrl": "https://demozoo.org/productions/290076/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/143b_Shanghai/143b_Shanghai.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/143b_Shanghai/143b_Shanghai.dsk",
+            "https://archive.org/download/a2_Shanghai_1986_Activision_cr_First_Class/Shanghai_1986_Activision_cr_First_Class.do"
+          ]
         },
         {
           "id": 381259,
@@ -3945,7 +5260,7 @@
           "author": "Firefox",
           "dateStr": "Aug 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/6b/53/a85f.371414.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ca/d7/9434.371416.png",
           "demozooUrl": "https://demozoo.org/productions/381259/",
           "page": 7
         },
@@ -3957,9 +5272,13 @@
           "author": "Disk Crasher",
           "dateStr": "Aug 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/fa/0a/0e1c.372312.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/33/e0/3c24.372313.png",
           "demozooUrl": "https://demozoo.org/productions/289714/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/103_Infocom_Cracker/103_Infocom_Cracker.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/103_Infocom_Cracker/103_Infocom_Cracker.dsk"
+          ]
         },
         {
           "id": 288304,
@@ -3969,9 +5288,13 @@
           "author": "Wizard IIe",
           "dateStr": "May 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ca/b0/876b.371425.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/86/bf/8d28.371424.png",
           "demozooUrl": "https://demozoo.org/productions/288304/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/016_RDOS_Master/016_RDOS_Master.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/016_RDOS_Master/016_RDOS_Master.dsk"
+          ]
         },
         {
           "id": 288333,
@@ -3981,9 +5304,13 @@
           "author": "Gadget Master",
           "dateStr": "Apr 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/5f/92/00ec.371432.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/6b/a5/28cf.283789.png",
           "demozooUrl": "https://demozoo.org/productions/288333/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/048_GM_QuikRaks_IIe/048_GM_QuikRaks_IIe.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/048_GM_QuikRaks_IIe/048_GM_QuikRaks_IIe.dsk"
+          ]
         },
         {
           "id": 381900,
@@ -3993,7 +5320,7 @@
           "author": "Legion of Underground Software Technicians",
           "dateStr": "Mar 1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/8f/e5/f908.372240.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/2c/95/f231.372243.png",
           "demozooUrl": "https://demozoo.org/productions/381900/",
           "page": 7
         },
@@ -4007,7 +5334,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e0/2d/62ff.295727.png",
           "demozooUrl": "https://demozoo.org/productions/297123/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/357_Alter_Ego_Disk_3_Side_2/357_Alter_Ego_Disk_3_Side_2.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/357_Alter_Ego_Disk_3_Side_2/357_Alter_Ego_Disk_3_Side_2.dsk"
+          ]
         },
         {
           "id": 381886,
@@ -4043,7 +5374,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0e/3b/2e0e.290928.png",
           "demozooUrl": "https://demozoo.org/productions/293799/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/280b_World_Karate_Championship/280b_World_Karate_Championship.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/280b_World_Karate_Championship/280b_World_Karate_Championship.dsk"
+          ]
         },
         {
           "id": 381916,
@@ -4065,9 +5400,14 @@
           "author": "Black Bag",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d7/6b/64ab.371306.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7d/8e/d7f6.74135.jpg",
           "demozooUrl": "https://demozoo.org/productions/121613/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.scene.org/pub/demos/groups/black_bag/blackbag3.zip",
+          "downloadUrls": [
+            "https://archive.scene.org/pub/demos/groups/black_bag/blackbag3.zip",
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BLACKBAG3.zip"
+          ]
         },
         {
           "id": 381922,
@@ -4077,7 +5417,7 @@
           "author": "Evil Sock / Optimus Prime",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ba/1e/5c62.372287.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/88/3b/d657.372286.png",
           "demozooUrl": "https://demozoo.org/productions/381922/",
           "page": 7
         },
@@ -4091,7 +5431,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7f/9c/8710.172344.png",
           "demozooUrl": "https://demozoo.org/productions/194715/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "http://boutillon.free.fr/Underground/Deplombage/Interviews/Mister_Z/Disks/Where_In_The_USA_Is_Carmen_San_Diego_Intro_Z.dsk.gz",
+          "downloadUrls": [
+            "http://boutillon.free.fr/Underground/Deplombage/Interviews/Mister_Z/Disks/Where_In_The_USA_Is_Carmen_San_Diego_Intro_Z.dsk.gz"
+          ]
         },
         {
           "id": 381954,
@@ -4113,7 +5457,7 @@
           "author": "",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bc/0b/78dd.372342.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7e/49/8f92.372340.png",
           "demozooUrl": "https://demozoo.org/productions/381953/",
           "page": 7
         },
@@ -4185,7 +5529,7 @@
           "author": "First Class",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/fc/84/12e4.372183.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/6d/e1/bb65.372182.png",
           "demozooUrl": "https://demozoo.org/productions/381865/",
           "page": 7
         },
@@ -4211,7 +5555,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9d/7b/ed41.290225.png",
           "demozooUrl": "https://demozoo.org/productions/293265/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/250_Super_Sunday/250_Super_Sunday.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/250_Super_Sunday/250_Super_Sunday.dsk"
+          ]
         },
         {
           "id": 310518,
@@ -4223,7 +5571,12 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/af/88/fa7a.311107.png",
           "demozooUrl": "https://demozoo.org/productions/310518/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://archive.org/download/448b_Super_Huey/448b_Super_Huey.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/448b_Super_Huey/448b_Super_Huey.dsk",
+            "https://archive.org/download/a2_Super_Huey/Super_Huey.dsk"
+          ]
         },
         {
           "id": 147052,
@@ -4235,7 +5588,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/89/03/4d47.331203.jpg",
           "demozooUrl": "https://demozoo.org/productions/147052/",
-          "page": 7
+          "page": 7,
+          "downloadUrl": "https://ftp.untergrund.net/users/StingRay/AppleII/Cracktro%20Only-Super%20Boulderdash.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/StingRay/AppleII/Cracktro%20Only-Super%20Boulderdash.zip"
+          ]
         }
       ]
     },
@@ -4276,7 +5633,12 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/4a/ad/a90c.286104.png",
           "demozooUrl": "https://demozoo.org/productions/290081/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/148b_Championship_Boxing/148b_Championship_Boxing.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/148b_Championship_Boxing/148b_Championship_Boxing.dsk",
+            "https://archive.org/download/a2_Sierra_Championship_Boxing_1985_Sierra_cr_Digital_Gang/Sierra_Championship_Boxing_1985_Sierra_cr_Digital_Gang.do"
+          ]
         },
         {
           "id": 289460,
@@ -4288,7 +5650,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1c/c5/e733.285096.png",
           "demozooUrl": "https://demozoo.org/productions/289460/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/3d0g_103b_Sensible_Grammar/103b_Sensible_Grammar.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_103b_Sensible_Grammar/103b_Sensible_Grammar.dsk"
+          ]
         },
         {
           "id": 381883,
@@ -4312,7 +5678,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8a/9c/3fa4.372276.png",
           "demozooUrl": "https://demozoo.org/productions/381158/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/rrascalc.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/rrascalc.gif"
+          ]
         },
         {
           "id": 381149,
@@ -4334,7 +5704,7 @@
           "author": "Extension 1200",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bd/33/4ceb.372053.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/79/bd/7e5e.372054.png",
           "demozooUrl": "https://demozoo.org/productions/381797/",
           "page": 8
         },
@@ -4370,9 +5740,13 @@
           "author": "The Integral Matrix",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/44/99/2726.371439.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/5f/e0/ceff.371441.png",
           "demozooUrl": "https://demozoo.org/productions/292816/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/244_Pursuit_of_Piracy/244_Pursuit_of_Piracy.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/244_Pursuit_of_Piracy/244_Pursuit_of_Piracy.dsk"
+          ]
         },
         {
           "id": 309374,
@@ -4382,7 +5756,7 @@
           "author": "Star League",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d8/1e/6537.371115.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/97/6d/029d.371114.png",
           "demozooUrl": "https://demozoo.org/productions/309374/",
           "page": 8
         },
@@ -4430,7 +5804,7 @@
           "author": "Lone Star Distributors",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/18/f6/f9e7.371020.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4e/ba/3b7c.371021.png",
           "demozooUrl": "https://demozoo.org/productions/381088/",
           "page": 8
         },
@@ -4444,7 +5818,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/12/6f/9ca6.295235.png",
           "demozooUrl": "https://demozoo.org/productions/296787/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/318_Multiscribe_Side_1/318_Multiscribe_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/318_Multiscribe_Side_1/318_Multiscribe_Side_1.dsk"
+          ]
         },
         {
           "id": 381103,
@@ -4514,9 +5892,13 @@
           "author": "Masters Cracking Service",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/b8/30/f733.172347.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/d7/f1/acde.172348.png",
           "demozooUrl": "https://demozoo.org/productions/194716/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "http://boutillon.free.fr/Underground/Deplombage/MCS_Toolbox/Disks/MCS_Toolbox.do.gz",
+          "downloadUrls": [
+            "http://boutillon.free.fr/Underground/Deplombage/MCS_Toolbox/Disks/MCS_Toolbox.do.gz"
+          ]
         },
         {
           "id": 381071,
@@ -4562,7 +5944,7 @@
           "author": "Digital Gang",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/36/cc/27a9.370986.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/5e/db/2fca.370987.png",
           "demozooUrl": "https://demozoo.org/productions/381068/",
           "page": 8
         },
@@ -4576,7 +5958,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b1/8c/1ccd.290233.png",
           "demozooUrl": "https://demozoo.org/productions/293269/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/253a_Kings_Quest_III_Side_1/253a_Kings_Quest_III_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/253a_Kings_Quest_III_Side_1/253a_Kings_Quest_III_Side_1.dsk"
+          ]
         },
         {
           "id": 288294,
@@ -4624,7 +6010,12 @@
           "year": "1986",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/381194/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/trinity.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/trinity.gif",
+            "http://artscene.textfiles.com/intros/APPLEII/trinitym.gif"
+          ]
         },
         {
           "id": 290005,
@@ -4636,7 +6027,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/43/ac/71b5.285981.png",
           "demozooUrl": "https://demozoo.org/productions/290005/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/141a_Ikari_Warriors_Side_1/141a_Ikari_Warriors_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/141a_Ikari_Warriors_Side_1/141a_Ikari_Warriors_Side_1.dsk"
+          ]
         },
         {
           "id": 380917,
@@ -4670,7 +6065,7 @@
           "author": "Digital Gang",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d7/07/7b84.370727.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/bf/39/072d.370726.png",
           "demozooUrl": "https://demozoo.org/productions/380904/",
           "page": 8
         },
@@ -4684,7 +6079,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/be/3d/bdda.308401.png",
           "demozooUrl": "https://demozoo.org/productions/308371/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/Gunslinger-S1/Gunslinger-S1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/Gunslinger-S1/Gunslinger-S1.dsk"
+          ]
         },
         {
           "id": 296792,
@@ -4694,9 +6093,13 @@
           "author": "Coast To Coast",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/95/be/8837.295238.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/87/ac/3d16.371354.png",
           "demozooUrl": "https://demozoo.org/productions/296792/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/321_Guitar_Wizard/321_Guitar_Wizard.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/321_Guitar_Wizard/321_Guitar_Wizard.dsk"
+          ]
         },
         {
           "id": 381810,
@@ -4720,7 +6123,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a5/c6/a77b.370668.png",
           "demozooUrl": "https://demozoo.org/productions/288323/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/031b_Fooblitzky/031b_Fooblitzky.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/031b_Fooblitzky/031b_Fooblitzky.dsk"
+          ]
         },
         {
           "id": 380879,
@@ -4756,7 +6163,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d9/db/f3d6.297192.png",
           "demozooUrl": "https://demozoo.org/productions/298778/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/396_-Donald_Ducks_Playground/396_-Donald_Ducks_Playground.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/396_-Donald_Ducks_Playground/396_-Donald_Ducks_Playground.dsk"
+          ]
         },
         {
           "id": 380844,
@@ -4792,7 +6203,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/71/25/5c60.172386.png",
           "demozooUrl": "https://demozoo.org/productions/194762/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "http://boutillon.free.fr/Underground/Deplombage/Cracking_Techniques/1986/Disks/Cracking_Techniques_1986.dsk.gz",
+          "downloadUrls": [
+            "http://boutillon.free.fr/Underground/Deplombage/Cracking_Techniques/1986/Disks/Cracking_Techniques_1986.dsk.gz"
+          ]
         },
         {
           "id": 289598,
@@ -4804,7 +6219,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/56/b3/dbb4.285498.png",
           "demozooUrl": "https://demozoo.org/productions/289598/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/080_Conjector/080_Conjector.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/080_Conjector/080_Conjector.dsk"
+          ]
         },
         {
           "id": 298617,
@@ -4816,7 +6235,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a3/66/b51c.297149.png",
           "demozooUrl": "https://demozoo.org/productions/298617/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/380_Conflict_in_Vietnam_Side_1/380_Conflict_in_Vietnam_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/380_Conflict_in_Vietnam_Side_1/380_Conflict_in_Vietnam_Side_1.dsk"
+          ]
         },
         {
           "id": 295548,
@@ -4828,7 +6251,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b2/06/2544.293458.png",
           "demozooUrl": "https://demozoo.org/productions/295548/",
-          "page": 8
+          "page": 8,
+          "downloadUrl": "https://archive.org/download/284_Championship_Gambler/284_Championship_Gambler.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/284_Championship_Gambler/284_Championship_Gambler.dsk"
+          ]
         },
         {
           "id": 381946,
@@ -4855,9 +6282,13 @@
           "author": "Coast To Coast",
           "dateStr": "1986",
           "year": "1986",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/7a/f9/0e11.297147.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/70/4a/2b67.297146.png",
           "demozooUrl": "https://demozoo.org/productions/298615/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/370_Battlefront_Side_1/370_Battlefront_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/370_Battlefront_Side_1/370_Battlefront_Side_1.dsk"
+          ]
         },
         {
           "id": 381750,
@@ -4881,7 +6312,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c9/88/f57c.283998.png",
           "demozooUrl": "https://demozoo.org/productions/288506/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/064_AE_1986/064_AE_1986.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/064_AE_1986/064_AE_1986.dsk"
+          ]
         },
         {
           "id": 288311,
@@ -4893,7 +6328,11 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2d/46/04e9.283756.png",
           "demozooUrl": "https://demozoo.org/productions/288311/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/019_Animate/019_Animate.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/019_Animate/019_Animate.dsk"
+          ]
         },
         {
           "id": 380805,
@@ -4929,7 +6368,12 @@
           "year": "1986",
           "screenshotUrl": "https://media.demozoo.org/screens/t/50/76/8374.289557.png",
           "demozooUrl": "https://demozoo.org/productions/268895/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "ftp://computermuseum.informatik.uni-stuttgart.de/apple/mirrors.apple2.org.za/ftp.apple.asimov.net/images/games/adventure/221b_baker_street/221b_baker_street_1.dsk",
+          "downloadUrls": [
+            "ftp://computermuseum.informatik.uni-stuttgart.de/apple/mirrors.apple2.org.za/ftp.apple.asimov.net/images/games/adventure/221b_baker_street/221b_baker_street_1.dsk",
+            "https://archive.org/download/221b_baker_street_1/221b_baker_street_1.dsk"
+          ]
         },
         {
           "id": 380903,
@@ -4977,7 +6421,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a2/bb/bb87.297272.png",
           "demozooUrl": "https://demozoo.org/productions/298784/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/399_Fantastic_Four_Side_1/399_Fantastic_Four_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/399_Fantastic_Four_Side_1/399_Fantastic_Four_Side_1.dsk"
+          ]
         },
         {
           "id": 381174,
@@ -5011,7 +6459,7 @@
           "author": "Digital Gang / Gadget Master",
           "dateStr": "Oct 1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/dc/ec/eaab.370581.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/1a/2d/f289.370582.png",
           "demozooUrl": "https://demozoo.org/productions/380841/",
           "page": 9
         },
@@ -5037,7 +6485,12 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/33/2c/6e94.311170.png",
           "demozooUrl": "https://demozoo.org/productions/310540/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/sherlock_holmes_another_bow_1/sherlock_holmes_another_bow_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/sherlock_holmes_another_bow_1/sherlock_holmes_another_bow_1.dsk",
+            "https://archive.org/download/sherlock_holmes_another_bow_1/sherlock_holmes_another_bow_2.dsk"
+          ]
         },
         {
           "id": 381049,
@@ -5073,7 +6526,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/79/ad/c5ee.295728.png",
           "demozooUrl": "https://demozoo.org/productions/297124/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/364_At_the_Gates_of_Moscow_Side_1/364_At_the_Gates_of_Moscow_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/364_At_the_Gates_of_Moscow_Side_1/364_At_the_Gates_of_Moscow_Side_1.dsk"
+          ]
         },
         {
           "id": 380884,
@@ -5097,7 +6554,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/54/bb/32db.306356.png",
           "demozooUrl": "https://demozoo.org/productions/306532/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/3d0g_186b_Mindbind/186b_Mindbind.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_186b_Mindbind/186b_Mindbind.dsk"
+          ]
         },
         {
           "id": 381833,
@@ -5133,7 +6594,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/08/d8/d539.331204.jpg",
           "demozooUrl": "https://demozoo.org/productions/121612/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/PIRATEROGUE.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/PIRATEROGUE.zip"
+          ]
         },
         {
           "id": 382240,
@@ -5157,7 +6622,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/18/4d/885c.286103.png",
           "demozooUrl": "https://demozoo.org/productions/290080/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/148a_Championship_Tennis/148a_Championship_Tennis.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/148a_Championship_Tennis/148a_Championship_Tennis.dsk"
+          ]
         },
         {
           "id": 147056,
@@ -5167,9 +6636,14 @@
           "author": "Digital Gang",
           "dateStr": "Apr 1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/02/d8/cb6c.372334.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/80/3b/00b3.372336.png",
           "demozooUrl": "https://demozoo.org/productions/147056/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "http://mysql.crihan.fr/crihan/apple.asimov.net/ftp.apple.asimov.net/pub/apple_II/images/graphics/hi_res_scroller.dsk.gz",
+          "downloadUrls": [
+            "http://mysql.crihan.fr/crihan/apple.asimov.net/ftp.apple.asimov.net/pub/apple_II/images/graphics/hi_res_scroller.dsk.gz"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=aNCJULMUANE"
         },
         {
           "id": 381830,
@@ -5179,7 +6653,7 @@
           "author": "",
           "dateStr": "Apr 1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/44/d6/e3b7.372102.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8f/be/78e9.372103.png",
           "demozooUrl": "https://demozoo.org/productions/381830/",
           "page": 9
         },
@@ -5203,7 +6677,7 @@
           "author": "Club 68000 / Squadron 617",
           "dateStr": "Mar 1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/67/a6/af68.371189.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a2/80/b400.371188.png",
           "demozooUrl": "https://demozoo.org/productions/381176/",
           "page": 9
         },
@@ -5215,7 +6689,7 @@
           "author": "Captain Nemo / Oliver Wendell Jones",
           "dateStr": "Jan 1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/51/df/2af2.370443.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/78/e0/6cdf.370444.png",
           "demozooUrl": "https://demozoo.org/productions/380800/",
           "page": 9
         },
@@ -5263,9 +6737,13 @@
           "author": "Pacific Pirate's Guild",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/3d/41/1447.370557.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/04/d4/9f14.283836.png",
           "demozooUrl": "https://demozoo.org/productions/288349/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/051_Wilderness/051_Wilderness.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/051_Wilderness/051_Wilderness.dsk"
+          ]
         },
         {
           "id": 290095,
@@ -5275,9 +6753,13 @@
           "author": "Black Bag",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/6f/9d/118a.371333.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ef/95/c0dc.286123.png",
           "demozooUrl": "https://demozoo.org/productions/290095/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/162a_Where_in_the_World_is_Carmen_SanDiego_CTRL-I_Side_1/162a_Where_in_the_World_is_Carmen_SanDiego_CTRL-I_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/162a_Where_in_the_World_is_Carmen_SanDiego_CTRL-I_Side_1/162a_Where_in_the_World_is_Carmen_SanDiego_CTRL-I_Side_1.dsk"
+          ]
         },
         {
           "id": 290762,
@@ -5289,7 +6771,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ec/3c/c291.286812.png",
           "demozooUrl": "https://demozoo.org/productions/290762/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/164a_Where_In_The_World_Is_Carmen_Sandiego_Side_1/164a_Where_In_The_World_Is_Carmen_Sandiego_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/164a_Where_In_The_World_Is_Carmen_Sandiego_Side_1/164a_Where_In_The_World_Is_Carmen_Sandiego_Side_1.dsk"
+          ]
         },
         {
           "id": 147064,
@@ -5301,7 +6787,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7a/71/ad62.284855.png",
           "demozooUrl": "https://demozoo.org/productions/147064/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/ROUNDTABLE.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/ROUNDTABLE.zip"
+          ]
         },
         {
           "id": 381211,
@@ -5311,7 +6801,7 @@
           "author": "",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bd/88/67d6.371280.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/dd/ef/21fa.371279.png",
           "demozooUrl": "https://demozoo.org/productions/381211/",
           "page": 9
         },
@@ -5325,7 +6815,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/aa/3e/2d3d.293459.png",
           "demozooUrl": "https://demozoo.org/productions/295549/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/285b_Video_Vegas/285b_Video_Vegas.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/285b_Video_Vegas/285b_Video_Vegas.dsk"
+          ]
         },
         {
           "id": 381250,
@@ -5371,9 +6865,13 @@
           "author": "Southwest Pirate's Guild",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4c/e1/1e28.371401.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/d0/f0/9f84.371400.png",
           "demozooUrl": "https://demozoo.org/productions/291118/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/198_Ultima_IV_Construction_Set/198_Ultima_IV_Construction_Set.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/198_Ultima_IV_Construction_Set/198_Ultima_IV_Construction_Set.dsk"
+          ]
         },
         {
           "id": 147074,
@@ -5385,7 +6883,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/20/3d/405c.331210.jpg",
           "demozooUrl": "https://demozoo.org/productions/147074/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/WAREFORCE.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/WAREFORCE.zip"
+          ]
         },
         {
           "id": 288309,
@@ -5397,7 +6899,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a6/5a/4d80.283754.png",
           "demozooUrl": "https://demozoo.org/productions/288309/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/016b_Track_and_Field/016b_Track_and_Field.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/016b_Track_and_Field/016b_Track_and_Field.dsk"
+          ]
         },
         {
           "id": 381193,
@@ -5433,7 +6939,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a3/3f/81cc.290223.png",
           "demozooUrl": "https://demozoo.org/productions/293263/",
-          "page": 9
+          "page": 9,
+          "downloadUrl": "https://archive.org/download/248_Secure_Disk/248_Secure_Disk.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/248_Secure_Disk/248_Secure_Disk.dsk"
+          ]
         },
         {
           "id": 380797,
@@ -5443,7 +6953,7 @@
           "author": "Micro-Mafia",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/97/2a/7ea8.370441.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b6/03/6ac5.370440.png",
           "demozooUrl": "https://demozoo.org/productions/380797/",
           "page": 9
         }
@@ -5460,9 +6970,13 @@
           "author": "Surfer Bill",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/55/5f/7f9c.293457.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/03/fc/e982.370670.png",
           "demozooUrl": "https://demozoo.org/productions/295547/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/280_The_Phrase_That_Pays/280_The_Phrase_That_Pays.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/280_The_Phrase_That_Pays/280_The_Phrase_That_Pays.dsk"
+          ]
         },
         {
           "id": 381229,
@@ -5472,7 +6986,7 @@
           "author": "Digital Gang",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/6c/91/fcaa.371325.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a5/1d/fd3b.371324.png",
           "demozooUrl": "https://demozoo.org/productions/381229/",
           "page": 10
         },
@@ -5486,7 +7000,12 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/35/39/7108.300892.png",
           "demozooUrl": "https://demozoo.org/productions/302296/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/3d0g_178a_Covenant/178a_-_Covenant_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_178a_Covenant/178a_-_Covenant_-_Side_1.dsk",
+            "https://archive.org/download/3d0g_178a_Covenant/178b_-_Covenant_-_Side_2.dsk"
+          ]
         },
         {
           "id": 380914,
@@ -5510,7 +7029,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3b/0f/e1ad.286097.png",
           "demozooUrl": "https://demozoo.org/productions/290074/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/143a_Great_American_Road_Race/143a_Great_American_Road_Race.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/143a_Great_American_Road_Race/143a_Great_American_Road_Race.dsk"
+          ]
         },
         {
           "id": 289198,
@@ -5520,9 +7043,13 @@
           "author": "Digital Gang / First Class",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/cc/66/1e33.370619.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/0b/31/61e2.284852.png",
           "demozooUrl": "https://demozoo.org/productions/289198/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/3d0g_036b_The_Eidolon/036b_The_Eidolon.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_036b_The_Eidolon/036b_The_Eidolon.dsk"
+          ]
         },
         {
           "id": 292031,
@@ -5534,7 +7061,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b6/88/9345.288259.png",
           "demozooUrl": "https://demozoo.org/productions/292031/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/209a_Temple_of_Apshai_Trilogy/209a_Temple_of_Apshai_Trilogy.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/209a_Temple_of_Apshai_Trilogy/209a_Temple_of_Apshai_Trilogy.dsk"
+          ]
         },
         {
           "id": 381903,
@@ -5570,7 +7101,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/19/eb/2f3d.299731.png",
           "demozooUrl": "https://demozoo.org/productions/301019/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/3d0g_169a_Spider-Man/169a_-_Spider-Man_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_169a_Spider-Man/169a_-_Spider-Man_-_Side_1.dsk"
+          ]
         },
         {
           "id": 381821,
@@ -5594,7 +7129,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/24/37/0000.289552.png",
           "demozooUrl": "https://demozoo.org/productions/292781/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/221a_Short_Circuit/221a_Short_Circuit.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/221a_Short_Circuit/221a_Short_Circuit.dsk"
+          ]
         },
         {
           "id": 381162,
@@ -5604,7 +7143,7 @@
           "author": "Surfer Bill",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/48/8f/c2f3.371145.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/0c/cf/5d1b.371146.png",
           "demozooUrl": "https://demozoo.org/productions/381162/",
           "page": 10
         },
@@ -5616,7 +7155,7 @@
           "author": "First Class",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c4/63/e3dc.302967.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/fc/03/ac8f.372127.png",
           "demozooUrl": "https://demozoo.org/productions/303744/",
           "page": 10
         },
@@ -5628,7 +7167,7 @@
           "author": "Five Star",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a4/b0/612c.372354.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/31/ca/10d6.372355.png",
           "demozooUrl": "https://demozoo.org/productions/381963/",
           "page": 10
         },
@@ -5654,7 +7193,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9b/ac/8d3b.284854.png",
           "demozooUrl": "https://demozoo.org/productions/147062/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/FIRSTCLASS.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/FIRSTCLASS.zip"
+          ]
         },
         {
           "id": 381139,
@@ -5666,7 +7209,11 @@
           "year": "1985",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/381139/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/phantasiec.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/phantasiec.gif"
+          ]
         },
         {
           "id": 381111,
@@ -5676,7 +7223,7 @@
           "author": "Apple Spy",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/15/0a/fc98.371059.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e8/14/9368.371058.png",
           "demozooUrl": "https://demozoo.org/productions/381111/",
           "page": 10
         },
@@ -5702,7 +7249,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/e0/6d/b9cd.371036.png",
           "demozooUrl": "https://demozoo.org/productions/147054/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BLACKBAG2.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BLACKBAG2.zip"
+          ]
         },
         {
           "id": 289728,
@@ -5714,7 +7265,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/19/4b/c937.285685.png",
           "demozooUrl": "https://demozoo.org/productions/289728/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/103_MouseBudget/103_MouseBudget.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/103_MouseBudget/103_MouseBudget.dsk"
+          ]
         },
         {
           "id": 304453,
@@ -5726,7 +7281,12 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1c/9e/744a.303690.png",
           "demozooUrl": "https://demozoo.org/productions/304453/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/3d0g_183a_Moebius/183a_-_Moebius_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_183a_Moebius/183a_-_Moebius_-_Side_1.dsk",
+            "https://archive.org/download/3d0g_183a_Moebius/183b_-_Moebius_-_Side_2.dsk"
+          ]
         },
         {
           "id": 381896,
@@ -5748,9 +7308,13 @@
           "author": "Lone Star Distributors",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/72/17/6311.300894.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f7/58/f83d.300893.png",
           "demozooUrl": "https://demozoo.org/productions/302298/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/3d0g_182b_Mech_Brigade/182b_Mech_Brigade.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_182b_Mech_Brigade/182b_Mech_Brigade.dsk"
+          ]
         },
         {
           "id": 381717,
@@ -5772,9 +7336,14 @@
           "author": "The Maggot",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4d/46/1b55.370996.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4c/b1/27a9.287184.png",
           "demozooUrl": "https://demozoo.org/productions/291119/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/199b_Lordlings_of_Yore/199b_Lordlings_of_Yore.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/199b_Lordlings_of_Yore/199b_Lordlings_of_Yore.dsk",
+            "https://archive.org/download/222_Lord_of_Yore/222_Lord_of_Yore.dsk"
+          ]
         },
         {
           "id": 381074,
@@ -5798,7 +7367,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/cc/47/7e00.314569.png",
           "demozooUrl": "https://demozoo.org/productions/147059/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/SIXPACK.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/SIXPACK.zip"
+          ]
         },
         {
           "id": 290083,
@@ -5810,7 +7383,13 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a8/bc/33a8.286106.png",
           "demozooUrl": "https://demozoo.org/productions/290083/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/150b_Kung_Fu_Master/150b_Kung_Fu_Master.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/150b_Kung_Fu_Master/150b_Kung_Fu_Master.dsk",
+            "https://archive.org/download/a2_Kung_Fu_Master_1985_Dataeast_cr_Digital_Gang/Kung_Fu_Master_1985_Dataeast_cr_Digital_Gang.do",
+            "https://archive.org/download/a2_Kung_Fu_Master_1985_Dataeast_cr_Digital_Gang_a/Kung_Fu_Master_1985_Dataeast_cr_Digital_Gang_a.do"
+          ]
         },
         {
           "id": 293797,
@@ -5820,9 +7399,13 @@
           "author": "Pirate's Harbor / The Disk Jockey",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a7/3c/c35c.372062.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/09/4c/1847.372061.png",
           "demozooUrl": "https://demozoo.org/productions/293797/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/276a_Kraking_Disk_2_by_The_Disk_Jockey/276a_Kraking_Disk_2_by_The_Disk_Jockey.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/276a_Kraking_Disk_2_by_The_Disk_Jockey/276a_Kraking_Disk_2_by_The_Disk_Jockey.dsk"
+          ]
         },
         {
           "id": 381065,
@@ -5846,7 +7429,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7b/a9/4120.372308.png",
           "demozooUrl": "https://demozoo.org/productions/381067/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/kq2.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/kq2.gif"
+          ]
         },
         {
           "id": 179775,
@@ -5870,7 +7457,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/90/02/73fd.293473.png",
           "demozooUrl": "https://demozoo.org/productions/295561/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/308_Instant_Pascal/308_Instant_Pascal.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/308_Instant_Pascal/308_Instant_Pascal.dsk"
+          ]
         },
         {
           "id": 381911,
@@ -5894,7 +7485,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/81/42/8cd4.299732.png",
           "demozooUrl": "https://demozoo.org/productions/301020/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/3d0g_170a_I_Damiano/170a_-_I_Damiano_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_170a_I_Damiano/170a_-_I_Damiano_-_Side_1.dsk"
+          ]
         },
         {
           "id": 381891,
@@ -5930,7 +7525,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a4/fd/bbe9.283727.png",
           "demozooUrl": "https://demozoo.org/productions/288298/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/012a_Gremlins/012a_Gremlins.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/012a_Gremlins/012a_Gremlins.dsk"
+          ]
         },
         {
           "id": 147061,
@@ -5942,7 +7541,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ac/81/130f.370709.png",
           "demozooUrl": "https://demozoo.org/productions/147061/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/PIRATECH.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/PIRATECH.zip"
+          ]
         },
         {
           "id": 381962,
@@ -5952,7 +7555,7 @@
           "author": "The Sheik",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d9/4e/90df.372351.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/cc/43/08b8.372352.png",
           "demozooUrl": "https://demozoo.org/productions/381962/",
           "page": 10
         },
@@ -5990,7 +7593,12 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/67/68/13c3.286105.png",
           "demozooUrl": "https://demozoo.org/productions/290082/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/149a_GI_Joe_Side_1/149a_GI_Joe_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/149a_GI_Joe_Side_1/149a_GI_Joe_Side_1.dsk",
+            "https://archive.org/download/vdw_GI_Joe_Side_1/GI_Joe_Side_1.dsk"
+          ]
         },
         {
           "id": 380865,
@@ -6000,7 +7608,7 @@
           "author": "The Sheik",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a5/22/e349.370640.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/eb/49/87e6.370641.png",
           "demozooUrl": "https://demozoo.org/productions/380865/",
           "page": 10
         },
@@ -6036,9 +7644,13 @@
           "author": "Black Bag",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/11/44/6f79.293469.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7a/1c/41df.372116.png",
           "demozooUrl": "https://demozoo.org/productions/295557/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "https://archive.org/download/298_Fantavision/298_Fantavision.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/298_Fantavision/298_Fantavision.dsk"
+          ]
         },
         {
           "id": 147057,
@@ -6050,7 +7662,12 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/70/9c/ffcd.331208.jpg",
           "demozooUrl": "https://demozoo.org/productions/147057/",
-          "page": 10
+          "page": 10,
+          "downloadUrl": "http://apple1.chez.com/Apple2cDskArchive/archive/Utils/Bin/Fantavision.zip",
+          "downloadUrls": [
+            "http://apple1.chez.com/Apple2cDskArchive/archive/Utils/Bin/Fantavision.zip"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=Y3h_hCXEvo8"
         }
       ]
     },
@@ -6065,9 +7682,14 @@
           "author": "Black Bag",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/e8/25/e4d8.303692.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/82/39/4b5f.370636.png",
           "demozooUrl": "https://demozoo.org/productions/147053/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_184b_F-15_Strike_Eagle/184b_F-15_Strike_Eagle.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_184b_F-15_Strike_Eagle/184b_F-15_Strike_Eagle.dsk",
+            "https://ftp.untergrund.net/users/crazycellist/Cracktro%20Only-F-15%20Strike%20Eagle.zip"
+          ]
         },
         {
           "id": 298783,
@@ -6077,9 +7699,13 @@
           "author": "Crustaceo Mutoid",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/21/ba/dc04.297270.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/97/06/34d2.371368.png",
           "demozooUrl": "https://demozoo.org/productions/298783/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/398_Europe_Ablaze_Side_2/398_Europe_Ablaze_Side_2.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/398_Europe_Ablaze_Side_2/398_Europe_Ablaze_Side_2.dsk"
+          ]
         },
         {
           "id": 380857,
@@ -6149,9 +7775,13 @@
           "author": "Digital Gang",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ca/ca/c916.370590.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/db/a0/9b3f.370591.png",
           "demozooUrl": "https://demozoo.org/productions/288505/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/063a_Destiny_Side_1/063a_Destiny_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/063a_Destiny_Side_1/063a_Destiny_Side_1.dsk"
+          ]
         },
         {
           "id": 298776,
@@ -6163,7 +7793,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/cd/cc/49c5.297190.png",
           "demozooUrl": "https://demozoo.org/productions/298776/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/390_Decision_in_the_Desert_Side_1/390_Decision_in_the_Desert_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/390_Decision_in_the_Desert_Side_1/390_Decision_in_the_Desert_Side_1.dsk"
+          ]
         },
         {
           "id": 288328,
@@ -6175,7 +7809,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/07/4c/4405.283784.jpg",
           "demozooUrl": "https://demozoo.org/productions/288328/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/036b_Dazzle_Draw/036b_Dazzle_Draw.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/036b_Dazzle_Draw/036b_Dazzle_Draw.dsk"
+          ]
         },
         {
           "id": 381960,
@@ -6209,9 +7847,13 @@
           "author": "The Round Table",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/55/c7/4b3c.371353.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/08/a8/cd5a.371352.png",
           "demozooUrl": "https://demozoo.org/productions/288514/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/074_Crosscountry_USA_Cracked_Copy_II_Disk_With_Format/074_Crosscountry_USA_Cracked_Copy_II_Disk_With_Format.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/074_Crosscountry_USA_Cracked_Copy_II_Disk_With_Format/074_Crosscountry_USA_Cracked_Copy_II_Disk_With_Format.dsk"
+          ]
         },
         {
           "id": 194763,
@@ -6223,7 +7865,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/bb/bd/02c4.172387.png",
           "demozooUrl": "https://demozoo.org/productions/194763/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "http://boutillon.free.fr/Underground/Deplombage/Cracking_Techniques/1985/Disks/Cracking_Techniques_1985.dsk.gz",
+          "downloadUrls": [
+            "http://boutillon.free.fr/Underground/Deplombage/Cracking_Techniques/1985/Disks/Cracking_Techniques_1985.dsk.gz"
+          ]
         },
         {
           "id": 293272,
@@ -6235,7 +7881,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/90/47/9db7.290250.png",
           "demozooUrl": "https://demozoo.org/productions/293272/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/257_Countdown_to_Shutdown/257_Countdown_to_Shutdown.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/257_Countdown_to_Shutdown/257_Countdown_to_Shutdown.dsk"
+          ]
         },
         {
           "id": 381171,
@@ -6259,7 +7909,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c7/47/dbd4.299685.png",
           "demozooUrl": "https://demozoo.org/productions/301004/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_166a_Seven_Cities_of_Gold/166a_-_Seven_Cities_of_Gold_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_166a_Seven_Cities_of_Gold/166a_-_Seven_Cities_of_Gold_-_Side_1.dsk"
+          ]
         },
         {
           "id": 381875,
@@ -6281,7 +7935,7 @@
           "author": "Professor Xavier",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/35/6f/596c.370575.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/55/14/e001.370579.png",
           "demozooUrl": "https://demozoo.org/productions/380840/",
           "page": 11
         },
@@ -6295,7 +7949,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a5/45/34b1.297643.png",
           "demozooUrl": "https://demozoo.org/productions/299181/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_149b_Chrono_Warrior/149b_Chrono_Warrior.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_149b_Chrono_Warrior/149b_Chrono_Warrior.dsk"
+          ]
         },
         {
           "id": 380836,
@@ -6305,7 +7963,7 @@
           "author": "Club 68000",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/0c/5e/47a8.370562.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/be/b2/ae3f.370561.png",
           "demozooUrl": "https://demozoo.org/productions/380836/",
           "page": 11
         },
@@ -6319,7 +7977,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/05/da/b441.303691.png",
           "demozooUrl": "https://demozoo.org/productions/304454/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_184a_Chipwits/184a_Chipwits.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_184a_Chipwits/184a_Chipwits.dsk"
+          ]
         },
         {
           "id": 289458,
@@ -6331,7 +7993,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/27/af/755b.285095.png",
           "demozooUrl": "https://demozoo.org/productions/289458/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_103a_Catalyst_3.0/103a_Catalyst_3.0.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_103a_Catalyst_3.0/103a_Catalyst_3.0.dsk"
+          ]
         },
         {
           "id": 381897,
@@ -6353,7 +8019,7 @@
           "author": "Atlantic Pirates Guild",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/72/79/e205.370558.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/d6/0c/ec9a.370559.png",
           "demozooUrl": "https://demozoo.org/productions/380835/",
           "page": 11
         },
@@ -6365,7 +8031,7 @@
           "author": "Golden State Pirates",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bd/d1/4c94.194874.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/66/c7/a607.372111.png",
           "demozooUrl": "https://demozoo.org/productions/268903/",
           "page": 11
         },
@@ -6377,9 +8043,14 @@
           "author": "The New Orleans Pirates Guild",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/21/f4/0a41.371347.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/53/b7/f26c.300885.png",
           "demozooUrl": "https://demozoo.org/productions/302290/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_177a_Buckaroo_Banzai/177a_-_Buckaroo_Banzai_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_177a_Buckaroo_Banzai/177a_-_Buckaroo_Banzai_-_Side_1.dsk",
+            "https://archive.org/download/3d0g_177a_Buckaroo_Banzai/177b_-_Buckaroo_Banzai_-_Side_2.dsk"
+          ]
         },
         {
           "id": 288507,
@@ -6391,7 +8062,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/77/e4/5294.283999.png",
           "demozooUrl": "https://demozoo.org/productions/288507/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/065a_Borrowed_Time_Side_1/065a_Borrowed_Time_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/065a_Borrowed_Time_Side_1/065a_Borrowed_Time_Side_1.dsk"
+          ]
         },
         {
           "id": 289456,
@@ -6403,7 +8078,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/28/3c/ddc7.285093.png",
           "demozooUrl": "https://demozoo.org/productions/289456/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_081b_BeastWar/081b_BeastWar.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_081b_BeastWar/081b_BeastWar.dsk"
+          ]
         },
         {
           "id": 293798,
@@ -6415,7 +8094,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/35/ab/c022.290927.png",
           "demozooUrl": "https://demozoo.org/productions/293798/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/279b_Beach-Head_II/279b_Beach-Head_II.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/279b_Beach-Head_II/279b_Beach-Head_II.dsk"
+          ]
         },
         {
           "id": 298613,
@@ -6427,7 +8110,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/27/f5/b6a1.297144.png",
           "demozooUrl": "https://demozoo.org/productions/298613/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/368_Battle_of_Antietam_Side_1/368_Battle_of_Antietam_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/368_Battle_of_Antietam_Side_1/368_Battle_of_Antietam_Side_1.dsk"
+          ]
         },
         {
           "id": 268905,
@@ -6437,7 +8124,7 @@
           "author": "Black Bag",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/41/d7/79f2.370673.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/bb/d1/f3c4.370674.png",
           "demozooUrl": "https://demozoo.org/productions/268905/",
           "page": 11
         },
@@ -6449,7 +8136,7 @@
           "author": "Club X / Coast To Coast",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bb/5c/29b0.372196.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ff/f4/7e46.372195.png",
           "demozooUrl": "https://demozoo.org/productions/381873/",
           "page": 11
         },
@@ -6463,7 +8150,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1b/9c/7ddd.285966.png",
           "demozooUrl": "https://demozoo.org/productions/289931/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/125_Adept/125_Adept.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/125_Adept/125_Adept.dsk"
+          ]
         },
         {
           "id": 313879,
@@ -6485,7 +8176,7 @@
           "author": "Gadget Master",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c2/26/a97b.371296.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7a/87/8b09.371297.png",
           "demozooUrl": "https://demozoo.org/productions/381221/",
           "page": 11
         },
@@ -6497,7 +8188,7 @@
           "author": "Atlantic Pirates Guild",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/68/44/029d.372180.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/0c/d7/a55c.372179.png",
           "demozooUrl": "https://demozoo.org/productions/381864/",
           "page": 11
         },
@@ -6535,7 +8226,11 @@
           "year": "1985",
           "screenshotUrl": "https://media.demozoo.org/screens/t/9f/d6/66cf.290921.png",
           "demozooUrl": "https://demozoo.org/productions/293791/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/266_Adventure_Construction_Set_Data_Side_1/266_Adventure_Construction_Set_Data_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/266_Adventure_Construction_Set_Data_Side_1/266_Adventure_Construction_Set_Data_Side_1.dsk"
+          ]
         },
         {
           "id": 313877,
@@ -6557,7 +8252,7 @@
           "author": "Apple Underground",
           "dateStr": "1985",
           "year": "1985",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c4/cf/0fa2.370960.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/36/09/a745.370961.png",
           "demozooUrl": "https://demozoo.org/productions/381055/",
           "page": 11
         },
@@ -6581,7 +8276,7 @@
           "author": "Midwest Pirates Guild",
           "dateStr": "Dec 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/2d/e9/ef28.371196.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/d0/a3/45e2.371198.png",
           "demozooUrl": "https://demozoo.org/productions/381180/",
           "page": 11
         },
@@ -6595,7 +8290,11 @@
           "year": "1984",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/381142/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/ppghunt.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/ppghunt.gif"
+          ]
         },
         {
           "id": 289455,
@@ -6605,9 +8304,13 @@
           "author": "Black Bag",
           "dateStr": "Nov 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/cd/4b/4efa.371307.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/61/ed/02fc.285092.png",
           "demozooUrl": "https://demozoo.org/productions/289455/",
-          "page": 11
+          "page": 11,
+          "downloadUrl": "https://archive.org/download/3d0g_079a_Jig_Saw/079a_Jig_Saw.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_079a_Jig_Saw/079a_Jig_Saw.dsk"
+          ]
         },
         {
           "id": 381724,
@@ -6617,7 +8320,7 @@
           "author": "The Sector Smasher",
           "dateStr": "Nov 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/49/0b/097d.371968.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/78/52/9a0e.371966.png",
           "demozooUrl": "https://demozoo.org/productions/381724/",
           "page": 11
         },
@@ -6629,7 +8332,7 @@
           "author": "Midwest Pirates Guild",
           "dateStr": "Oct 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/92/27/6686.371984.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a3/cb/8615.371985.png",
           "demozooUrl": "https://demozoo.org/productions/381732/",
           "page": 11
         },
@@ -6641,7 +8344,7 @@
           "author": "West Coast Connection",
           "dateStr": "Oct 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/70/6e/fcc0.371073.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ac/94/c61c.371072.png",
           "demozooUrl": "https://demozoo.org/productions/381114/",
           "page": 11
         },
@@ -6682,7 +8385,7 @@
           "author": "Sherlock Apple / The Apple Mafia",
           "dateStr": "Oct 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/e2/5f/51c2.370460.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/c9/a4/6590.370461.png",
           "demozooUrl": "https://demozoo.org/productions/380806/",
           "page": 12
         },
@@ -6708,7 +8411,12 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/4f/98/48a7.283787.png",
           "demozooUrl": "https://demozoo.org/productions/288331/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/041_Take_1/041_Take_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/041_Take_1/041_Take_1.dsk",
+            "https://archive.org/download/287a_Take_1_Side_1/287a_Take_1_Side_1.dsk"
+          ]
         },
         {
           "id": 290769,
@@ -6718,9 +8426,14 @@
           "author": "Midwest Pirates Guild",
           "dateStr": "Aug 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a9/51/bfb6.286820.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/3b/0b/b50e.371321.png",
           "demozooUrl": "https://demozoo.org/productions/290769/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/191_Archon/191_Archon.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/191_Archon/191_Archon.dsk",
+            "https://archive.org/download/317_Archon/317_Archon.dsk"
+          ]
         },
         {
           "id": 381826,
@@ -6730,7 +8443,7 @@
           "author": "Dalton",
           "dateStr": "Jul 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/47/e6/75f6.372094.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e6/41/a420.372096.png",
           "demozooUrl": "https://demozoo.org/productions/381826/",
           "page": 12
         },
@@ -6742,7 +8455,7 @@
           "author": "Cat-Ware / Hi-Res&lt;&gt;Hijackers / The Ware Lords",
           "dateStr": "Jun 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/3e/1f/c788.371936.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/fc/46/023c.371937.png",
           "demozooUrl": "https://demozoo.org/productions/381707/",
           "page": 12
         },
@@ -6754,7 +8467,7 @@
           "author": "Johnney Appleseed",
           "dateStr": "Jun 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/f8/eb/e81c.371202.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/1c/85/9955.371204.png",
           "demozooUrl": "https://demozoo.org/productions/381182/",
           "page": 12
         },
@@ -6768,7 +8481,11 @@
           "year": "1984",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/380837/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/claymorguet.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/claymorguet.gif"
+          ]
         },
         {
           "id": 381722,
@@ -6790,7 +8507,7 @@
           "author": "Midwest Pirates Guild",
           "dateStr": "Jun 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/fa/d7/a863.370493.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b7/24/e03a.370495.png",
           "demozooUrl": "https://demozoo.org/productions/380819/",
           "page": 12
         },
@@ -6804,7 +8521,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/59/8a/d9c6.331209.png",
           "demozooUrl": "https://demozoo.org/productions/147067/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "http://mirrors.apple2.org.za/landover.no-ip.com/Applications/Pirate's%20Signature%20v1.0%20(19xx)(Johnhey%20Appleseed).dsk",
+          "downloadUrls": [
+            "http://mirrors.apple2.org.za/landover.no-ip.com/Applications/Pirate's%20Signature%20v1.0%20(19xx)(Johnhey%20Appleseed).dsk"
+          ]
         },
         {
           "id": 381899,
@@ -6838,7 +8559,7 @@
           "author": "Cyborg",
           "dateStr": "Apr 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/e5/77/a274.371973.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/81/f8/86fc.371971.png",
           "demozooUrl": "https://demozoo.org/productions/381727/",
           "page": 12
         },
@@ -6898,9 +8619,13 @@
           "author": "The Apple Mafia",
           "dateStr": "Feb 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/f8/2f/f232.370422.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/34/a6/6008.370428.png",
           "demozooUrl": "https://demozoo.org/productions/289197/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/3d0g_022b_Black_Belt/022b_Black_Belt.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_022b_Black_Belt/022b_Black_Belt.dsk"
+          ]
         },
         {
           "id": 289599,
@@ -6912,7 +8637,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/4d/0c/bfcd.285499.png",
           "demozooUrl": "https://demozoo.org/productions/289599/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/082_EDD/082_EDD.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/082_EDD/082_EDD.dsk"
+          ]
         },
         {
           "id": 381755,
@@ -6922,7 +8651,7 @@
           "author": "Black Bag",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/59/db/8bd4.372024.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/36/3c/237d.372023.png",
           "demozooUrl": "https://demozoo.org/productions/381755/",
           "page": 12
         },
@@ -6934,7 +8663,7 @@
           "author": "Tri-State Pirates",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/65/7d/0ca9.371293.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/df/51/bfdf.371294.png",
           "demozooUrl": "https://demozoo.org/productions/381219/",
           "page": 12
         },
@@ -6946,7 +8675,7 @@
           "author": "Mr. Krac-Man",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/45/34/7069.371290.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e0/01/da78.371289.png",
           "demozooUrl": "https://demozoo.org/productions/381216/",
           "page": 12
         },
@@ -6960,7 +8689,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/46/ef/d91d.286821.png",
           "demozooUrl": "https://demozoo.org/productions/290770/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/195b_Wizard_of_Id_WizType/195b_Wizard_of_Id_WizType.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/195b_Wizard_of_Id_WizType/195b_Wizard_of_Id_WizType.dsk"
+          ]
         },
         {
           "id": 381215,
@@ -7008,7 +8741,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/82/1c/414a.299675.png",
           "demozooUrl": "https://demozoo.org/productions/300994/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/3d0g_154b_Up_and_Down/154b_Up_and_Down.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_154b_Up_and_Down/154b_Up_and_Down.dsk"
+          ]
         },
         {
           "id": 381210,
@@ -7032,7 +8769,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/68/3e/9586.285629.png",
           "demozooUrl": "https://demozoo.org/productions/289689/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/099_Trivia_Fever_Side_1/099_Trivia_Fever_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/099_Trivia_Fever_Side_1/099_Trivia_Fever_Side_1.dsk"
+          ]
         },
         {
           "id": 301001,
@@ -7044,7 +8785,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ee/e8/5bfe.299682.png",
           "demozooUrl": "https://demozoo.org/productions/301001/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/3d0g_163a_Trivia_Fever/163a_-_Trivia_Fever_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_163a_Trivia_Fever/163a_-_Trivia_Fever_-_Side_1.dsk"
+          ]
         },
         {
           "id": 147077,
@@ -7056,7 +8801,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a9/65/6b74.331211.jpg",
           "demozooUrl": "https://demozoo.org/productions/147077/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/MIAMIVICE.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/MIAMIVICE.zip"
+          ]
         },
         {
           "id": 381199,
@@ -7066,7 +8815,7 @@
           "author": "Black Bag",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/7b/83/2755.371256.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/99/5e/6cc3.371255.png",
           "demozooUrl": "https://demozoo.org/productions/381199/",
           "page": 12
         },
@@ -7092,7 +8841,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0f/0f/7148.299681.png",
           "demozooUrl": "https://demozoo.org/productions/301000/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/3d0g_161a_Trivia_Arcade/161a_-_Trivia_Arcade_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_161a_Trivia_Arcade/161a_-_Trivia_Arcade_-_Side_1.dsk"
+          ]
         },
         {
           "id": 380897,
@@ -7102,7 +8855,7 @@
           "author": "The Racketeers",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/57/2d/71fc.370708.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/c9/21/444e.370707.png",
           "demozooUrl": "https://demozoo.org/productions/380897/",
           "page": 12
         },
@@ -7140,7 +8893,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/dc/e3/0b5b.286101.png",
           "demozooUrl": "https://demozoo.org/productions/290078/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/144a_The_Print_Shop/144a_The_Print_Shop.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/144a_The_Print_Shop/144a_The_Print_Shop.dsk"
+          ]
         },
         {
           "id": 381181,
@@ -7150,7 +8907,7 @@
           "author": "The Count",
           "dateStr": "Jan 1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/37/42/bc77.371200.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/2b/dd/038a.371199.png",
           "demozooUrl": "https://demozoo.org/productions/381181/",
           "page": 12
         },
@@ -7164,7 +8921,12 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2f/60/c986.285090.png",
           "demozooUrl": "https://demozoo.org/productions/289453/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/102_Newsroom/102_Newsroom.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/102_Newsroom/102_Newsroom.dsk",
+            "https://archive.org/download/3d0g_064b_Newsroom/064b_Newsroom.dsk"
+          ]
         },
         {
           "id": 381223,
@@ -7174,7 +8936,7 @@
           "author": "West Coast Connection",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1e/db/1f73.371299.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/73/bd/a980.371300.png",
           "demozooUrl": "https://demozoo.org/productions/381223/",
           "page": 12
         },
@@ -7186,9 +8948,13 @@
           "author": "Black Bag",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d2/1b/a39c.370950.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/2e/83/6573.370949.png",
           "demozooUrl": "https://demozoo.org/productions/128287/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BLACKBAG.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BLACKBAG.zip"
+          ]
         },
         {
           "id": 288503,
@@ -7200,7 +8966,12 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/68/9b/a118.283995.png",
           "demozooUrl": "https://demozoo.org/productions/288503/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/060_Hitchhikers_Guide_to_the_Galaxy/060_Hitchhikers_Guide_to_the_Galaxy.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/060_Hitchhikers_Guide_to_the_Galaxy/060_Hitchhikers_Guide_to_the_Galaxy.dsk",
+            "https://archive.org/download/192_The_Hitchhikers_Guide_to_the_Galaxy/192_The_Hitchhikers_Guide_to_the_Galaxy.dsk"
+          ]
         },
         {
           "id": 381871,
@@ -7222,9 +8993,13 @@
           "author": "M.B.P.A.",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bc/43/e74a.285089.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/1e/d3/0610.371217.png",
           "demozooUrl": "https://demozoo.org/productions/289452/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/3d0g_060b_Tapper/060b_Tapper.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_060b_Tapper/060b_Tapper.dsk"
+          ]
         },
         {
           "id": 381188,
@@ -7234,7 +9009,7 @@
           "author": "M.B.P.A.",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/44/99/ca92.371219.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/eb/97/7c17.371218.png",
           "demozooUrl": "https://demozoo.org/productions/381188/",
           "page": 12
         },
@@ -7248,7 +9023,12 @@
           "year": "1984",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/381190/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/tapperc.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/tapperc.gif",
+            "http://artscene.textfiles.com/intros/APPLEII/tapperm.gif"
+          ]
         },
         {
           "id": 291117,
@@ -7260,7 +9040,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/93/49/6af5.287182.png",
           "demozooUrl": "https://demozoo.org/productions/291117/",
-          "page": 12
+          "page": 12,
+          "downloadUrl": "https://archive.org/download/198a_Swiss_Family_Robinson/198a_Swiss_Family_Robinson.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/198a_Swiss_Family_Robinson/198a_Swiss_Family_Robinson.dsk"
+          ]
         }
       ]
     },
@@ -7277,7 +9061,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/fd/cd/3a0d.297145.png",
           "demozooUrl": "https://demozoo.org/productions/298614/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/369b_Super_Zaxxon/369b_Super_Zaxxon.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/369b_Super_Zaxxon/369b_Super_Zaxxon.dsk"
+          ]
         },
         {
           "id": 301002,
@@ -7289,7 +9077,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5f/e5/7c6f.371314.png",
           "demozooUrl": "https://demozoo.org/productions/301002/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/3d0g_164a_Sun_Dog/164a_-_Sun_Dog_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_164a_Sun_Dog/164a_-_Sun_Dog_-_Side_1.dsk"
+          ]
         },
         {
           "id": 380735,
@@ -7359,9 +9151,13 @@
           "author": "Pacific Pirate's Guild",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/fb/86/d1a3.370556.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/d1/68/3ea3.299680.png",
           "demozooUrl": "https://demozoo.org/productions/300999/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/3d0g_160a_Solo_Flight/160a_Solo_Flight.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_160a_Solo_Flight/160a_Solo_Flight.dsk"
+          ]
         },
         {
           "id": 380834,
@@ -7395,9 +9191,13 @@
           "author": "The Apple Mafia",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bb/70/8b17.331212.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/10/ac/77a9.371191.png",
           "demozooUrl": "https://demozoo.org/productions/147070/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/APPLEMAFIA.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/APPLEMAFIA.zip"
+          ]
         },
         {
           "id": 380793,
@@ -7407,7 +9207,7 @@
           "author": "The Apple Mafia",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/76/b1/862c.370419.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/60/83/a9ad.370418.png",
           "demozooUrl": "https://demozoo.org/productions/380793/",
           "page": 13
         },
@@ -7421,7 +9221,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/88/93/65b1.285091.png",
           "demozooUrl": "https://demozoo.org/productions/289454/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/3d0g_067a_Skyfox/067a_Skyfox.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_067a_Skyfox/067a_Skyfox.dsk"
+          ]
         },
         {
           "id": 381165,
@@ -7431,7 +9235,7 @@
           "author": "Black Bag",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/0d/bd/36b1.371160.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/61/f0/a7ae.371161.png",
           "demozooUrl": "https://demozoo.org/productions/381165/",
           "page": 13
         },
@@ -7445,7 +9249,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/92/30/09cb.299684.png",
           "demozooUrl": "https://demozoo.org/productions/301003/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/3d0g_166a_Seven_Cities_of_Gold/166a_-_Seven_Cities_of_Gold_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_166a_Seven_Cities_of_Gold/166a_-_Seven_Cities_of_Gold_-_Side_1.dsk"
+          ]
         },
         {
           "id": 381159,
@@ -7455,7 +9263,7 @@
           "author": "Midwest Pirates Guild / The Racketeers",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a5/56/63df.371140.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e1/a4/c744.371141.png",
           "demozooUrl": "https://demozoo.org/productions/381159/",
           "page": 13
         },
@@ -7467,7 +9275,7 @@
           "author": "Atlantic Pirates Guild / The 1200 Club",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4b/6a/c639.370399.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b5/96/4404.370398.png",
           "demozooUrl": "https://demozoo.org/productions/380785/",
           "page": 13
         },
@@ -7479,9 +9287,13 @@
           "author": "The Racketeers",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a8/91/e82a.293462.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/64/af/7b19.293461.png",
           "demozooUrl": "https://demozoo.org/productions/295550/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/285_Rescue_Raiders/285_Rescue_Raiders.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/285_Rescue_Raiders/285_Rescue_Raiders.dsk"
+          ]
         },
         {
           "id": 380737,
@@ -7515,7 +9327,7 @@
           "author": "Johnney Appleseed",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a7/2a/4be8.372156.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/02/42/d056.372157.png",
           "demozooUrl": "https://demozoo.org/productions/381858/",
           "page": 13
         },
@@ -7529,7 +9341,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/84/4c/c637.283777.png",
           "demozooUrl": "https://demozoo.org/productions/288321/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/029b_Path_Tactics/029b_Path_Tactics.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/029b_Path_Tactics/029b_Path_Tactics.dsk"
+          ]
         },
         {
           "id": 381127,
@@ -7575,7 +9391,7 @@
           "author": "The Racketeers",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1a/4e/68b5.371055.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a2/67/f35b.371054.png",
           "demozooUrl": "https://demozoo.org/productions/381109/",
           "page": 13
         },
@@ -7623,7 +9439,7 @@
           "author": "Mr. Krac-Man",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/21/78/3fd3.370690.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ed/18/ec02.370689.png",
           "demozooUrl": "https://demozoo.org/productions/380890/",
           "page": 13
         },
@@ -7637,7 +9453,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1b/cc/bbdd.371447.png",
           "demozooUrl": "https://demozoo.org/productions/292578/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/211b_Mr._Robot_and_His_Robot_Factory/211b_Mr._Robot_and_His_Robot_Factory.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/211b_Mr._Robot_and_His_Robot_Factory/211b_Mr._Robot_and_His_Robot_Factory.dsk"
+          ]
         },
         {
           "id": 381099,
@@ -7647,7 +9467,7 @@
           "author": "",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1d/00/2fc7.371038.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/28/28/c8dc.371037.png",
           "demozooUrl": "https://demozoo.org/productions/381099/",
           "page": 13
         },
@@ -7671,7 +9491,7 @@
           "author": "Clean Crack Band",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/b4/14/1859.172351.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/10/e1/6885.371958.png",
           "demozooUrl": "https://demozoo.org/productions/194717/",
           "page": 13
         },
@@ -7697,7 +9517,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ed/0d/b073.285971.png",
           "demozooUrl": "https://demozoo.org/productions/289936/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/131_Montezumas_Revenge/131_Montezumas_Revenge.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/131_Montezumas_Revenge/131_Montezumas_Revenge.dsk"
+          ]
         },
         {
           "id": 382234,
@@ -7733,7 +9557,11 @@
           "year": "1984",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/381100/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/mshadow.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/mshadow.gif"
+          ]
         },
         {
           "id": 381720,
@@ -7779,9 +9607,13 @@
           "author": "The 202 Alliance",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/51/90/7035.371000.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/3a/75/b315.331214.jpg",
           "demozooUrl": "https://demozoo.org/productions/147079/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/202ALLIANCE.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/202ALLIANCE.zip"
+          ]
         },
         {
           "id": 295553,
@@ -7793,7 +9625,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f1/af/808c.293465.png",
           "demozooUrl": "https://demozoo.org/productions/295553/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://archive.org/download/292b_Lost_Tomb/292b_Lost_Tomb.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/292b_Lost_Tomb/292b_Lost_Tomb.dsk"
+          ]
         },
         {
           "id": 380838,
@@ -7815,7 +9651,7 @@
           "author": "Pirate's Harbor / The Disk Jockey",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/e7/c4/782c.372366.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ac/2d/a06b.372368.png",
           "demozooUrl": "https://demozoo.org/productions/381969/",
           "page": 13
         },
@@ -7841,7 +9677,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/44/22/bebf.331215.png",
           "demozooUrl": "https://demozoo.org/productions/147051/",
-          "page": 13
+          "page": 13,
+          "downloadUrl": "https://ftp.untergrund.net/users/crazycellist/Cracktro%20Only-KidsOnKeys_Kidwriter.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/crazycellist/Cracktro%20Only-KidsOnKeys_Kidwriter.zip"
+          ]
         },
         {
           "id": 381234,
@@ -7851,7 +9691,7 @@
           "author": "Association of Broadcasting Crackers",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/38/39/728c.371344.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/70/fe/2a17.371343.png",
           "demozooUrl": "https://demozoo.org/productions/381234/",
           "page": 13
         },
@@ -7882,7 +9722,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8b/fc/c128.331216.png",
           "demozooUrl": "https://demozoo.org/productions/147050/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://ftp.untergrund.net/users/crazycellist/Cracktro%20Only-AKETARAK.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/crazycellist/Cracktro%20Only-AKETARAK.zip"
+          ]
         },
         {
           "id": 380770,
@@ -7904,7 +9748,7 @@
           "author": "Black Bag",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1a/70/265e.370973.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/cb/55/2838.370972.png",
           "demozooUrl": "https://demozoo.org/productions/381060/",
           "page": 14
         },
@@ -7964,7 +9808,7 @@
           "author": "Shaolin Disciples",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c2/5e/1e1b.372021.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b2/88/761f.372020.png",
           "demozooUrl": "https://demozoo.org/productions/381754/",
           "page": 14
         },
@@ -7976,7 +9820,7 @@
           "author": "Shaolin Disciples",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/f9/3f/8cba.372018.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/db/f0/bf79.372019.png",
           "demozooUrl": "https://demozoo.org/productions/381753/",
           "page": 14
         },
@@ -7988,7 +9832,7 @@
           "author": "PAUL",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9c/67/9955.371075.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/da/02/060f.371074.png",
           "demozooUrl": "https://demozoo.org/productions/381115/",
           "page": 14
         },
@@ -8036,9 +9880,13 @@
           "author": "Pacific Pirate's Guild",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/eb/17/445c.370253.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/77/db/e5a6.370254.png",
           "demozooUrl": "https://demozoo.org/productions/380705/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "HES_Games_Pacific_Pirates_Guild_crack_Side_1.dsk",
+          "downloadUrls": [
+            "HES_Games_Pacific_Pirates_Guild_crack_Side_1.dsk"
+          ]
         },
         {
           "id": 380704,
@@ -8048,9 +9896,13 @@
           "author": "The Club",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/81/90/7abf.370252.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/07/17/816e.370251.png",
           "demozooUrl": "https://demozoo.org/productions/380704/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/hes_games1/hes_games1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/hes_games1/hes_games1.dsk"
+          ]
         },
         {
           "id": 380870,
@@ -8132,7 +9984,7 @@
           "author": "The Racketeers / The Ware Lords",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/71/e9/f820.331217.jpg",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/97/0c/07c6.370654.png",
           "demozooUrl": "https://demozoo.org/productions/147069/",
           "page": 14
         },
@@ -8158,7 +10010,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/67/c9/f1bd.288108.png",
           "demozooUrl": "https://demozoo.org/productions/291936/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/207a_50_Mission_Crush/207a_50_Mission_Crush.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/207a_50_Mission_Crush/207a_50_Mission_Crush.dsk"
+          ]
         },
         {
           "id": 290094,
@@ -8170,7 +10026,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f4/52/ee2a.286122.png",
           "demozooUrl": "https://demozoo.org/productions/290094/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/162a_FAX_Side_1/162a_FAX_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/162a_FAX_Side_1/162a_FAX_Side_1.dsk"
+          ]
         },
         {
           "id": 381937,
@@ -8230,7 +10090,11 @@
           "year": "1984",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/380854/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/edelights.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/edelights.gif"
+          ]
         },
         {
           "id": 380861,
@@ -8264,7 +10128,7 @@
           "author": "Black Bag / The Ware Lords",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a5/df/4c76.370400.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/03/ad/8692.370401.png",
           "demozooUrl": "https://demozoo.org/productions/380786/",
           "page": 14
         },
@@ -8276,7 +10140,7 @@
           "author": "The Apple Mafia",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/40/53/b571.370416.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/79/d0/8b54.370415.png",
           "demozooUrl": "https://demozoo.org/productions/380792/",
           "page": 14
         },
@@ -8290,7 +10154,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/bf/91/ff09.285611.png",
           "demozooUrl": "https://demozoo.org/productions/289679/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/098_Dazzledraw/098_Dazzledraw.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/098_Dazzledraw/098_Dazzledraw.dsk"
+          ]
         },
         {
           "id": 288510,
@@ -8302,7 +10170,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8d/4a/d2af.284002.png",
           "demozooUrl": "https://demozoo.org/productions/288510/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/070b_Cutthroats/070b_Cutthroats.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/070b_Cutthroats/070b_Cutthroats.dsk"
+          ]
         },
         {
           "id": 290093,
@@ -8314,7 +10186,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8e/8c/29d0.286121.png",
           "demozooUrl": "https://demozoo.org/productions/290093/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/160_Crypt_of_Medea/160_Crypt_of_Medea.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/160_Crypt_of_Medea/160_Crypt_of_Medea.dsk"
+          ]
         },
         {
           "id": 292033,
@@ -8324,9 +10200,13 @@
           "author": "The Apple Mafia",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/76/03/9871.370414.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/30/61/8c95.288261.png",
           "demozooUrl": "https://demozoo.org/productions/292033/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/211a_Crime_and_Punishment/211a_Crime_and_Punishment.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/211a_Crime_and_Punishment/211a_Crime_and_Punishment.dsk"
+          ]
         },
         {
           "id": 381859,
@@ -8336,7 +10216,7 @@
           "author": "Pirate's Harbor",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/41/39/1fba.372164.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f3/ce/b76e.372165.png",
           "demozooUrl": "https://demozoo.org/productions/381859/",
           "page": 14
         },
@@ -8350,7 +10230,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d7/20/7436.286819.png",
           "demozooUrl": "https://demozoo.org/productions/290768/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/191a_Copy_Plus_Version_2.0/191a_Copy_Plus_Version_2.0.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/191a_Copy_Plus_Version_2.0/191a_Copy_Plus_Version_2.0.dsk"
+          ]
         },
         {
           "id": 380839,
@@ -8374,7 +10258,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/66/5a/3fc3.370565.png",
           "demozooUrl": "https://demozoo.org/productions/288325/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/033a_Competition_Karate/033a_Competition_Karate.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/033a_Competition_Karate/033a_Competition_Karate.dsk"
+          ]
         },
         {
           "id": 381712,
@@ -8420,9 +10308,13 @@
           "author": "Apple Bandit / The Syndicate",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c8/35/1f8d.283757.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b1/99/0913.370529.png",
           "demozooUrl": "https://demozoo.org/productions/288312/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://archive.org/download/019b_Buck_Rogers_Planet_of_Zoom/019b_Buck_Rogers_Planet_of_Zoom.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/019b_Buck_Rogers_Planet_of_Zoom/019b_Buck_Rogers_Planet_of_Zoom.dsk"
+          ]
         },
         {
           "id": 147081,
@@ -8432,9 +10324,13 @@
           "author": "Cat-Ware / Hi-Res&lt;&gt;Hijackers / The Ware Lords",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9e/9e/f428.370542.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a0/ed/2d8f.370541.png",
           "demozooUrl": "https://demozoo.org/productions/147081/",
-          "page": 14
+          "page": 14,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/COPYCAT.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/COPYCAT.zip"
+          ]
         },
         {
           "id": 381240,
@@ -8468,7 +10364,7 @@
           "author": "The Apple Mafia",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/3a/7e/6d28.370433.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/62/9c/c4a1.370436.png",
           "demozooUrl": "https://demozoo.org/productions/380795/",
           "page": 14
         }
@@ -8487,7 +10383,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/36/46/f3e6.283730.png",
           "demozooUrl": "https://demozoo.org/productions/288301/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/014b_Black_Belt/014b_Black_Belt.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/014b_Black_Belt/014b_Black_Belt.dsk"
+          ]
         },
         {
           "id": 381827,
@@ -8511,7 +10411,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/14/13/758e.371362.png",
           "demozooUrl": "https://demozoo.org/productions/289796/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/109b_Beyond_Castle/109b_Beyond_Castle.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/109b_Beyond_Castle/109b_Beyond_Castle.dsk"
+          ]
         },
         {
           "id": 381885,
@@ -8535,7 +10439,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ee/11/4792.297148.png",
           "demozooUrl": "https://demozoo.org/productions/298616/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/372_Below_the_Root_Side_1/372_Below_the_Root_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/372_Below_the_Root_Side_1/372_Below_the_Root_Side_1.dsk"
+          ]
         },
         {
           "id": 380802,
@@ -8559,7 +10467,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/76/eb/f0bf.295236.png",
           "demozooUrl": "https://demozoo.org/productions/296788/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/321_B.C._Quest_for_Tires/321_B.C._Quest_for_Tires.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/321_B.C._Quest_for_Tires/321_B.C._Quest_for_Tires.dsk"
+          ]
         },
         {
           "id": 381084,
@@ -8569,7 +10481,7 @@
           "author": "The 202 Alliance",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/6a/16/0551.371011.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/73/e5/c549.371010.png",
           "demozooUrl": "https://demozoo.org/productions/381084/",
           "page": 15
         },
@@ -8583,7 +10495,11 @@
           "year": "1984",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0a/56/f89e.331218.png",
           "demozooUrl": "https://demozoo.org/productions/147049/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://ftp.untergrund.net/users/crazycellist/Cracktro%20Only-AtariSoft%20Programs.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/crazycellist/Cracktro%20Only-AtariSoft%20Programs.zip"
+          ]
         },
         {
           "id": 380895,
@@ -8593,7 +10509,7 @@
           "author": "The Intern / The Penguin",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/bc/67/d950.370699.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/fe/19/6fd2.370698.png",
           "demozooUrl": "https://demozoo.org/productions/380895/",
           "page": 15
         },
@@ -8617,9 +10533,13 @@
           "author": "Connection / The 1200 Club",
           "dateStr": "1984",
           "year": "1984",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/8d/d3/42e7.371312.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a2/93/5b7c.290089.png",
           "demozooUrl": "https://demozoo.org/productions/293198/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/246a_Coast_to_Coast/246a_Coast_to_Coast.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/246a_Coast_to_Coast/246a_Coast_to_Coast.dsk"
+          ]
         },
         {
           "id": 381270,
@@ -8773,7 +10693,7 @@
           "author": "The Apple Mafia",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/e6/4a/558e.370408.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e7/5f/631f.370409.png",
           "demozooUrl": "https://demozoo.org/productions/380790/",
           "page": 15
         },
@@ -8787,7 +10707,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/68/bd/3926.283760.png",
           "demozooUrl": "https://demozoo.org/productions/288315/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/025a_Wings_Out_of_Shadow/025a_Wings_Out_of_Shadow.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/025a_Wings_Out_of_Shadow/025a_Wings_Out_of_Shadow.dsk"
+          ]
         },
         {
           "id": 289930,
@@ -8799,7 +10723,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d9/bc/fe6d.285965.png",
           "demozooUrl": "https://demozoo.org/productions/289930/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/121_Music_Construction_Set/121_Music_Construction_Set.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/121_Music_Construction_Set/121_Music_Construction_Set.dsk"
+          ]
         },
         {
           "id": 381246,
@@ -8823,7 +10751,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/97/62/a391.283993.png",
           "demozooUrl": "https://demozoo.org/productions/288501/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/059_Will_Harveys_Music_Construction_Set/059_Will_Harveys_Music_Construction_Set.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/059_Will_Harveys_Music_Construction_Set/059_Will_Harveys_Music_Construction_Set.dsk"
+          ]
         },
         {
           "id": 381207,
@@ -8845,9 +10777,13 @@
           "author": "Krakowicz",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/64/1b/3d63.371341.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ce/48/5560.285609.png",
           "demozooUrl": "https://demozoo.org/productions/289677/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/096b_Wavy_Navy/096b_Wavy_Navy.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/096b_Wavy_Navy/096b_Wavy_Navy.dsk"
+          ]
         },
         {
           "id": 380813,
@@ -8869,7 +10805,7 @@
           "author": "The Whip",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/50/6c/9194.371994.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f9/09/cd7c.371993.png",
           "demozooUrl": "https://demozoo.org/productions/381737/",
           "page": 15
         },
@@ -8929,7 +10865,7 @@
           "author": "Gumby",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c9/0e/d390.370723.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b6/4d/f513.370722.png",
           "demozooUrl": "https://demozoo.org/productions/380901/",
           "page": 15
         },
@@ -8965,7 +10901,7 @@
           "author": "L.S.D. / The Freeze",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/86/e5/42c2.370994.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/9f/e0/6f0f.370993.png",
           "demozooUrl": "https://demozoo.org/productions/381072/",
           "page": 15
         },
@@ -9037,7 +10973,7 @@
           "author": "Mr. Krac-Man / The Disk Jockey",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9d/49/6eee.370672.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b2/9f/9326.370671.png",
           "demozooUrl": "https://demozoo.org/productions/380880/",
           "page": 15
         },
@@ -9075,7 +11011,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/56/7f/8bb2.286102.png",
           "demozooUrl": "https://demozoo.org/productions/290079/",
-          "page": 15
+          "page": 15,
+          "downloadUrl": "https://archive.org/download/145b_Talon/145b_Talon.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/145b_Talon/145b_Talon.dsk"
+          ]
         }
       ]
     },
@@ -9126,7 +11066,7 @@
           "author": "Mr. Krac-Man",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/14/62/bbc9.371210.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/77/d0/4d6e.371208.png",
           "demozooUrl": "https://demozoo.org/productions/381183/",
           "page": 16
         },
@@ -9138,7 +11078,7 @@
           "author": "Captain Kid Piracey Company Inc.",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/7b/ee/f487.371142.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ad/41/78f3.375360.png",
           "demozooUrl": "https://demozoo.org/productions/381160/",
           "page": 16
         },
@@ -9152,7 +11092,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b9/4f/fdef.285907.png",
           "demozooUrl": "https://demozoo.org/productions/289899/",
-          "page": 16
+          "page": 16,
+          "downloadUrl": "https://archive.org/download/119_Stellar_7/119_Stellar_7.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/119_Stellar_7/119_Stellar_7.dsk"
+          ]
         },
         {
           "id": 381730,
@@ -9162,7 +11106,7 @@
           "author": "Dr. Micro / The Freeze",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/85/c0/326e.371982.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a2/b1/abcc.371981.png",
           "demozooUrl": "https://demozoo.org/productions/381730/",
           "page": 16
         },
@@ -9174,7 +11118,7 @@
           "author": "MicMac / The Softman",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9b/21/bf63.372124.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/94/1b/530d.372122.png",
           "demozooUrl": "https://demozoo.org/productions/381837/",
           "page": 16
         },
@@ -9210,7 +11154,7 @@
           "author": "Buffalo Bill",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/fe/47/aa61.372087.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f0/1b/3b0c.372086.png",
           "demozooUrl": "https://demozoo.org/productions/381819/",
           "page": 16
         },
@@ -9222,7 +11166,7 @@
           "author": "Mr. Backup",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/f2/85/d072.371979.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ce/a2/e7dd.371980.png",
           "demozooUrl": "https://demozoo.org/productions/381729/",
           "page": 16
         },
@@ -9260,7 +11204,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6b/a8/8cf1.285968.png",
           "demozooUrl": "https://demozoo.org/productions/289933/",
-          "page": 16
+          "page": 16,
+          "downloadUrl": "https://archive.org/download/128_Sargon_III/128_Sargon_III.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/128_Sargon_III/128_Sargon_III.dsk"
+          ]
         },
         {
           "id": 304696,
@@ -9366,7 +11314,7 @@
           "author": "The Whip",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/81/1a/919c.371117.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/03/40/89c6.371116.png",
           "demozooUrl": "https://demozoo.org/productions/381140/",
           "page": 16
         },
@@ -9392,7 +11340,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/87/21/966e.293464.png",
           "demozooUrl": "https://demozoo.org/productions/295552/",
-          "page": 16
+          "page": 16,
+          "downloadUrl": "https://archive.org/download/291_Planetfall/291_Planetfall.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/291_Planetfall/291_Planetfall.dsk"
+          ]
         },
         {
           "id": 380773,
@@ -9414,7 +11366,7 @@
           "author": "Corrupt Computing",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4f/15/5093.370982.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/bb/8a/d4c5.370981.png",
           "demozooUrl": "https://demozoo.org/productions/381064/",
           "page": 16
         },
@@ -9462,7 +11414,7 @@
           "author": "Dr. Micro / L.S.D. / The Freeze",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/30/e9/fa34.371317.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f0/50/3ca8.371318.png",
           "demozooUrl": "https://demozoo.org/productions/381228/",
           "page": 16
         },
@@ -9476,7 +11428,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1c/2b/047f.283780.png",
           "demozooUrl": "https://demozoo.org/productions/288324/",
-          "page": 16
+          "page": 16,
+          "downloadUrl": "https://archive.org/download/033_One_on_One/033_One_on_One.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/033_One_on_One/033_One_on_One.dsk"
+          ]
         },
         {
           "id": 290771,
@@ -9488,7 +11444,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8f/f3/359e.286822.png",
           "demozooUrl": "https://demozoo.org/productions/290771/",
-          "page": 16
+          "page": 16,
+          "downloadUrl": "https://archive.org/download/195_Old_Ironsides/195_Old_Ironsides.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/195_Old_Ironsides/195_Old_Ironsides.dsk"
+          ]
         },
         {
           "id": 381118,
@@ -9522,7 +11482,7 @@
           "author": "007",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a2/b1/ae15.371049.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a2/9e/0b18.371048.png",
           "demozooUrl": "https://demozoo.org/productions/381105/",
           "page": 16
         },
@@ -9570,7 +11530,7 @@
           "author": "Baud Bandits",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9b/e9/cd72.371269.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4f/41/03e4.371268.png",
           "demozooUrl": "https://demozoo.org/productions/381205/",
           "page": 16
         },
@@ -9594,7 +11554,7 @@
           "author": "Clean Crack Band",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/24/18/2354.371953.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/29/5d/4a65.371952.png",
           "demozooUrl": "https://demozoo.org/productions/381718/",
           "page": 16
         },
@@ -9620,7 +11580,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/96/f8/afa7.295725.png",
           "demozooUrl": "https://demozoo.org/productions/297121/",
-          "page": 16
+          "page": 16,
+          "downloadUrl": "https://archive.org/download/342_Diagnostics/342_Diagnostics.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/342_Diagnostics/342_Diagnostics.dsk"
+          ]
         },
         {
           "id": 290766,
@@ -9632,7 +11596,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2f/90/e83d.286817.png",
           "demozooUrl": "https://demozoo.org/productions/290766/",
-          "page": 16
+          "page": 16,
+          "downloadUrl": "https://archive.org/download/185_Masquerade_Side_1/185_Masquerade_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/185_Masquerade_Side_1/185_Masquerade_Side_1.dsk"
+          ]
         },
         {
           "id": 381075,
@@ -9654,7 +11622,7 @@
           "author": "The Disk Jockey",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/37/57/3143.370393.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/cf/fe/7d1e.370394.png",
           "demozooUrl": "https://demozoo.org/productions/380781/",
           "page": 16
         },
@@ -9791,7 +11759,7 @@
           "author": "Mr. Krac-Man",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/92/23/6de2.370536.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ee/7f/e173.370534.png",
           "demozooUrl": "https://demozoo.org/productions/380830/",
           "page": 17
         },
@@ -9803,7 +11771,7 @@
           "author": "The 1200 Club",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/57/5b/7aec.370692.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/2d/df/e540.370691.png",
           "demozooUrl": "https://demozoo.org/productions/380891/",
           "page": 17
         },
@@ -9827,7 +11795,7 @@
           "author": "Midwest Pirates Guild",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/30/27/42d8.370307.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e9/70/239a.370308.png",
           "demozooUrl": "https://demozoo.org/productions/380733/",
           "page": 17
         },
@@ -9853,7 +11821,12 @@
           "year": "1983",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/380862/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/examazon.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/examazon.gif",
+            "http://artscene.textfiles.com/intros/APPLEII/examazonc.gif"
+          ]
         },
         {
           "id": 296786,
@@ -9863,9 +11836,13 @@
           "author": "Krakowicz",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/20/50/613a.371340.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/6b/15/23fd.295234.png",
           "demozooUrl": "https://demozoo.org/productions/296786/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "https://archive.org/download/316_Epidemic/316_Epidemic.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/316_Epidemic/316_Epidemic.dsk"
+          ]
         },
         {
           "id": 381704,
@@ -9889,7 +11866,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5c/1d/69aa.295287.png",
           "demozooUrl": "https://demozoo.org/productions/296847/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "https://archive.org/download/323_Einstein_Compiler/323_Einstein_Compiler.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/323_Einstein_Compiler/323_Einstein_Compiler.dsk"
+          ]
         },
         {
           "id": 381692,
@@ -9913,7 +11894,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/67/18/e9dd.285501.png",
           "demozooUrl": "https://demozoo.org/productions/289601/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "https://archive.org/download/089_Drol/089_Drol.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/089_Drol/089_Drol.dsk"
+          ]
         },
         {
           "id": 380850,
@@ -9923,7 +11908,7 @@
           "author": "Krakowicz / La Thief",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/18/d9/c17f.370612.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4a/f0/06af.370613.png",
           "demozooUrl": "https://demozoo.org/productions/380850/",
           "page": 17
         },
@@ -9935,7 +11920,7 @@
           "author": "The Freeze",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/37/3e/b97e.370598.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ba/27/adce.370599.png",
           "demozooUrl": "https://demozoo.org/productions/380845/",
           "page": 17
         },
@@ -9947,7 +11932,7 @@
           "author": "Sync#Cruncher",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/0d/d1/4c56.370600.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e7/2a/05ae.370602.png",
           "demozooUrl": "https://demozoo.org/productions/380846/",
           "page": 17
         },
@@ -9971,9 +11956,13 @@
           "author": "Midwest Pirates Guild",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/3e/da/0f0d.371322.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8f/7c/f3b7.371323.png",
           "demozooUrl": "https://demozoo.org/productions/289461/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "https://archive.org/download/3d0g_120a_Dino_Eggs/120a_Dino_Eggs.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_120a_Dino_Eggs/120a_Dino_Eggs.dsk"
+          ]
         },
         {
           "id": 380849,
@@ -9983,7 +11972,7 @@
           "author": "Mr. Krac-Man / Taskmaster",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ef/8f/6d22.370608.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/15/e3/f633.370607.png",
           "demozooUrl": "https://demozoo.org/productions/380849/",
           "page": 17
         },
@@ -10009,7 +11998,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c3/2d/dd0c.293471.png",
           "demozooUrl": "https://demozoo.org/productions/295559/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "https://archive.org/download/307_Dark_Crystal_Side_1a/307_Dark_Crystal_Side_1a.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/307_Dark_Crystal_Side_1a/307_Dark_Crystal_Side_1a.dsk"
+          ]
         },
         {
           "id": 380881,
@@ -10043,7 +12036,7 @@
           "author": "Clean Crack Band",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d9/52/0655.371867.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/9f/42/fa2b.371868.png",
           "demozooUrl": "https://demozoo.org/productions/381662/",
           "page": 17
         },
@@ -10067,7 +12060,7 @@
           "author": "",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/32/da/4a62.371087.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ba/c3/4c7a.371086.png",
           "demozooUrl": "https://demozoo.org/productions/381121/",
           "page": 17
         },
@@ -10091,7 +12084,7 @@
           "author": "Krakowicz",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/49/82/49e8.371912.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f6/28/2c41.371913.png",
           "demozooUrl": "https://demozoo.org/productions/381693/",
           "page": 17
         },
@@ -10103,7 +12096,7 @@
           "author": "Midwest Pirates Guild",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/eb/6c/56e2.372108.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/fa/f4/aabd.372110.png",
           "demozooUrl": "https://demozoo.org/productions/381834/",
           "page": 17
         },
@@ -10115,7 +12108,7 @@
           "author": "The Freeze",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/33/93/fe2d.370538.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e7/b7/010c.370540.png",
           "demozooUrl": "https://demozoo.org/productions/380829/",
           "page": 17
         },
@@ -10139,7 +12132,7 @@
           "author": "Connection / The Interrupt",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d4/3c/b4b9.194876.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b5/85/8f96.194875.png",
           "demozooUrl": "https://demozoo.org/productions/268904/",
           "page": 17
         },
@@ -10163,7 +12156,7 @@
           "author": "Corrupt Computing / The Stack",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/b1/c1/0922.370390.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4d/77/48cf.370391.png",
           "demozooUrl": "https://demozoo.org/productions/380779/",
           "page": 17
         },
@@ -10187,7 +12180,7 @@
           "author": "Buffalo Bill",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d2/17/29fb.371917.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/6e/6f/d478.371918.png",
           "demozooUrl": "https://demozoo.org/productions/381696/",
           "page": 17
         },
@@ -10199,7 +12192,7 @@
           "author": "Super Pirates of Minneapolis",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/66/af/aea3.370473.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7c/30/d9b2.370474.png",
           "demozooUrl": "https://demozoo.org/productions/380810/",
           "page": 17
         },
@@ -10247,7 +12240,7 @@
           "author": "The Whip",
           "dateStr": "1983",
           "year": "1983",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/28/f0/90fe.371905.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b4/a5/37d1.371906.png",
           "demozooUrl": "https://demozoo.org/productions/381687/",
           "page": 17
         },
@@ -10261,7 +12254,11 @@
           "year": "1983",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b8/b6/a643.285760.png",
           "demozooUrl": "https://demozoo.org/productions/289794/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "https://archive.org/download/104_LSD_Crack_Files_Side_1/104_LSD_Crack_Files_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/104_LSD_Crack_Files_Side_1/104_LSD_Crack_Files_Side_1.dsk"
+          ]
         },
         {
           "id": 288513,
@@ -10273,7 +12270,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/02/bf/63a7.284009.png",
           "demozooUrl": "https://demozoo.org/productions/288513/",
-          "page": 17
+          "page": 17,
+          "downloadUrl": "https://archive.org/download/074_A.E._Side_1/074_A.E._Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/074_A.E._Side_1/074_A.E._Side_1.dsk"
+          ]
         },
         {
           "id": 381131,
@@ -10312,7 +12313,7 @@
           "author": "Black Bart",
           "dateStr": "Mar 1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/7d/91/49bc.370282.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/ca/47/c573.370283.png",
           "demozooUrl": "https://demozoo.org/productions/380720/",
           "page": 18
         },
@@ -10326,7 +12327,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/0e/86/3025.287186.png",
           "demozooUrl": "https://demozoo.org/productions/291121/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/204a_Zoom_Grafix/204a_Zoom_Grafix.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/204a_Zoom_Grafix/204a_Zoom_Grafix.dsk"
+          ]
         },
         {
           "id": 381243,
@@ -10362,7 +12367,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/59/d0/883d.284853.png",
           "demozooUrl": "https://demozoo.org/productions/289199/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/3d0g_039a_Zoom_Graftrix/039a_Zoom_Graftrix.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_039a_Zoom_Graftrix/039a_Zoom_Graftrix.dsk"
+          ]
         },
         {
           "id": 381686,
@@ -10384,7 +12393,7 @@
           "author": "Krakowicz",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/b7/3f/22f3.370347.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/53/ef/6fb1.370345.png",
           "demozooUrl": "https://demozoo.org/productions/380757/",
           "page": 18
         },
@@ -10456,9 +12465,13 @@
           "author": "Krakowicz",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a6/cc/fd72.286108.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8a/8a/763f.370353.png",
           "demozooUrl": "https://demozoo.org/productions/290088/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/156_Type_Attack/156_Type_Attack.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/156_Type_Attack/156_Type_Attack.dsk"
+          ]
         },
         {
           "id": 381201,
@@ -10480,7 +12493,7 @@
           "author": "The Disk Jockey",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/10/ab/d416.370952.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/6c/29/ca22.370951.png",
           "demozooUrl": "https://demozoo.org/productions/381050/",
           "page": 18
         },
@@ -10506,7 +12519,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/40/e3/f94b.283758.png",
           "demozooUrl": "https://demozoo.org/productions/288313/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/020_Transylvania/020_Transylvania.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/020_Transylvania/020_Transylvania.dsk"
+          ]
         },
         {
           "id": 380728,
@@ -10530,7 +12547,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/25/49/2757.370255.png",
           "demozooUrl": "https://demozoo.org/productions/380707/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/a2_Federation_19xx__Torax_1981_Creative_Computing_cr_Zargs_19xx_/Federation_19xx____Torax_1981_Creative_Computing_cr__Zargs_19xx__.do",
+          "downloadUrls": [
+            "https://archive.org/download/a2_Federation_19xx__Torax_1981_Creative_Computing_cr_Zargs_19xx_/Federation_19xx____Torax_1981_Creative_Computing_cr__Zargs_19xx__.do"
+          ]
         },
         {
           "id": 381974,
@@ -10540,7 +12561,7 @@
           "author": "The Disk Jockey",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/77/0b/ffb9.372372.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/17/fd/c04a.372371.png",
           "demozooUrl": "https://demozoo.org/productions/381974/",
           "page": 18
         },
@@ -10566,7 +12587,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/04/1d/2b23.331220.png",
           "demozooUrl": "https://demozoo.org/productions/147082/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "http://mirrors.apple2.org.za/landover.no-ip.com/Applications/Music%20Disk,%20The%20(1982)(Walter%20Marcinko%20Jr.).dsk",
+          "downloadUrls": [
+            "http://mirrors.apple2.org.za/landover.no-ip.com/Applications/Music%20Disk,%20The%20(1982)(Walter%20Marcinko%20Jr.).dsk"
+          ]
         },
         {
           "id": 289600,
@@ -10578,7 +12603,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/08/99/e517.285500.png",
           "demozooUrl": "https://demozoo.org/productions/289600/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/085_Missing_Ring/085_Missing_Ring.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/085_Missing_Ring/085_Missing_Ring.dsk"
+          ]
         },
         {
           "id": 381077,
@@ -10590,7 +12619,11 @@
           "year": "1982",
           "screenshotUrl": "",
           "demozooUrl": "https://demozoo.org/productions/381077/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/masksun.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/masksun.gif"
+          ]
         },
         {
           "id": 288330,
@@ -10600,9 +12633,13 @@
           "author": "Mr. Krac-Man",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d6/52/2888.283786.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4d/bb/ec01.371339.png",
           "demozooUrl": "https://demozoo.org/productions/288330/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/039_Desecration/039_Desecration.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/039_Desecration/039_Desecration.dsk"
+          ]
         },
         {
           "id": 381652,
@@ -10624,7 +12661,7 @@
           "author": "Krakowicz",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/24/a4/7da0.370349.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/60/58/371b.370348.png",
           "demozooUrl": "https://demozoo.org/productions/380758/",
           "page": 18
         },
@@ -10638,7 +12675,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c4/96/0d1c.293472.png",
           "demozooUrl": "https://demozoo.org/productions/295560/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/307_The_Lean_Mean_Arcade_Machine/307_The_Lean_Mean_Arcade_Machine.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/307_The_Lean_Mean_Arcade_Machine/307_The_Lean_Mean_Arcade_Machine.dsk"
+          ]
         },
         {
           "id": 380809,
@@ -10672,7 +12713,7 @@
           "author": "The Artist",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/59/ce/40fc.371509.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7e/fb/77f8.371510.png",
           "demozooUrl": "https://demozoo.org/productions/381314/",
           "page": 18
         },
@@ -10698,7 +12739,12 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/70/02/b837.370262.png",
           "demozooUrl": "https://demozoo.org/productions/380709/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/Games_Suicide_Firebird_Genetic_Drift_Snack_Attack/Games_Suicide_Firebird_Genetic_Drift_Snack_Attack.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/Games_Suicide_Firebird_Genetic_Drift_Snack_Attack/Games_Suicide_Firebird_Genetic_Drift_Snack_Attack.dsk",
+            "https://archive.org/download/a2_countycarnival_hardhat_lemmings_peoplepong_suicide/countycarnival_hardhat_lemmings_peoplepong_suicide.dsk"
+          ]
         },
         {
           "id": 380788,
@@ -10722,7 +12768,12 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/02/71/a063.370256.png",
           "demozooUrl": "https://demozoo.org/productions/380703/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/a2_Starblaster_19xx_C_G_cr_Star_Trek_1983_Sega_cr_Shuttle_Intercept_19xx__cr/Starblaster_19xx_C__G_cr__Star_Trek_1983_Sega_cr__Shuttle_Intercept_19xx___cr.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/a2_Starblaster_19xx_C_G_cr_Star_Trek_1983_Sega_cr_Shuttle_Intercept_19xx__cr/Starblaster_19xx_C__G_cr__Star_Trek_1983_Sega_cr__Shuttle_Intercept_19xx___cr.dsk",
+            "https://defacto2.net/image/milestone/starblaster-mr-xerox.webm"
+          ]
         },
         {
           "id": 380746,
@@ -10746,7 +12797,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d2/7e/212d.370265.png",
           "demozooUrl": "https://demozoo.org/productions/380710/",
-          "page": 18
+          "page": 18,
+          "downloadUrl": "https://archive.org/download/a2_Star_Blazer_1981_Star_Craft/Star_Blazer_1981_Star_Craft.do",
+          "downloadUrls": [
+            "https://archive.org/download/a2_Star_Blazer_1981_Star_Craft/Star_Blazer_1981_Star_Craft.do"
+          ]
         },
         {
           "id": 380751,
@@ -10792,7 +12847,7 @@
           "author": "The Black Hole",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/15/7b/a611.370335.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8c/10/2365.370336.png",
           "demozooUrl": "https://demozoo.org/productions/380752/",
           "page": 18
         },
@@ -10864,7 +12919,7 @@
           "author": "Apple Pirated Program Library Exchange",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/31/85/7438.370284.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a8/98/4795.370286.png",
           "demozooUrl": "https://demozoo.org/productions/380722/",
           "page": 18
         },
@@ -10917,7 +12972,7 @@
           "author": "Krakowicz",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/50/82/9120.370342.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/65/d7/6295.370343.png",
           "demozooUrl": "https://demozoo.org/productions/380755/",
           "page": 19
         },
@@ -10931,7 +12986,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/da/fd/08ef.370260.png",
           "demozooUrl": "https://demozoo.org/productions/380708/",
-          "page": 19
+          "page": 19,
+          "downloadUrl": "https://archive.org/download/arcade-games-arena-of-octos-photar-battlefield-frogger/Arcade%20Games%20%28Arena%20of%20Octos%2C%20Photar%2C%20Battlefield%2C%20Frogger%29.do",
+          "downloadUrls": [
+            "https://archive.org/download/arcade-games-arena-of-octos-photar-battlefield-frogger/Arcade%20Games%20%28Arena%20of%20Octos%2C%20Photar%2C%20Battlefield%2C%20Frogger%29.do"
+          ]
         },
         {
           "id": 380711,
@@ -10943,7 +13002,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a6/89/bf7e.370267.png",
           "demozooUrl": "https://demozoo.org/productions/380711/",
-          "page": 19
+          "page": 19,
+          "downloadUrl": "https://archive.org/download/a2_Russki_Duck_1982_Gebelli_Software_cr_Mr._Xerox/Russki_Duck_1982_Gebelli_Software_cr_Mr._Xerox.do",
+          "downloadUrls": [
+            "https://archive.org/download/a2_Russki_Duck_1982_Gebelli_Software_cr_Mr._Xerox/Russki_Duck_1982_Gebelli_Software_cr_Mr._Xerox.do"
+          ]
         },
         {
           "id": 381665,
@@ -10965,7 +13028,7 @@
           "author": "Zero Page",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/3f/1f/d887.370499.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7f/63/25e1.370501.png",
           "demozooUrl": "https://demozoo.org/productions/380821/",
           "page": 19
         },
@@ -11013,7 +13076,7 @@
           "author": "Krakowicz",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/26/6b/e2cb.371281.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4c/05/4530.371282.png",
           "demozooUrl": "https://demozoo.org/productions/380747/",
           "page": 19
         },
@@ -11063,7 +13126,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1a/15/a866.284001.png",
           "demozooUrl": "https://demozoo.org/productions/288509/",
-          "page": 19
+          "page": 19,
+          "downloadUrl": "https://archive.org/download/068_Pner_II/068_Prisoner_II.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/068_Pner_II/068_Prisoner_II.dsk"
+          ]
         },
         {
           "id": 288326,
@@ -11075,7 +13142,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1f/68/1501.283782.png",
           "demozooUrl": "https://demozoo.org/productions/288326/",
-          "page": 19
+          "page": 19,
+          "downloadUrl": "https://archive.org/download/034_Pinball_Construction_Set/034_Pinball_Construction_Set.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/034_Pinball_Construction_Set/034_Pinball_Construction_Set.dsk"
+          ]
         },
         {
           "id": 381803,
@@ -11157,7 +13228,7 @@
           "author": "Quick Silver",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/0a/82/62bd.371060.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/95/7b/3a8a.371061.png",
           "demozooUrl": "https://demozoo.org/productions/381112/",
           "page": 19
         },
@@ -11243,7 +13314,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8b/5d/4737.285638.png",
           "demozooUrl": "https://demozoo.org/productions/289713/",
-          "page": 19
+          "page": 19,
+          "downloadUrl": "https://archive.org/download/100_Microscopic_Journey/100_Microscopic_Journey.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/100_Microscopic_Journey/100_Microscopic_Journey.dsk"
+          ]
         },
         {
           "id": 380772,
@@ -11279,7 +13354,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/95/17/842b.371374.png",
           "demozooUrl": "https://demozoo.org/productions/289196/",
-          "page": 19
+          "page": 19,
+          "downloadUrl": "https://archive.org/download/3d0g_014a_Lunar_Leeper/014a_Lunar_Leeper.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_014a_Lunar_Leeper/014a_Lunar_Leeper.dsk"
+          ]
         },
         {
           "id": 380725,
@@ -11289,7 +13368,7 @@
           "author": "Apple Pirated Program Library Exchange",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1c/e9/58ab.370289.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/18/32/e95b.370291.png",
           "demozooUrl": "https://demozoo.org/productions/380725/",
           "page": 19
         },
@@ -11301,7 +13380,7 @@
           "author": "The Whip",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/7b/50/818e.370379.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/34/dd/2190.370378.png",
           "demozooUrl": "https://demozoo.org/productions/380771/",
           "page": 19
         },
@@ -11337,7 +13416,7 @@
           "author": "Black Bag",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1c/58/f6a5.370980.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/68/bb/98b2.370979.png",
           "demozooUrl": "https://demozoo.org/productions/381063/",
           "page": 19
         },
@@ -11385,7 +13464,7 @@
           "author": "Apple Pirated Program Library Exchange",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/98/69/9aa5.370287.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/90/f4/aff9.370288.png",
           "demozooUrl": "https://demozoo.org/productions/380724/",
           "page": 19
         },
@@ -11421,7 +13500,7 @@
           "author": "Mr. Xerox",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/7d/eb/34c7.370276.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/91/99/b23f.370277.png",
           "demozooUrl": "https://demozoo.org/productions/380717/",
           "page": 19
         },
@@ -11445,7 +13524,7 @@
           "author": "Sowbug",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/8a/a1/b72b.371517.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/bb/8c/885b.371516.png",
           "demozooUrl": "https://demozoo.org/productions/381319/",
           "page": 19
         },
@@ -11546,7 +13625,7 @@
           "author": "Captain Computer",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/e8/76/1311.370661.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/eb/ab/353c.370662.png",
           "demozooUrl": "https://demozoo.org/productions/380874/",
           "page": 20
         },
@@ -11570,7 +13649,7 @@
           "author": "Crow's Nest Software",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/84/4e/8d75.370643.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/f0/0f/f3cc.370642.png",
           "demozooUrl": "https://demozoo.org/productions/380867/",
           "page": 20
         },
@@ -11596,7 +13675,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/48/64/eb5f.293470.png",
           "demozooUrl": "https://demozoo.org/productions/295558/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/305_Evolution/305_Evolution.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/305_Evolution/305_Evolution.dsk"
+          ]
         },
         {
           "id": 381668,
@@ -11606,7 +13689,7 @@
           "author": "Apple Pirated Program Library Exchange",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a1/b2/836b.371878.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/74/a4/b211.371877.png",
           "demozooUrl": "https://demozoo.org/productions/381668/",
           "page": 20
         },
@@ -11654,7 +13737,7 @@
           "author": "Mr. Xerox",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9c/fa/618f.370280.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/bf/1b/bb37.370281.png",
           "demozooUrl": "https://demozoo.org/productions/380719/",
           "page": 20
         },
@@ -11678,7 +13761,7 @@
           "author": "Super Pirates of Minneapolis",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9d/ed/9e4f.372649.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b2/4a/0cce.372648.png",
           "demozooUrl": "https://demozoo.org/productions/382233/",
           "page": 20
         },
@@ -11704,7 +13787,13 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c1/ed/02c6.286816.png",
           "demozooUrl": "https://demozoo.org/productions/121615/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/182_Dawn_Patrol/182_Dawn_Patrol.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/182_Dawn_Patrol/182_Dawn_Patrol.dsk",
+            "https://archive.scene.org/pub/demos/groups/the_hoosier_connection/hoosier.zip",
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/HOOSIER.zip"
+          ]
         },
         {
           "id": 380726,
@@ -11728,7 +13817,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5f/3c/0640.295233.png",
           "demozooUrl": "https://demozoo.org/productions/296785/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/312_Cyclotron/312_Cyclotron.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/312_Cyclotron/312_Cyclotron.dsk"
+          ]
         },
         {
           "id": 380741,
@@ -11750,7 +13843,7 @@
           "author": "Krakowicz",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a9/fa/e2bc.370339.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/65/74/cb85.370341.png",
           "demozooUrl": "https://demozoo.org/productions/380754/",
           "page": 20
         },
@@ -11764,7 +13857,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f4/9f/0c29.285970.png",
           "demozooUrl": "https://demozoo.org/productions/289935/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/129b_Crisis_Mountain/129b_Crisis_Mountain.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/129b_Crisis_Mountain/129b_Crisis_Mountain.dsk"
+          ]
         },
         {
           "id": 381658,
@@ -11774,7 +13871,7 @@
           "author": "Super Pirates of Minneapolis",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/3e/96/c609.371863.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b4/5b/624e.371864.png",
           "demozooUrl": "https://demozoo.org/productions/381658/",
           "page": 20
         },
@@ -11788,7 +13885,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/13/cd/9b36.285967.png",
           "demozooUrl": "https://demozoo.org/productions/289932/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/127_Cosmic_Balance/127_Cosmic_Balance.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/127_Cosmic_Balance/127_Cosmic_Balance.dsk"
+          ]
         },
         {
           "id": 381783,
@@ -11812,7 +13913,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/06/d0/328d.372360.png",
           "demozooUrl": "https://demozoo.org/productions/380712/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/cfoosball.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/cfoosball.gif"
+          ]
         },
         {
           "id": 380713,
@@ -11824,7 +13929,12 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ab/0e/62fe.372010.png",
           "demozooUrl": "https://demozoo.org/productions/380713/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/choplifter.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/choplifter.gif",
+            "http://artscene.textfiles.com/intros/APPLEII/choplifterc.gif"
+          ]
         },
         {
           "id": 380723,
@@ -11836,7 +13946,12 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/18/cb/c885.372362.png",
           "demozooUrl": "https://demozoo.org/productions/380723/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "http://artscene.textfiles.com/intros/APPLEII/choplift.gif",
+          "downloadUrls": [
+            "http://artscene.textfiles.com/intros/APPLEII/choplift.gif",
+            "http://artscene.textfiles.com/intros/APPLEII/chopliftc.gif"
+          ]
         },
         {
           "id": 381967,
@@ -11858,7 +13973,7 @@
           "author": "Trystan II",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/39/52/81b3.370477.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/3e/34/f537.370476.png",
           "demozooUrl": "https://demozoo.org/productions/380811/",
           "page": 20
         },
@@ -11882,7 +13997,7 @@
           "author": "Mr. Krac-Man",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/57/4e/4b91.370526.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/0f/71/4ea2.370528.png",
           "demozooUrl": "https://demozoo.org/productions/380827/",
           "page": 20
         },
@@ -11894,7 +14009,7 @@
           "author": "The Untouchables",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/86/d5/9e5c.370497.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/8c/8c/c049.370498.png",
           "demozooUrl": "https://demozoo.org/productions/380820/",
           "page": 20
         },
@@ -11918,7 +14033,7 @@
           "author": "Black Bag",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/72/58/54d5.371266.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/56/34/dde9.371267.png",
           "demozooUrl": "https://demozoo.org/productions/381204/",
           "page": 20
         },
@@ -11930,9 +14045,13 @@
           "author": "Mr. Xerox",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d1/4d/1b3e.370257.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/97/44/9aa9.302798.jpg",
           "demozooUrl": "https://demozoo.org/productions/303709/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/a2_Battlesight_1982_Versa_Computing_cr_Mr._Xerox/Battlesight_1982_Versa_Computing_cr_Mr._Xerox.do",
+          "downloadUrls": [
+            "https://archive.org/download/a2_Battlesight_1982_Versa_Computing_cr_Mr._Xerox/Battlesight_1982_Versa_Computing_cr_Mr._Xerox.do"
+          ]
         },
         {
           "id": 268902,
@@ -11954,7 +14073,7 @@
           "author": "The Fongus",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/23/8a/e359.371860.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/57/6c/5891.371861.png",
           "demozooUrl": "https://demozoo.org/productions/381654/",
           "page": 20
         },
@@ -11966,7 +14085,7 @@
           "author": "Worm!",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/6d/80/03a2.370318.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7e/65/5de1.370320.png",
           "demozooUrl": "https://demozoo.org/productions/380740/",
           "page": 20
         },
@@ -11978,7 +14097,7 @@
           "author": "The MWT",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ad/e1/5d5c.371858.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/91/a6/2cd4.371859.png",
           "demozooUrl": "https://demozoo.org/productions/381653/",
           "page": 20
         },
@@ -12028,7 +14147,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/81/c4/c2cf.286823.png",
           "demozooUrl": "https://demozoo.org/productions/290772/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/196_Ali_Baba/196_Ali_Baba.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/196_Ali_Baba/196_Ali_Baba.dsk"
+          ]
         },
         {
           "id": 298785,
@@ -12040,7 +14163,11 @@
           "year": "1982",
           "screenshotUrl": "https://media.demozoo.org/screens/t/09/4e/a97a.297273.png",
           "demozooUrl": "https://demozoo.org/productions/298785/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/3d0g_121b_Abuse/121b_Abuse.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_121b_Abuse/121b_Abuse.dsk"
+          ]
         },
         {
           "id": 293795,
@@ -12050,9 +14177,13 @@
           "author": "Crack's Product",
           "dateStr": "1982",
           "year": "1982",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/80/35/1c90.372373.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e4/77/70ef.372374.png",
           "demozooUrl": "https://demozoo.org/productions/293795/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://archive.org/download/268a_AE_Side_1/268a_AE_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/268a_AE_Side_1/268a_AE_Side_1.dsk"
+          ]
         },
         {
           "id": 147055,
@@ -12064,7 +14195,11 @@
           "year": "1981",
           "screenshotUrl": "https://media.demozoo.org/screens/t/71/b2/b62b.331221.png",
           "demozooUrl": "https://demozoo.org/productions/147055/",
-          "page": 20
+          "page": 20,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/PIRATE.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/PIRATE.zip"
+          ]
         },
         {
           "id": 381966,
@@ -12086,7 +14221,7 @@
           "author": "Bobby The Kid",
           "dateStr": "Jun 1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ef/5c/39bc.371534.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/eb/f6/b67e.371533.png",
           "demozooUrl": "https://demozoo.org/productions/381330/",
           "page": 20
         },
@@ -12115,7 +14250,7 @@
           "author": "Apple Pirated Program Library Exchange",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/f1/75/89a9.370300.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/84/29/cc2d.370298.png",
           "demozooUrl": "https://demozoo.org/productions/380729/",
           "page": 21
         },
@@ -12199,7 +14334,7 @@
           "author": "Bobby The Kid",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/92/d2/3e8a.371029.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/4f/69/1112.371031.png",
           "demozooUrl": "https://demozoo.org/productions/381094/",
           "page": 21
         },
@@ -12223,7 +14358,7 @@
           "author": "",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ec/b6/b387.370358.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/07/10/beb3.370357.png",
           "demozooUrl": "https://demozoo.org/productions/380762/",
           "page": 21
         },
@@ -12247,7 +14382,7 @@
           "author": "The Whip",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/19/c7/7a36.371522.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/d1/87/6d52.371523.png",
           "demozooUrl": "https://demozoo.org/productions/381323/",
           "page": 21
         },
@@ -12271,7 +14406,7 @@
           "author": "Apple Pirated Program Library Exchange",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/58/cb/5392.371270.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/39/00/ceef.371271.png",
           "demozooUrl": "https://demozoo.org/productions/381206/",
           "page": 21
         },
@@ -12283,7 +14418,7 @@
           "author": "The Whip",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/ee/cd/6e4f.371527.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/46/14/b91e.371528.png",
           "demozooUrl": "https://demozoo.org/productions/381326/",
           "page": 21
         },
@@ -12343,7 +14478,7 @@
           "author": "Cracker-Jack",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a3/2d/ceef.371529.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/40/09/d84f.372358.png",
           "demozooUrl": "https://demozoo.org/productions/381327/",
           "page": 21
         },
@@ -12367,9 +14502,13 @@
           "author": "Hack Ware",
           "dateStr": "1981",
           "year": "1981",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/7a/10/a765.283724.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b2/f6/f16d.374917.png",
           "demozooUrl": "https://demozoo.org/productions/288295/",
-          "page": 21
+          "page": 21,
+          "downloadUrl": "https://archive.org/download/008b_Animated_French_Sex_Postcards/008b_Animated_French_Sex_Postcards.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/008b_Animated_French_Sex_Postcards/008b_Animated_French_Sex_Postcards.dsk"
+          ]
         },
         {
           "id": 380718,
@@ -12391,7 +14530,7 @@
           "author": "Mac",
           "dateStr": "Sep 1980",
           "year": "1980",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/19/fd/689c.370505.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/20/79/6aa6.370677.png",
           "demozooUrl": "https://demozoo.org/productions/380761/",
           "page": 21
         },
@@ -12429,7 +14568,11 @@
           "year": "1979",
           "screenshotUrl": "https://media.demozoo.org/screens/t/06/f6/740e.331223.jpg",
           "demozooUrl": "https://demozoo.org/productions/147083/",
-          "page": 21
+          "page": 21,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BRIAN.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/BRIAN.zip"
+          ]
         },
         {
           "id": 121614,
@@ -12441,7 +14584,12 @@
           "year": "1978",
           "screenshotUrl": "https://media.demozoo.org/screens/t/81/af/e0e7.331222.png",
           "demozooUrl": "https://demozoo.org/productions/121614/",
-          "page": 21
+          "page": 21,
+          "downloadUrl": "ftp://ftp.apple.asimov.net/pub/apple_II/images/masters/dos33_with_adt.dsk",
+          "downloadUrls": [
+            "ftp://ftp.apple.asimov.net/pub/apple_II/images/masters/dos33_with_adt.dsk"
+          ],
+          "youtubeUrl": "https://www.youtube.com/watch?v=RiWE-aO-cyU"
         },
         {
           "id": 380804,
@@ -12475,7 +14623,7 @@
           "author": "",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9f/b8/f4c5.372153.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/7b/6e/060b.372152.png",
           "demozooUrl": "https://demozoo.org/productions/381857/",
           "page": 21
         },
@@ -12489,7 +14637,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2b/c4/1070.290251.png",
           "demozooUrl": "https://demozoo.org/productions/293273/",
-          "page": 21
+          "page": 21,
+          "downloadUrl": "https://archive.org/download/258_Witch_Head_Nebula/258_Witch_Head_Nebula.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/258_Witch_Head_Nebula/258_Witch_Head_Nebula.dsk"
+          ]
         },
         {
           "id": 297122,
@@ -12501,7 +14653,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/88/6e/6a99.295726.png",
           "demozooUrl": "https://demozoo.org/productions/297122/",
-          "page": 21
+          "page": 21,
+          "downloadUrl": "https://archive.org/download/345_ViewTron/345_ViewTron.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/345_ViewTron/345_ViewTron.dsk"
+          ]
         },
         {
           "id": 381269,
@@ -12523,7 +14679,7 @@
           "author": "",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/2f/ec/959a.372012.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/a7/3b/85d8.372011.png",
           "demozooUrl": "https://demozoo.org/productions/381748/",
           "page": 21
         },
@@ -12583,7 +14739,7 @@
           "author": "The National Apple Pirate's League",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/78/aa/97c7.372099.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/54/7e/6844.372100.png",
           "demozooUrl": "https://demozoo.org/productions/381829/",
           "page": 21
         },
@@ -12619,7 +14775,7 @@
           "author": "Automan / Kracking Guild",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/4f/3c/aa8e.372027.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/d1/d2/1b9e.372028.png",
           "demozooUrl": "https://demozoo.org/productions/381763/",
           "page": 21
         },
@@ -12633,7 +14789,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7d/3c/e9a8.289558.png",
           "demozooUrl": "https://demozoo.org/productions/292782/",
-          "page": 21
+          "page": 21,
+          "downloadUrl": "https://archive.org/download/226b_Defender_Centipede_Pac-Man_Dig-Dug/226b_Defender_Centipede_Pac-Man_Dig-Dug.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/226b_Defender_Centipede_Pac-Man_Dig-Dug/226b_Defender_Centipede_Pac-Man_Dig-Dug.dsk"
+          ]
         },
         {
           "id": 290084,
@@ -12645,7 +14805,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2b/b8/1dd0.286107.png",
           "demozooUrl": "https://demozoo.org/productions/290084/",
-          "page": 21
+          "page": 21,
+          "downloadUrl": "https://archive.org/download/155_CP-5/155_CP-5.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/155_CP-5/155_CP-5.dsk"
+          ]
         },
         {
           "id": 194761,
@@ -12667,7 +14831,7 @@
           "author": "The Wareforce",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/a1/27/0549.371212.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/67/b3/afba.371213.png",
           "demozooUrl": "https://demozoo.org/productions/381184/",
           "page": 21
         },
@@ -12703,7 +14867,7 @@
           "author": "",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/fd/11/e467.372045.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/73/9c/9b3b.372044.png",
           "demozooUrl": "https://demozoo.org/productions/381790/",
           "page": 21
         }
@@ -12722,7 +14886,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ae/68/d929.283778.png",
           "demozooUrl": "https://demozoo.org/productions/288322/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/031_Star_Wars/031_Star_Wars.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/031_Star_Wars/031_Star_Wars.dsk"
+          ]
         },
         {
           "id": 301022,
@@ -12734,7 +14902,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f6/7d/68e9.299734.png",
           "demozooUrl": "https://demozoo.org/productions/301022/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/3d0g_176a_Starball/176a_Starball.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_176a_Starball/176a_Starball.dsk"
+          ]
         },
         {
           "id": 292815,
@@ -12746,7 +14918,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/01/65/af67.289599.png",
           "demozooUrl": "https://demozoo.org/productions/292815/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/244a_Sound_Wizard/244a_Sound_Wizard.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/244a_Sound_Wizard/244a_Sound_Wizard.dsk"
+          ]
         },
         {
           "id": 157913,
@@ -12756,9 +14932,13 @@
           "author": "Crackman",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/d6/f9/1041.107954.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/04/d7/cd37.107955.png",
           "demozooUrl": "https://demozoo.org/productions/157913/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "http://www.brutaldeluxe.fr/products/underground/crackman/crackman_slideshow.DSK",
+          "downloadUrls": [
+            "http://www.brutaldeluxe.fr/products/underground/crackman/crackman_slideshow.DSK"
+          ]
         },
         {
           "id": 292785,
@@ -12770,7 +14950,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ef/98/ed41.289561.png",
           "demozooUrl": "https://demozoo.org/productions/292785/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/229b_Animated_Sex_Cartoons_Side_2/229b_Animated_Sex_Cartoons_Side_2.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/229b_Animated_Sex_Cartoons_Side_2/229b_Animated_Sex_Cartoons_Side_2.dsk"
+          ]
         },
         {
           "id": 289451,
@@ -12782,7 +14966,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/bd/6c/0407.285088.png",
           "demozooUrl": "https://demozoo.org/productions/289451/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/3d0g_042a_Sesame_Street_Games/042a_-_Sesame_Street_Games_-_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_042a_Sesame_Street_Games/042a_-_Sesame_Street_Games_-_Side_1.dsk"
+          ]
         },
         {
           "id": 301021,
@@ -12794,7 +14982,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/7f/2f/5229.299733.png",
           "demozooUrl": "https://demozoo.org/productions/301021/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/3d0g_173a_Sargon_III_Plus/173a_Sargon_III_Plus.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_173a_Sargon_III_Plus/173a_Sargon_III_Plus.dsk"
+          ]
         },
         {
           "id": 298786,
@@ -12806,7 +14998,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a7/43/1530.297274.png",
           "demozooUrl": "https://demozoo.org/productions/298786/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/3d0g_137b_Ringside_Seat/137b_Ringside_Seat.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/3d0g_137b_Ringside_Seat/137b_Ringside_Seat.dsk"
+          ]
         },
         {
           "id": 381971,
@@ -12830,7 +15026,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/c7/cf/aab9.283753.png",
           "demozooUrl": "https://demozoo.org/productions/288308/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/016a_Radio_Control_Flight_Simulator_II/016a_Radio_Control_Flight_Simulator_II.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/016a_Radio_Control_Flight_Simulator_II/016a_Radio_Control_Flight_Simulator_II.dsk"
+          ]
         },
         {
           "id": 289801,
@@ -12842,7 +15042,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/2e/b3/a102.285906.png",
           "demozooUrl": "https://demozoo.org/productions/289801/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/118_Quest_of_the_Gem_Side_1/118_Quest_of_the_Gem_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/118_Quest_of_the_Gem_Side_1/118_Quest_of_the_Gem_Side_1.dsk"
+          ]
         },
         {
           "id": 381711,
@@ -12852,7 +15056,7 @@
           "author": "Digital Gang / First Class",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/c1/ed/6f30.371942.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/34/ea/9bb9.371943.png",
           "demozooUrl": "https://demozoo.org/productions/381711/",
           "page": 22
         },
@@ -12876,9 +15080,13 @@
           "author": "Club Med",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/08/1a/2a30.372155.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/1a/4c/b75e.285763.png",
           "demozooUrl": "https://demozoo.org/productions/289797/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/109_Pirates_Signature/109_Pirates_Signature.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/109_Pirates_Signature/109_Pirates_Signature.dsk"
+          ]
         },
         {
           "id": 147085,
@@ -12890,7 +15098,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/1d/b0/7791.284866.png",
           "demozooUrl": "https://demozoo.org/productions/147085/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://ftp.untergrund.net/users/hitchhikr/old/apple2/EDIMENSION.zip",
+          "downloadUrls": [
+            "https://ftp.untergrund.net/users/hitchhikr/old/apple2/EDIMENSION.zip"
+          ]
         },
         {
           "id": 381674,
@@ -12914,7 +15126,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/ac/b9/6ad4.283722.png",
           "demozooUrl": "https://demozoo.org/productions/288293/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/003_PFS_Reports/003_PFS_Reports.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/003_PFS_Reports/003_PFS_Reports.dsk"
+          ]
         },
         {
           "id": 381806,
@@ -12938,7 +15154,12 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/07/82/8b43.285770.png",
           "demozooUrl": "https://demozoo.org/productions/289798/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/112_Music_Maker/112_Music_Maker.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/112_Music_Maker/112_Music_Maker.dsk",
+            "https://archive.org/download/343_Music_Maker/343_Music_Maker.dsk"
+          ]
         },
         {
           "id": 381078,
@@ -12972,7 +15193,7 @@
           "author": "Club 68000 / Dr. Crunch",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/cd/60/a811.372120.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/e6/66/568b.372117.png",
           "demozooUrl": "https://demozoo.org/productions/381836/",
           "page": 22
         },
@@ -12986,7 +15207,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/a6/05/cdde.283721.png",
           "demozooUrl": "https://demozoo.org/productions/288292/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/004_Lode_Runner_II/004_Lode_Runner_II.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/004_Lode_Runner_II/004_Lode_Runner_II.dsk"
+          ]
         },
         {
           "id": 291122,
@@ -12998,7 +15223,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/33/48/0b7a.287187.png",
           "demozooUrl": "https://demozoo.org/productions/291122/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/205a_Lode_Runner_II/205a_Lode_Runner_II.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/205a_Lode_Runner_II/205a_Lode_Runner_II.dsk"
+          ]
         },
         {
           "id": 380826,
@@ -13008,7 +15237,7 @@
           "author": "Krakerjack",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/90/e4/7f24.370515.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/27/a4/53c8.370518.png",
           "demozooUrl": "https://demozoo.org/productions/380826/",
           "page": 22
         },
@@ -13034,7 +15263,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/43/3d/b5d1.283788.png",
           "demozooUrl": "https://demozoo.org/productions/288332/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/043_Jumpman/043_Jumpman.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/043_Jumpman/043_Jumpman.dsk"
+          ]
         },
         {
           "id": 381056,
@@ -13056,7 +15289,7 @@
           "author": "The Software Underground",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/db/ee/d8c5.370964.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/61/5d/29ce.370963.png",
           "demozooUrl": "https://demozoo.org/productions/381057/",
           "page": 22
         },
@@ -13070,7 +15303,12 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/00/73/467e.107952.png",
           "demozooUrl": "https://demozoo.org/productions/157912/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "http://www.brutaldeluxe.fr/products/underground/bones/bones_slideshow_5.DSK",
+          "downloadUrls": [
+            "http://www.brutaldeluxe.fr/products/underground/bones/bones_slideshow_5.DSK",
+            "https://archive.scene.org/pub/demos/groups/bones/bones_slideshow_5.zip"
+          ]
         },
         {
           "id": 381669,
@@ -13106,7 +15344,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6c/1e/db8a.372218.png",
           "demozooUrl": "https://demozoo.org/productions/289597/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/078_Cheat_Files/078_Cheat_Files.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/078_Cheat_Files/078_Cheat_Files.dsk"
+          ]
         },
         {
           "id": 380899,
@@ -13128,7 +15370,7 @@
           "author": "Association of French Crackers",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/e8/2a/a0f1.371932.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/92/07/34c2.371929.png",
           "demozooUrl": "https://demozoo.org/productions/381706/",
           "page": 22
         },
@@ -13142,7 +15384,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/8f/2b/14c6.290920.png",
           "demozooUrl": "https://demozoo.org/productions/293789/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/262a_Floppy/262a_Floppy.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/262a_Floppy/262a_Floppy.dsk"
+          ]
         },
         {
           "id": 288348,
@@ -13154,7 +15400,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/52/c2/3eb2.371449.png",
           "demozooUrl": "https://demozoo.org/productions/288348/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/049_Firebugs/049_Firebugs.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/049_Firebugs/049_Firebugs.dsk"
+          ]
         },
         {
           "id": 291120,
@@ -13164,9 +15414,13 @@
           "author": "The Wizz",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/1c/97/e7a2.287185.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/5c/ef/9a86.371370.png",
           "demozooUrl": "https://demozoo.org/productions/291120/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/203_FireKracker/203_FireKracker.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/203_FireKracker/203_FireKracker.dsk"
+          ]
         },
         {
           "id": 381132,
@@ -13188,7 +15442,7 @@
           "author": "The Catcher",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/eb/00/9b44.370635.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/5e/c1/998b.370634.png",
           "demozooUrl": "https://demozoo.org/productions/380864/",
           "page": 22
         },
@@ -13202,7 +15456,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/87/f5/7b60.293468.png",
           "demozooUrl": "https://demozoo.org/productions/295556/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/296_Epyx_Volume_1_PS_Graphics/296_Epyx_Volume_1_PS_Graphics.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/296_Epyx_Volume_1_PS_Graphics/296_Epyx_Volume_1_PS_Graphics.dsk"
+          ]
         },
         {
           "id": 292579,
@@ -13214,7 +15472,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/3f/65/52db.288914.png",
           "demozooUrl": "https://demozoo.org/productions/292579/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/219b_Electromania/219b_Electromania.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/219b_Electromania/219b_Electromania.dsk"
+          ]
         },
         {
           "id": 381804,
@@ -13238,7 +15500,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/6e/71/0486.297191.png",
           "demozooUrl": "https://demozoo.org/productions/298777/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/394_Dollars_and_Sense_Side_1/394_Dollars_and_Sense_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/394_Dollars_and_Sense_Side_1/394_Dollars_and_Sense_Side_1.dsk"
+          ]
         },
         {
           "id": 381825,
@@ -13274,7 +15540,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/f5/c0/51c2.287181.png",
           "demozooUrl": "https://demozoo.org/productions/290893/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/197_Digital_Tunesmith/197_Digital_Tunesmith.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/197_Digital_Tunesmith/197_Digital_Tunesmith.dsk"
+          ]
         },
         {
           "id": 157911,
@@ -13284,9 +15554,14 @@
           "author": "Bones",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/2b/bf/9a9b.107946.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/07/ac/58f5.107945.png",
           "demozooUrl": "https://demozoo.org/productions/157911/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "http://www.brutaldeluxe.fr/products/underground/bones/bones_slideshow_4.DSK",
+          "downloadUrls": [
+            "http://www.brutaldeluxe.fr/products/underground/bones/bones_slideshow_4.DSK",
+            "https://archive.scene.org/pub/demos/groups/bones/bones_slideshow_4.zip"
+          ]
         },
         {
           "id": 381681,
@@ -13310,7 +15585,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/5e/63/0079.286983.png",
           "demozooUrl": "https://demozoo.org/productions/290892/",
-          "page": 22
+          "page": 22,
+          "downloadUrl": "https://archive.org/download/196b_DOS_File_Exchange/196b_DOS_File_Exchange.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/196b_DOS_File_Exchange/196b_DOS_File_Exchange.dsk"
+          ]
         }
       ]
     },
@@ -13325,7 +15604,7 @@
           "author": "The Glitch",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/0b/e7/87e2.370685.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/11/d5/c221.370686.png",
           "demozooUrl": "https://demozoo.org/productions/380887/",
           "page": 23
         },
@@ -13361,7 +15640,7 @@
           "author": "The Disk Jockey",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/9c/8f/3b5d.372363.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/b5/5a/41df.372365.png",
           "demozooUrl": "https://demozoo.org/productions/381968/",
           "page": 23
         },
@@ -13387,7 +15666,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/dc/4c/40b2.283726.png",
           "demozooUrl": "https://demozoo.org/productions/288297/",
-          "page": 23
+          "page": 23,
+          "downloadUrl": "https://archive.org/download/010_Clipart_2_For_NewsRoom/010_Clipart_2_For_NewsRoom.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/010_Clipart_2_For_NewsRoom/010_Clipart_2_For_NewsRoom.dsk"
+          ]
         },
         {
           "id": 290767,
@@ -13399,7 +15682,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/d1/4b/9776.286818.png",
           "demozooUrl": "https://demozoo.org/productions/290767/",
-          "page": 23
+          "page": 23,
+          "downloadUrl": "https://archive.org/download/186_Car_Builders/186_Car_Builders.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/186_Car_Builders/186_Car_Builders.dsk"
+          ]
         },
         {
           "id": 288296,
@@ -13411,7 +15698,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/02/21/5a5b.283725.png",
           "demozooUrl": "https://demozoo.org/productions/288296/",
-          "page": 23
+          "page": 23,
+          "downloadUrl": "https://archive.org/download/009a_California_Games_Disk_1/009a_California_Games_Disk_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/009a_California_Games_Disk_1/009a_California_Games_Disk_1.dsk"
+          ]
         },
         {
           "id": 380900,
@@ -13421,7 +15712,7 @@
           "author": "Black Bag",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/5d/f6/d5b7.370719.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/12/69/6aca.370721.png",
           "demozooUrl": "https://demozoo.org/productions/380900/",
           "page": 23
         },
@@ -13435,7 +15726,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/b4/d2/7365.286815.png",
           "demozooUrl": "https://demozoo.org/productions/290765/",
-          "page": 23
+          "page": 23,
+          "downloadUrl": "https://archive.org/download/181_Battle_of_Normandy/181_Battle_of_Normandy.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/181_Battle_of_Normandy/181_Battle_of_Normandy.dsk"
+          ]
         },
         {
           "id": 380885,
@@ -13459,7 +15754,11 @@
           "year": "",
           "screenshotUrl": "https://media.demozoo.org/screens/t/40/7e/9248.286813.png",
           "demozooUrl": "https://demozoo.org/productions/290763/",
-          "page": 23
+          "page": 23,
+          "downloadUrl": "https://archive.org/download/172_Aliens/172_Aliens.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/172_Aliens/172_Aliens.dsk"
+          ]
         },
         {
           "id": 292787,
@@ -13469,9 +15768,13 @@
           "author": "The Dark Prophet",
           "dateStr": "",
           "year": "",
-          "screenshotUrl": "https://media.demozoo.org/screens/t/65/00/0259.371361.png",
+          "screenshotUrl": "https://media.demozoo.org/screens/t/52/88/509d.289562.png",
           "demozooUrl": "https://demozoo.org/productions/292787/",
-          "page": 23
+          "page": 23,
+          "downloadUrl": "https://archive.org/download/241a_Air_Wolf_Side_1/241a_Air_Wolf_Side_1.dsk",
+          "downloadUrls": [
+            "https://archive.org/download/241a_Air_Wolf_Side_1/241a_Air_Wolf_Side_1.dsk"
+          ]
         },
         {
           "id": 382239,

--- a/src/ui/devices/disk/demozoodialog.css
+++ b/src/ui/devices/disk/demozoodialog.css
@@ -27,7 +27,53 @@
   border-bottom: 2px solid #C32E3B;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   flex-shrink: 0;
+}
+
+.dzd-header-left {
+  display: flex;
+  align-items: center;
+}
+
+.dzd-error-banner {
+  background: #c32e3b;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 4px 14px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  animation: dzd-fade-in 0.2s ease-in-out;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  user-select: none;
+  white-space: nowrap;
+}
+
+@keyframes dzd-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.dzd-snapshot-badge {
+  font-size: 0.72rem;
+  color: #ffcccc;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 200, 200, 0.2);
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  user-select: none;
+  white-space: nowrap;
 }
 
 .dzd-logo {

--- a/src/ui/devices/disk/demozoodialog.tsx
+++ b/src/ui/devices/disk/demozoodialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import "./demozoodialog.css"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faStar as faStarOutline } from "@fortawesome/free-regular-svg-icons"
@@ -8,8 +8,7 @@ import { CLOUD_SYNC } from "../../../common/utility"
 import { svgDemoZooLogo, svgDemoZooTitle } from "../../img/icon_demozoo"
 import { DISK_COLLECTION_ITEM_TYPE } from "../../diskdialog/diskpanel_utils"
 import { showGlobalProgressModal } from "../../ui_utilities"
-import { handleSetDiskFromURL } from "./driveprops"
-import { apple2tsProxyPath, hasApple2tsProxy } from "./apple2tsproxy"
+import { fetchWithCorsProxy, getWaybackRawUrl, handleSetDiskFromURL, normalizeDownloadUrl } from "./driveprops"
 import { useTranslation } from "../../../i18n/useTranslation"
 export interface DemoZooItem {
   id: number
@@ -23,12 +22,15 @@ export interface DemoZooItem {
   demozooUrl: string
   page: number
   downloadUrl?: string
+  downloadUrls?: string[]
   downloadLinkClass?: string
+  youtubeUrl?: string
   externalUrl?: string
 }
 
 interface DemoZooSnapshot {
   pageCount: number
+  generatedAt?: string
   pages: Array<{ page: number; items: DemoZooItem[] }>
 }
 
@@ -55,7 +57,7 @@ export const filterDemoZooItems = (items: DemoZooItem[], type: string, query: st
       item.author.toLowerCase().includes(normalizedQuery)))
 }
 
-export const createDemoZooCloudData = (item: DemoZooItem, downloadUrl = item.demozooUrl): CloudData => ({
+export const createDemoZooCloudData = (item: DemoZooItem, downloadUrl = item.downloadUrl || item.demozooUrl): CloudData => ({
   providerName: "DemoZoo",
   syncStatus: CLOUD_SYNC.INACTIVE,
   syncInterval: -1,
@@ -207,9 +209,26 @@ const isDiskDownloadUrl = (url: string) => {
   }
 }
 
+const nonDiskMediaExtensions = [
+  ".mp4", ".webm", ".mkv", ".avi", ".mov", ".flv", ".wmv", ".m4v",
+  ".mp3", ".ogg", ".flac", ".wav", ".aac", ".m4a",
+  ".pdf", ".txt", ".nfo", ".diz", ".doc",
+  ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"
+]
+
+const isNonDiskMediaUrl = (url: string) => {
+  try {
+    const pathname = decodeURIComponent(new URL(url).pathname).toLowerCase()
+    return nonDiskMediaExtensions.some(extension => pathname.endsWith(extension))
+  } catch {
+    return false
+  }
+}
+
 const chooseDemoZooDownloadUrls = (links: RawDemoZooApiProduction["download_links"] = []) => {
   return [...links]
-    .filter(link => Boolean(link.url))
+    .filter(link => Boolean(link.url) && !isNonDiskMediaUrl(link.url))
+    .map(link => ({ ...link, url: normalizeDownloadUrl(link.url) }))
     .sort((left, right) => {
       const leftScore = isDiskDownloadUrl(left.url) ? 100 : /download/i.test(left.link_class || "") ? 10 : 0
       const rightScore = isDiskDownloadUrl(right.url) ? 100 : /download/i.test(right.link_class || "") ? 10 : 0
@@ -233,6 +252,7 @@ const parseDemoZooProductionPage = (html: string, id: number): RawDemoZooApiProd
       continue
     }
 
+    url = normalizeDownloadUrl(url)
     if (isDiskDownloadUrl(url)) {
       links.push({ url, link_class: "disk image" })
     } else if (/youtube\.com|youtu\.be/i.test(url)) {
@@ -248,7 +268,8 @@ const parseDemoZooProductionPage = (html: string, id: number): RawDemoZooApiProd
   }
 }
 
-const resolveExternalDownloadUrls = async (url: string): Promise<string[]> => {
+const resolveExternalDownloadUrls = async (rawUrl: string): Promise<string[]> => {
+  const url = normalizeDownloadUrl(rawUrl)
   try {
     new URL(url)
   } catch {
@@ -257,6 +278,10 @@ const resolveExternalDownloadUrls = async (url: string): Promise<string[]> => {
 
   if (isDiskDownloadUrl(url)) {
     return [url]
+  }
+
+  if (isNonDiskMediaUrl(url)) {
+    return []
   }
 
   const html = await fetchExternalServerText(url)
@@ -274,26 +299,44 @@ const resolveExternalDownloadUrls = async (url: string): Promise<string[]> => {
     }
   }
 
-  if (candidates.length === 0) throw new Error(`No disk image found on external page: ${url}`)
   return candidates
 }
 
 const fetchDemoZooServerText = async (url: string): Promise<string> => {
-  const parsed = new URL(url)
-  const response = await fetch(apple2tsProxyPath(`/api/demozoo-direct${parsed.pathname}${parsed.search}`))
-  if (!response.ok) throw new Error(`DemoZoo server fetch failed: ${response.status}`)
-  return response.text()
+  const corsResponse = await fetchWithCorsProxy(url)
+  if (corsResponse?.ok) return corsResponse.text()
+  try {
+    const response = await fetch(url)
+    if (response.ok) return response.text()
+  } catch {
+    // Fall through
+  }
+  throw new Error(`DemoZoo server fetch failed for ${url}`)
 }
 
 const fetchExternalServerText = async (url: string): Promise<string> => {
-  if (hasApple2tsProxy || /\.pages\.dev$/i.test(window.location.hostname)) {
-    const response = await fetch(apple2tsProxyPath(`/api/disk-direct?url=${encodeURIComponent(url)}`))
-    if (!response.ok) throw new Error(`External server fetch failed: ${response.status}`)
-    return response.text()
+  const corsResponse = await fetchWithCorsProxy(url)
+  if (corsResponse?.ok) {
+    return corsResponse.text()
   }
-  const response = await fetch(url)
-  if (!response.ok) throw new Error(`External server fetch failed: ${response.status}`)
-  return response.text()
+  try {
+    const response = await fetch(url)
+    if (response.ok) return response.text()
+  } catch {
+    // Fall through
+  }
+  const waybackUrl = getWaybackRawUrl(url)
+  if (waybackUrl) {
+    const wbCors = await fetchWithCorsProxy(waybackUrl)
+    if (wbCors?.ok) return wbCors.text()
+    try {
+      const wbRes = await fetch(waybackUrl)
+      if (wbRes.ok) return wbRes.text()
+    } catch {
+      // Fall through
+    }
+  }
+  throw new Error(`External server fetch failed: ${url}`)
 }
 
 const fetchDemoZooProduction = async (id: number): Promise<RawDemoZooApiProduction> => {
@@ -327,10 +370,17 @@ const fetchDemoZooProduction = async (id: number): Promise<RawDemoZooApiProducti
 }
 
 export const loadDemoZooResult = async (item: DemoZooItem, driveIndex: number): Promise<boolean> => {
-  let downloadUrls = item.downloadUrl ? [item.downloadUrl] : []
+  let downloadUrls = item.downloadUrls?.length
+    ? item.downloadUrls.map(normalizeDownloadUrl)
+    : (item.downloadUrl ? [normalizeDownloadUrl(item.downloadUrl)] : [])
+
   if (downloadUrls.length === 0) {
-    const detail = await fetchDemoZooProduction(item.id)
-    downloadUrls = chooseDemoZooDownloadUrls(detail.download_links)
+    try {
+      const detail = await fetchDemoZooProduction(item.id)
+      downloadUrls = chooseDemoZooDownloadUrls(detail.download_links)
+    } catch (e) {
+      console.warn("Fallback production detail fetch failed:", e)
+    }
   }
 
   const resolvedDownloadUrls: string[] = []
@@ -409,6 +459,20 @@ export interface DemoZooDialogProps {
   onLoadSuccess?: () => void
 }
 
+const formatSnapshotDate = (isoStr?: string): string => {
+  if (!isoStr) return ""
+  try {
+    const d = new Date(isoStr)
+    if (isNaN(d.getTime())) return ""
+    const y = d.getUTCFullYear()
+    const m = String(d.getUTCMonth() + 1).padStart(2, "0")
+    const day = String(d.getUTCDate()).padStart(2, "0")
+    return `${y}/${m}/${day}`
+  } catch {
+    return ""
+  }
+}
+
 const DemoZooDialog = (props: DemoZooDialogProps) => {
   const { t } = useTranslation()
   const [savedDialogState] = useState(readDemoZooDialogState)
@@ -426,6 +490,28 @@ const DemoZooDialog = (props: DemoZooDialogProps) => {
   const ITEMS_PER_PAGE = 50
   const [liveItems, setLiveItems] = useState<DemoZooItem[]>([])
   const [snapshotPageCount, setSnapshotPageCount] = useState<number>(1)
+  const [snapshotDate, setSnapshotDate] = useState<string>("")
+  const [downloadError, setDownloadError] = useState<string | null>(null)
+  const downloadErrorTimerRef = useRef<number | null>(null)
+
+  const showDownloadError = (msg = "Unable to Download!") => {
+    if (downloadErrorTimerRef.current !== null) {
+      window.clearTimeout(downloadErrorTimerRef.current)
+    }
+    setDownloadError(msg)
+    downloadErrorTimerRef.current = window.setTimeout(() => {
+      setDownloadError(null)
+      downloadErrorTimerRef.current = null
+    }, 2000)
+  }
+
+  useEffect(() => {
+    return () => {
+      if (downloadErrorTimerRef.current !== null) {
+        window.clearTimeout(downloadErrorTimerRef.current)
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (!props.open) return
@@ -441,6 +527,7 @@ const DemoZooDialog = (props: DemoZooDialogProps) => {
         // optional and must never turn a usable list into an empty dialog.
         setLiveItems(snapshotItems)
         setSnapshotPageCount(pages.length || 1)
+        setSnapshotDate(formatSnapshotDate(snapshot.generatedAt))
         if (snapshot.pageCount < 1) {
           try {
             const freshPages: Array<{ page: number; items: DemoZooItem[] }> = []
@@ -530,10 +617,12 @@ const DemoZooDialog = (props: DemoZooDialogProps) => {
   const handleTileClick = async (item: DemoZooItem) => {
     showGlobalProgressModal(true, t("disk.downloadingDisk"))
     try {
-      let downloadUrl = item.downloadUrl || ""
-      let downloadUrls = downloadUrl ? [downloadUrl] : []
-      let externalUrl = item.externalUrl || ""
-      if (!downloadUrl && !externalUrl) {
+      let downloadUrls = (item.downloadUrls && item.downloadUrls.length > 0)
+        ? item.downloadUrls.map(normalizeDownloadUrl)
+        : (item.downloadUrl ? [normalizeDownloadUrl(item.downloadUrl)] : [])
+      let downloadUrl = downloadUrls[0] || ""
+      let externalUrl = item.externalUrl || item.youtubeUrl || ""
+      if (downloadUrls.length === 0 && !externalUrl) {
         const detail = await fetchDemoZooProduction(item.id)
         downloadUrls = chooseDemoZooDownloadUrls(detail.download_links)
         downloadUrl = downloadUrls[0] || ""
@@ -595,16 +684,23 @@ const DemoZooDialog = (props: DemoZooDialogProps) => {
           props.onLoadSuccess?.()
         } else {
           console.error(`DemoZoo disk could not be loaded: ${downloadUrl}`)
+          showDownloadError("Unable to Download!")
         }
       } else {
-        setYoutubeModalInfo({
-          open: true,
-          title: item.title,
-          url: item.demozooUrl
-        })
+        if (item.demozooUrl) {
+          setYoutubeModalInfo({
+            open: true,
+            title: item.title,
+            url: item.demozooUrl
+          })
+        } else {
+          showDownloadError("Unable to Download!")
+        }
       }
     } catch (err) {
       console.error("Failed to load DemoZoo disk:", err)
+      showDownloadError("Unable to Download!")
+    } finally {
       showGlobalProgressModal(false)
     }
   }
@@ -634,8 +730,20 @@ const DemoZooDialog = (props: DemoZooDialogProps) => {
     <div className="modal-overlay" onClick={handleClose}>
       <div className="demozoo-dialog" onClick={e => e.stopPropagation()}>
         <div className="dzd-header">
-          {svgDemoZooLogo}
-          {svgDemoZooTitle}
+          <div className="dzd-header-left">
+            {svgDemoZooLogo}
+            {svgDemoZooTitle}
+          </div>
+          {downloadError && (
+            <div className="dzd-error-banner">
+              ⚠️ {downloadError}
+            </div>
+          )}
+          {snapshotDate && (
+            <div className="dzd-snapshot-badge" title={`DemoZoo snapshot created: ${snapshotDate}`}>
+              Snapshot at {snapshotDate}
+            </div>
+          )}
         </div>
         <div className="dzd-search">
           <div className="dzd-type-filters">

--- a/src/ui/devices/disk/diskdrive.tsx
+++ b/src/ui/devices/disk/diskdrive.tsx
@@ -20,9 +20,7 @@ import { DISK_COLLECTION_ITEM_TYPE } from "../../diskdialog/diskpanel_utils"
 import InternetArchivePopup from "./internetarchivedialog"
 import DemoZooDialog from "./demozoodialog"
 
-export const demoZooEnabled = import.meta.env.DEV ||
-  import.meta.env.VITE_DEMOZOO_ENABLED === "true" ||
-  (typeof window !== "undefined" && /\.pages\.dev$/i.test(window.location.hostname))
+export const demoZooEnabled = true
 import { DiskBookmarks } from "./diskbookmarks"
 import { determineVtocType, VTOC_REFRESH } from "../../../common/prodos_hdv"
 import { isFileSystemApiSupported } from "../../ui_utilities"

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -13,7 +13,6 @@ import {
 import { passSetDriveNewData, requestSetDriveNewData, passSetDriveProps, passSetBinaryBlock, passPasteText, handleGetRunMode, passSetRunMode, handleGetProdosFloppy } from "../../main2worker"
 import { showGlobalProgressModal } from "../../ui_utilities"
 import { internetArchiveUrlProtocol, getDiskImageUrlFromIdentifier } from "./internetarchive_utils"
-import { apple2tsProxyPath, hasApple2tsProxy } from "./apple2tsproxy"
 import { newReleases } from "./newreleases"
 import { DiskBookmarks } from "./diskbookmarks"
 import { parseGameList } from "./totalreplayutilities"
@@ -66,9 +65,45 @@ const isDemoZooDiskDownload = (url: string) => {
   }
 }
 
+export const normalizeDownloadUrl = (url: string): string => {
+  if (!url) return url
+  let trimmed = url.trim()
+  const sceneOrgMatch = trimmed.match(/^https?:\/\/files\.scene\.org\/(?:view|get)\/(.+)$/i)
+  if (sceneOrgMatch) {
+    trimmed = `https://archive.scene.org/pub/${sceneOrgMatch[1]}`
+  }
+  if (trimmed.includes("marqueeedesign_")) {
+    trimmed = trimmed.replace("marqueeedesign_", "marqueedesign_")
+  }
+  const brutalLocsMatch = trimmed.match(/^https?:\/\/(?:www\.)?brutaldeluxe\.fr\/products\/french\/locs\/(.+)$/i)
+  if (brutalLocsMatch) {
+    trimmed = `https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/${brutalLocsMatch[1]}`
+  }
+  return trimmed
+}
+
+export const getArchiveOrgCorsUrl = (url: string): string => {
+  if (!url) return ""
+  const trimmed = url.trim()
+  const match = trimmed.match(/^https?:\/\/archive\.org\/download\/(.+)$/i)
+  if (match) {
+    return `https://archive.org/cors/${match[1]}`
+  }
+  return ""
+}
+
+export const getWaybackRawUrl = (url: string): string => {
+  if (!url) return ""
+  const trimmed = url.trim()
+  if (!/^https?:/i.test(trimmed)) return ""
+  if (/web\.archive\.org|archive\.org/i.test(trimmed)) return ""
+  return `https://web.archive.org/web/0id_/${trimmed}`
+}
+
 const chooseDemoZooDownloads = (links: Array<{ url: string; link_class?: string }>) => {
   return [...links]
     .filter(link => Boolean(link.url))
+    .map(link => ({ ...link, url: normalizeDownloadUrl(link.url) }))
     .sort((left, right) => {
       const leftScore = isDemoZooDiskDownload(left.url) ? 100 : /download/i.test(left.link_class || "") ? 10 : 0
       const rightScore = isDemoZooDiskDownload(right.url) ? 100 : /download/i.test(right.link_class || "") ? 10 : 0
@@ -544,6 +579,7 @@ const logFetchDebug = (...args: unknown[]) => {
 const shouldAttemptDirectFetch = (url: string): boolean => {
   try {
     const parsed = new URL(url)
+    if (parsed.hostname === "github.com") return false
     return parsed.protocol === "http:" || parsed.protocol === "https:"
   } catch {
     // If URL parsing fails, keep prior behavior and try direct fetch.
@@ -556,7 +592,8 @@ const shouldUseCloudflareDiskProxy = (url: string): boolean => {
     const target = new URL(url)
     return /^https?:$/i.test(target.protocol) &&
       target.origin !== window.location.origin &&
-      (hasApple2tsProxy || /\.pages\.dev$/i.test(window.location.hostname))
+      typeof window !== "undefined" &&
+      /\.pages\.dev$/i.test(window.location.hostname)
   } catch {
     return false
   }
@@ -564,14 +601,14 @@ const shouldUseCloudflareDiskProxy = (url: string): boolean => {
 
 const fetchWithCloudflareDiskProxy = async (url: string): Promise<Response | null> => {
   try {
-    const response = await fetch(apple2tsProxyPath(`/api/disk-direct?url=${encodeURIComponent(url)}`))
+    const response = await fetch(`/api/disk-direct?url=${encodeURIComponent(url)}`)
     return response.ok ? response : null
   } catch {
     return null
   }
 }
 
-const fetchWithCorsProxy = async (url: string, debug?: (message: string) => void) => {
+export const fetchWithCorsProxy = async (url: string, debug?: (message: string) => void) => {
   let lastResponse: Response | null = null
   const domain = getProxyTargetDomain(url)
   const candidates = sortProxyCandidatesForDomain(domain, getCorsProxyCandidates(url))
@@ -604,27 +641,10 @@ const fetchWithCorsProxy = async (url: string, debug?: (message: string) => void
 }
 
 const fetchDemoZooResource = async (url: string): Promise<Response | null> => {
-  try {
-    const parsed = new URL(url)
-    if ((import.meta.env.DEV || hasApple2tsProxy || /\.pages\.dev$/i.test(window.location.hostname)) && parsed.hostname === "demozoo.org") {
-      return await fetch(apple2tsProxyPath(`/api/demozoo-direct${parsed.pathname}${parsed.search}`))
-    }
-  } catch {
-    return null
-  }
-
   return fetchWithCorsProxy(url)
 }
 
 const fetchExternalDownloadPage = async (url: string): Promise<Response | null> => {
-  if (hasApple2tsProxy || /\.pages\.dev$/i.test(window.location.hostname)) {
-    try {
-      return await fetch(apple2tsProxyPath(`/api/disk-direct?url=${encodeURIComponent(url)}`))
-    } catch {
-      return null
-    }
-  }
-
   return fetchWithCorsProxy(url)
 }
 
@@ -781,10 +801,8 @@ const setDiskFromURL = async (url: string,
     }
   }
 
-  // Transform scene.org view URL to direct download URL
-  if (url.includes("files.scene.org/view/")) {
-    url = url.replace("files.scene.org/view/", "files.scene.org/get/")
-  }
+  // Normalize external URLs such as scene.org to direct archive downloads
+  url = normalizeDownloadUrl(url)
 
   // Resolve DemoZoo production web page URL to direct download link if needed
   let alternateDownloadUrls: string[] = []
@@ -800,9 +818,7 @@ const setDiskFromURL = async (url: string,
             const resolvedUrls: string[] = []
             for (const downloadUrl of chooseDemoZooDownloads(prodData.download_links)) {
               const resolvedUrl = await findDirectDownloadOnExternalPage(downloadUrl) || downloadUrl
-              const normalizedUrl = resolvedUrl.includes("files.scene.org/view/")
-                ? resolvedUrl.replace("files.scene.org/view/", "files.scene.org/get/")
-                : resolvedUrl
+              const normalizedUrl = normalizeDownloadUrl(resolvedUrl)
               if (!resolvedUrls.includes(normalizedUrl)) {
                 resolvedUrls.push(normalizedUrl)
               }
@@ -835,14 +851,26 @@ const setDiskFromURL = async (url: string,
   // hosts). The disk VTOC check that drives these downloads is serialized one
   // request at a time, so this does not flood Internet Archive with parallel
   // requests (the cause of the earlier 429 throttling).
-  const downloadUrlsToTry = [url, ...alternateDownloadUrls.filter(candidate => candidate !== url)]
+  const initialUrls = [url, ...alternateDownloadUrls.filter(candidate => candidate !== url)]
+  const downloadUrlsToTry: string[] = []
+  for (const candidate of initialUrls) {
+    if (!downloadUrlsToTry.includes(candidate)) {
+      downloadUrlsToTry.push(candidate)
+    }
+    const iaCors = getArchiveOrgCorsUrl(candidate)
+    if (iaCors && !downloadUrlsToTry.includes(iaCors)) {
+      downloadUrlsToTry.push(iaCors)
+    }
+    const wayback = getWaybackRawUrl(candidate)
+    if (wayback && !downloadUrlsToTry.includes(wayback)) {
+      downloadUrlsToTry.push(wayback)
+    }
+  }
   for (const candidateUrl of downloadUrlsToTry) {
     url = candidateUrl
     response = null
 
-    if (shouldUseCloudflareDiskProxy(url)) {
-      response = await fetchWithCloudflareDiskProxy(url)
-    } else if (shouldAttemptDirectFetch(url)) {
+    if (shouldAttemptDirectFetch(url)) {
       try {
         response = await fetch(url)
         if (!response.ok) {
@@ -857,6 +885,10 @@ const setDiskFromURL = async (url: string,
     if (!response || !response.ok) {
       logFetchDebug("Direct fetch failed, trying corsfix proxy")
       response = await fetchWithCorsProxy(url, debug)
+    }
+
+    if ((!response || !response.ok) && shouldUseCloudflareDiskProxy(url)) {
+      response = await fetchWithCloudflareDiskProxy(url)
     }
 
     if (response?.ok) break

--- a/src/ui/devices/disk/internetarchive.ts
+++ b/src/ui/devices/disk/internetarchive.ts
@@ -1,5 +1,5 @@
 import { CLOUD_SYNC } from "../../../common/utility"
-import { apple2tsProxyPath, hasApple2tsProxy } from "./apple2tsproxy"
+import { hasApple2tsProxy } from "./apple2tsproxy"
 import { handleSetDiskFromURL } from "./driveprops"
 import { generateUrlFromInternetArchiveId } from "./internetarchive_utils"
 
@@ -76,8 +76,8 @@ export const searchInternetArchive = async (
   page = 1,
 ): Promise<InternetArchiveSearchPage> => {
   const queryUrl = buildInternetArchiveQueryUrl(query, collectionId, page)
-  const requestUrl = (hasApple2tsProxy || /\.pages\.dev$/i.test(window.location.hostname))
-    ? apple2tsProxyPath(`/api/disk-direct?url=${encodeURIComponent(queryUrl)}`)
+  const requestUrl = (typeof window !== "undefined" && /\.pages\.dev$/i.test(window.location.hostname) && !hasApple2tsProxy)
+    ? `/api/disk-direct?url=${encodeURIComponent(queryUrl)}`
     : queryUrl
   const response = await fetch(requestUrl)
   if (!response.ok) throw new Error(`Internet Archive search failed: ${response.status}`)

--- a/src/ui/devices/disk/internetarchive_utils.ts
+++ b/src/ui/devices/disk/internetarchive_utils.ts
@@ -1,5 +1,5 @@
 import { iconKey, iconData, iconName } from "../../img/iconfunctions"
-import { apple2tsProxyPath, hasApple2tsProxy } from "./apple2tsproxy"
+import { hasApple2tsProxy } from "./apple2tsproxy"
 
 export const internetArchiveUrlProtocol = "a2ia://"
 
@@ -97,9 +97,9 @@ const IA_CACHE_TTL_MS = 30 * 60 * 1000
 const IA_NEGATIVE_CACHE_TTL_MS = 2 * 60 * 1000
 
 const fetchCloudflareProxy = async (url: string): Promise<Response | null> => {
-  if (!hasApple2tsProxy && !/\.pages\.dev$/i.test(window.location.hostname)) return null
+  if (typeof window === "undefined" || !/\.pages\.dev$/i.test(window.location.hostname) || hasApple2tsProxy) return null
   try {
-    const response = await fetch(apple2tsProxyPath(`/api/disk-direct?url=${encodeURIComponent(url)}`))
+    const response = await fetch(`/api/disk-direct?url=${encodeURIComponent(url)}`)
     return response.ok ? response : null
   } catch {
     return null

--- a/tools/fetch-demozoo.mjs
+++ b/tools/fetch-demozoo.mjs
@@ -155,6 +155,62 @@ async function main() {
     return
   }
 
+  const diskExts = [".hdv", ".2mg", ".dsk", ".woz", ".po", ".do", ".bin", ".bas", ".nib", ".2img", ".d13", ".dc", ".img", ".zip", ".7z", ".gz", ".tar"]
+  const isDisk = url => {
+    try {
+      const path = decodeURIComponent(new URL(url).pathname).toLowerCase()
+      return diskExts.some(ext => path.endsWith(ext))
+    } catch {
+      return false
+    }
+  }
+
+  const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+  const normalizeUrl = raw => {
+    if (!raw) return ""
+    let trimmed = raw.trim()
+    const match = trimmed.match(/^https?:\/\/files\.scene\.org\/(?:view|get)\/(.+)$/i)
+    if (match) trimmed = `https://archive.scene.org/pub/${match[1]}`
+    if (trimmed.includes("marqueeedesign_")) {
+      trimmed = trimmed.replace("marqueeedesign_", "marqueedesign_")
+    }
+    const brutalLocsMatch = trimmed.match(/^https?:\/\/(?:www\.)?brutaldeluxe\.fr\/products\/french\/locs\/(.+)$/i)
+    if (brutalLocsMatch) {
+      trimmed = `https://web.archive.org/web/0id_/http://www.brutaldeluxe.fr/products/french/locs/${brutalLocsMatch[1]}`
+    }
+    return trimmed
+  }
+
+  const fetchDetailWithRetry = async id => {
+    const url = `https://demozoo.org/api/v1/productions/${id}/?format=json`
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        const { stdout } = await execFile("curl.exe", ["-L", "--fail", "--max-time", "15", "-sS", url])
+        if (/just a moment|enable javascript and cookies|cf-chl-/i.test(stdout)) {
+          console.warn(`CF challenge on item ${id}, waiting 3s (attempt ${attempt})`)
+          await sleep(3000)
+          continue
+        }
+        const detail = JSON.parse(stdout)
+        const links = (detail.download_links || [])
+          .filter(link => Boolean(link.url))
+          .map(link => ({ ...link, url: normalizeUrl(link.url) }))
+          .sort((a, b) => {
+            const sa = isDisk(a.url) ? 100 : (/download/i.test(a.link_class || "") ? 10 : 0)
+            const sb = isDisk(b.url) ? 100 : (/download/i.test(b.link_class || "") ? 10 : 0)
+            return sb - sa
+          })
+          .map(link => link.url)
+        const yt = (detail.external_links || []).find(link => /youtube/i.test(link.link_class || "") || /youtube\.com|youtu\.be/i.test(link.url || ""))?.url || ""
+        return { downloadUrls: links, downloadUrl: links[0] || "", youtubeUrl: yt }
+      } catch {
+        if (attempt < 3) await sleep(2000)
+      }
+    }
+    return { downloadUrls: [], downloadUrl: "", youtubeUrl: "" }
+  }
+
   const pages = []
   for (let page = 1; page <= 1000; page++) {
     try {
@@ -176,6 +232,31 @@ async function main() {
       throw error
     }
   }
+
+  const allItems = pages.flatMap(p => p.items)
+  console.log(`Pre-fetching download links for ${allItems.length} productions...`)
+  let linksCount = 0
+  for (let i = 0; i < allItems.length; i++) {
+    const item = allItems[i]
+    if (item.downloadUrls?.length) {
+      linksCount++
+      continue
+    }
+    const res = await fetchDetailWithRetry(item.id)
+    if (res.downloadUrl) {
+      item.downloadUrl = res.downloadUrl
+      item.downloadUrls = res.downloadUrls
+      linksCount++
+    }
+    if (res.youtubeUrl) {
+      item.youtubeUrl = res.youtubeUrl
+    }
+    if ((i + 1) % 50 === 0 || i + 1 === allItems.length) {
+      console.log(`Pre-fetch progress: ${i + 1}/${allItems.length} (${linksCount} with links)`)
+    }
+    await sleep(150)
+  }
+  console.log(`Pre-fetched download links: ${linksCount}/${allItems.length}`)
 
   await mkdir(dirname(OUTPUT), { recursive: true })
   await writeFile(OUTPUT, JSON.stringify({


### PR DESCRIPTION
> [!TIP]
> @ct6502 You no longer need to maintain or deploy the [apple2ts-proxy](https://github.com/ct6502/apple2ts-proxy) repository — it can be safely archived or removed!

## Summary

Knowing everyone has been busy lately, I took some time to rethink the DemoZoo integration architecture. Instead of relying on a dedicated Cloudflare Worker / backend proxy (`apple2ts-proxy`), this PR makes DemoZoo **100% self-contained and static** using a few handy techniques.

<img width="1408" height="768" alt="image" src="https://github.com/user-attachments/assets/53e74f6e-5d4e-437a-bb0c-6d520491f4f0" />

With this approach, DemoZoo works out of the box on **GitHub Pages, Cloudflare Pages, and local dev** with **zero backend setup or proxy server configuration required**.

---

## Key Highlights & Techniques Used

### 1. Pre-fetched Catalog Snapshot
- Added a pre-generated static catalog snapshot at `public/data/demozoo_snapshot.json` with pre-resolved direct download links.
- Instant browsing and searching in both the Web UI and Retro Mode terminal menu with no API rate-limiting or CORS blocks.
- Added a `Snapshot at YYYY/MM/DD` badge in the DemoZoo dialog header so users know the snapshot version.
- Added non-interactive build-safe prefetch tooling (`tools/fetch-demozoo.mjs`).

<img width="1022" height="910" alt="image" src="https://github.com/user-attachments/assets/1d4ddbe5-a172-4579-a221-690b6b6e29fa" />
**NOW DEMOZOO CATALOG PAGE CAN BE VIEWED ON GITHUB PAGES**

### 2. Multi-Tiered Direct Download Pipeline
When downloading productions, Apple2TS now tries a resilient fallback chain:
1. **Direct Fetch**: Immediate browser download for hosts with open CORS.
2. **Dedicated Internet Archive `/cors/` API**: Automatically converts `archive.org/download/...` to `archive.org/cors/...` to guarantee permissive CORS headers across all global CDN storage nodes (preventing 302 redirect CORS drops on some overseas nodes).
3. **Generic Wayback Machine Fallback**: If an external hosting website is offline or links are broken (such as older Brutal Deluxe LOCS disk links), it automatically requests the raw binary stream from the Internet Archive Wayback Machine (`https://web.archive.org/web/0id_/<url>`).
4. **CORS Proxy Fallback**: Fallback to `corsfix` if direct requests encounter origin restrictions.

<img width="770" height="966" alt="image" src="https://github.com/user-attachments/assets/0250a40b-a32b-4d4d-9973-0eeaee1e4dc0" />
**THIS PICTURE SHOWS THE "TEST LAB 2" DUAL MOCKINGBOARD DEMO WITH 12-CHANNEL MUSIC**

### 3. Polish & Edge Cases
- **Multi-link Resolution**: Iterates through candidate download mirrors and resolves external scrape pages.
- **Media Filtering**: Automatically ignores non-disk media files (e.g. `.mp4` video showcase files) in favour of playable disk images (`.dsk`, `.woz`, `.po`, `.zip`, etc.).
- **User Feedback**: Displays an `⚠️ Unable to Download!` badge in the dialog header for 2 seconds when all download mirrors fail, then cleanly returns to catalog browsing.
- **Documentation**: Updated `README.md` and `CHANGELOG.md` to reflect the self-contained static workflow.

---

## Verification & Testing

- Tested on static GitHub Pages deployment with zero console errors or `ERR_NAME_NOT_RESOLVED` calls.
- Verified productions across different hosts:
  - Archive.org direct & redirected cracktros (e.g., *Sound Wizard*)
  - Legacy/offline websites via Wayback fallback (e.g., *Langue d'Ocs 1/2/3*)
  - Scene.org direct downloads & typo corrections (e.g., *The Matr][x*, *Seasons Greetings Dec 2023*)
  - GitHub releases (e.g., *Bad Apple*)
- Verified in both Web dialog and Retro Text Menu (`demozoo_retro`).
- All 70 test suites (834 unit tests) passing:
  ```bash
  npm test
  # Test Suites: 70 passed, 70 total
  # Tests:       834 passed, 834 total
