### PR TITLE
feat(remote-control): add bounded memory search

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -65,6 +65,17 @@ type MemoryView = {
   bytes: Uint8Array,
 }
 
+type MemorySearchRequest = MemoryViewRequest & {
+  bytes: number[],
+  maxMatches?: number,
+}
+
+type MemorySearchResult = Omit<MemoryView, "bytes"> & {
+  matches: number[],
+  totalMatchCount: number,
+  truncated: boolean,
+}
+
 type KeyboardState = {
   key: number,
   isDown: boolean,

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -102,6 +102,7 @@ export enum MSG_MAIN {
   LOAD_BINARY,
   GET_MEMORY_VIEW,
   WRITE_MEMORY,
+  FIND_MEMORY,
 }
 
 export const DEFAULT_SLOT_CONFIG: SlotConfig = {

--- a/src/ui/api/remotecontrol.ts
+++ b/src/ui/api/remotecontrol.ts
@@ -69,7 +69,7 @@ import {
 } from "../devices/disk/driveprops"
 import { parseRemoteKeyboardState } from "./remotecontrol_input"
 import { captureRenderedScreen } from "./remotecontrol_screen"
-import { readRemoteMemory } from "./remotecontrol_memory"
+import { findRemoteMemory, readRemoteMemory } from "./remotecontrol_memory"
 
 const CONNECT_RETRY_MS = 3000
 const HEARTBEAT_MS = 2000
@@ -419,6 +419,10 @@ export const executeCommand = async (action: string, payload: Record<string, unk
 
     case "getMemoryView": {
       return readRemoteMemory(payload)
+    }
+
+    case "findMemory": {
+      return findRemoteMemory(payload)
     }
 
     case "captureScreen":

--- a/src/ui/api/remotecontrol_memory.test.ts
+++ b/src/ui/api/remotecontrol_memory.test.ts
@@ -1,8 +1,9 @@
-import { requestMemoryView } from "../main2worker"
-import { readRemoteMemory } from "./remotecontrol_memory"
+import { requestMemorySearch, requestMemoryView } from "../main2worker"
+import { findRemoteMemory, readRemoteMemory } from "./remotecontrol_memory"
 
-jest.mock("../main2worker", () => ({requestMemoryView: jest.fn()}))
+jest.mock("../main2worker", () => ({requestMemorySearch: jest.fn(), requestMemoryView: jest.fn()}))
 
+const mockRequestMemorySearch = jest.mocked(requestMemorySearch)
 const mockRequestMemoryView = jest.mocked(requestMemoryView)
 
 test("returns the complete worker-owned memory view", async () => {
@@ -46,5 +47,51 @@ test("returns the complete worker-owned memory view", async () => {
     length: 2,
     space: "aux",
     auxBank: undefined,
+  })
+})
+
+test("returns the worker-owned memory search result", async () => {
+  const result = {
+    address: 0x2000,
+    length: 16,
+    requestedSpace: "main" as const,
+    requestedAuxBank: null,
+    effectiveAuxBank: null,
+    effectiveSegments: [{address: 0x2000, length: 16, space: "main" as const}],
+    mapping: {RAMRD: false, RAMWRT: false, ALTZP: false, "80STORE": false, PAGE2: false, HIRES: false},
+    matches: [0x2004],
+    totalMatchCount: 1,
+    truncated: false,
+  }
+  mockRequestMemorySearch.mockResolvedValue(result)
+
+  await expect(findRemoteMemory({
+    address: 0x2000,
+    length: 16,
+    space: "main",
+    bytes: [0xAA],
+    maxMatches: 8,
+  })).resolves.toEqual(result)
+  expect(mockRequestMemorySearch).toHaveBeenCalledWith({
+    address: 0x2000,
+    length: 16,
+    space: "main",
+    auxBank: undefined,
+    bytes: [0xAA],
+    maxMatches: 8,
+  })
+})
+
+test("preserves the worker default when maximum matches is omitted", async () => {
+  mockRequestMemorySearch.mockResolvedValue({} as MemorySearchResult)
+
+  await findRemoteMemory({address: 0, length: 1, space: "active", bytes: [0]})
+  expect(mockRequestMemorySearch).toHaveBeenCalledWith({
+    address: 0,
+    length: 1,
+    space: "active",
+    auxBank: undefined,
+    bytes: [0],
+    maxMatches: undefined,
   })
 })

--- a/src/ui/api/remotecontrol_memory.ts
+++ b/src/ui/api/remotecontrol_memory.ts
@@ -1,4 +1,4 @@
-import { requestMemoryView } from "../main2worker"
+import { requestMemorySearch, requestMemoryView } from "../main2worker"
 
 export const readRemoteMemory = async (payload: Record<string, unknown>) => {
   const request = {
@@ -10,3 +10,12 @@ export const readRemoteMemory = async (payload: Record<string, unknown>) => {
   const view = await requestMemoryView(request)
   return {...view, bytes: Array.from(view.bytes)}
 }
+
+export const findRemoteMemory = (payload: Record<string, unknown>) => requestMemorySearch({
+  address: Number(payload.address),
+  length: Number(payload.length),
+  space: payload.space as MemorySpace,
+  auxBank: payload.auxBank === undefined ? undefined : Number(payload.auxBank),
+  bytes: payload.bytes as number[],
+  maxMatches: payload.maxMatches === undefined ? undefined : Number(payload.maxMatches),
+})

--- a/src/ui/main2worker.test.ts
+++ b/src/ui/main2worker.test.ts
@@ -7,6 +7,7 @@ import {
   requestSetState6502,
   requestSetRunMode,
   requestSpeedMode,
+  requestMemorySearch,
   requestMemoryView,
   setExecutionStateCallback,
   requestWriteMemory,
@@ -126,6 +127,28 @@ describe("worker operations", () => {
       msg: MSG_MAIN.GET_MEMORY_VIEW,
       payload: {address: 0x03A4, length: 1, space: "aux"},
     }))
+    sendOperationResult(message.operationId, undefined, value)
+    await expect(operation).resolves.toEqual(value)
+  })
+
+  test("returns a worker-owned memory search result", async () => {
+    const request = {address: 0x2000, length: 16, space: "main" as const, bytes: [0xAA]}
+    const operation = requestMemorySearch(request)
+    const message = worker.postMessage.mock.calls.at(-1)[0]
+    const value = {
+      address: 0x2000,
+      length: 16,
+      requestedSpace: "main",
+      requestedAuxBank: null,
+      effectiveAuxBank: null,
+      effectiveSegments: [{address: 0x2000, length: 16, space: "main"}],
+      mapping: {RAMRD: false, RAMWRT: false, ALTZP: false, "80STORE": false, PAGE2: false, HIRES: false},
+      matches: [0x2004],
+      totalMatchCount: 1,
+      truncated: false,
+    } as MemorySearchResult
+
+    expect(message).toEqual(expect.objectContaining({msg: MSG_MAIN.FIND_MEMORY, payload: request}))
     sendOperationResult(message.operationId, undefined, value)
     await expect(operation).resolves.toEqual(value)
   })

--- a/src/ui/main2worker.ts
+++ b/src/ui/main2worker.ts
@@ -378,6 +378,11 @@ export const requestMemoryView = (
   timeoutMs = 5000,
 ) => requestWorkerOperation<MemoryView>(MSG_MAIN.GET_MEMORY_VIEW, request, timeoutMs)
 
+export const requestMemorySearch = (
+  request: MemorySearchRequest,
+  timeoutMs = 5000,
+) => requestWorkerOperation<MemorySearchResult>(MSG_MAIN.FIND_MEMORY, request, timeoutMs)
+
 // This is a cached memory dump, updated whenever the main requests a new one.
 // Currently only used by the AI Agent, since it may want to look at memory
 // even when the emulator is not paused.

--- a/src/worker/memory.test.ts
+++ b/src/worker/memory.test.ts
@@ -19,7 +19,7 @@ import { setIsTesting } from "./worker2main"
 import { getApple2State, setApple2State } from "./save_restore"
 import { SWITCHES } from "./softswitches"
 import { setKeyboardState } from "./devices/keyboard"
-import { getMemoryView } from "./memory_view"
+import { findMemory, getMemoryView } from "./memory_view"
 
 type ExpectValue = (i: number) => void
 
@@ -536,6 +536,98 @@ describe("side-effect-free memory views", () => {
       SWITCHES.BSRREADRAM.isSet = previous.BSRREADRAM
       updateAddressTables()
     }
+  })
+})
+
+describe("side-effect-free memory search", () => {
+  beforeEach(() => {
+    setAuxCardEnabled(true)
+    setRamWorks(128)
+    memoryReset()
+  })
+
+  afterEach(() => {
+    setAuxCardEnabled(true)
+    setRamWorks(64)
+    memoryReset()
+  })
+
+  test("finds overlapping matches in ascending order and truncates deterministically", () => {
+    memory.set([0xAA, 0xAA, 0xAA, 0x00, 0xAA, 0xAA], 0x2000)
+
+    expect(findMemory({
+      address: 0x2000,
+      length: 6,
+      space: "main",
+      bytes: [0xAA, 0xAA],
+      maxMatches: 2,
+    })).toMatchObject({
+      matches: [0x2000, 0x2001],
+      totalMatchCount: 3,
+      truncated: true,
+      effectiveSegments: [{address: 0x2000, length: 6, space: "main"}],
+    })
+  })
+
+  test("reuses active mapping and selected auxiliary-bank semantics", () => {
+    SWITCHES.STORE80.isSet = true
+    SWITCHES.PAGE2.isSet = true
+    updateAddressTables()
+    memory[0x03FF] = 0x12
+    memory[RamWorksMemoryStart + 0x0400] = 0x34
+
+    expect(findMemory({
+      address: 0x03FF,
+      length: 2,
+      space: "active",
+      bytes: [0x12, 0x34],
+    })).toMatchObject({
+      matches: [0x03FF],
+      totalMatchCount: 1,
+      truncated: false,
+      effectiveSegments: [
+        {address: 0x03FF, length: 1, space: "main"},
+        {address: 0x0400, length: 1, space: "aux", auxBank: 0},
+      ],
+    })
+
+    memory[RamWorksMemoryStart + 0x10000 + 0x1000] = 0x56
+    expect(findMemory({
+      address: 0x1000,
+      length: 1,
+      space: "aux",
+      auxBank: 1,
+      bytes: [0x56],
+    }).matches).toEqual([0x1000])
+    expect(findMemory({
+      address: 0x1000,
+      length: 1,
+      space: "main",
+      bytes: [0x56],
+    }).matches).toEqual([])
+
+    const beforeSwitches = [SWITCHES.RAMRD, SWITCHES.RAMWRT, SWITCHES.ALTZP]
+      .map((softSwitch) => softSwitch.isSet)
+    const systemByte = getMemoryView({address: 0xC000, length: 1, space: "active"}).bytes[0]
+    expect(findMemory({
+      address: 0xC000,
+      length: 1,
+      space: "active",
+      bytes: [systemByte],
+    }).matches).toEqual([0xC000])
+    expect([SWITCHES.RAMRD, SWITCHES.RAMWRT, SWITCHES.ALTZP]
+      .map((softSwitch) => softSwitch.isSet)).toEqual(beforeSwitches)
+  })
+
+  test("returns no matches and validates search-specific bounds", () => {
+    expect(findMemory({address: 0, length: 1, space: "main", bytes: [0x42]}))
+      .toMatchObject({matches: [], totalMatchCount: 0, truncated: false})
+    expect(() => findMemory({address: 0, length: 1, space: "main", bytes: []}))
+      .toThrow("Memory pattern must contain 1 to 32 byte values")
+    expect(() => findMemory({address: 0, length: 1, space: "main", bytes: [256]}))
+      .toThrow("Memory pattern must contain 1 to 32 byte values")
+    expect(() => findMemory({address: 0, length: 1, space: "main", bytes: [0], maxMatches: 65}))
+      .toThrow("Maximum matches must be between 1 and 64")
   })
 })
 

--- a/src/worker/memory_view.ts
+++ b/src/worker/memory_view.ts
@@ -103,3 +103,30 @@ export const getMemoryView = (request: MemoryViewRequest): MemoryView => {
     bytes,
   }
 }
+
+export const findMemory = (request: MemorySearchRequest): MemorySearchResult => {
+  const {bytes: pattern, maxMatches = 32} = request
+  if (!Array.isArray(pattern) || pattern.length < 1 || pattern.length > 32
+    || pattern.some((byte) => !Number.isInteger(byte) || byte < 0 || byte > 0xFF)) {
+    throw new Error("Memory pattern must contain 1 to 32 byte values")
+  }
+  if (!Number.isInteger(maxMatches) || maxMatches < 1 || maxMatches > 64) {
+    throw new Error("Maximum matches must be between 1 and 64")
+  }
+
+  const {bytes, ...view} = getMemoryView(request)
+  const matches: number[] = []
+  let totalMatchCount = 0
+  for (let offset = 0; offset + pattern.length <= bytes.length; offset++) {
+    if (pattern.every((byte, index) => bytes[offset + index] === byte)) {
+      totalMatchCount++
+      if (matches.length < maxMatches) matches.push(request.address + offset)
+    }
+  }
+  return {
+    ...view,
+    matches,
+    totalMatchCount,
+    truncated: totalMatchCount > matches.length,
+  }
+}

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -3,7 +3,7 @@ import { getAuxCardEnabled, getHires, memGet, memSet, memory, setAuxCardEnabled,
 import { s6502, setPC } from "./instructions"
 import { hiresLineToAddress, RamWorksMemoryStart, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
-import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, doStepOver, doWriteMemory, getExternalMachineState, getExternalMemoryView, resetCpuSpeedForTesting } from "./motherboard"
+import { doBoot, doLoadBinary, doReset, doRunBinary, doSetCycleCount, doSetMachineName, doSetRunMode, doSetSiriusJoyport, doSetSpeedMode, doSetState6502, doStepOver, doWriteMemory, findExternalMemory, getExternalMachineState, getExternalMemoryView, resetCpuSpeedForTesting } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { setIsTesting } from "./worker2main"
 import { BreakpointMap, BreakpointNew } from "../common/breakpoint"
@@ -27,6 +27,8 @@ test("physical memory inspection requires a stable paused worker", () => {
   setIsTesting()
   doSetRunMode(RUN_MODE.PAUSED, false)
   expect(getExternalMemoryView({address: 0, length: 1, space: "main"}).bytes).toHaveLength(1)
+  expect(findExternalMemory({address: 0, length: 1, space: "main", bytes: [0]}))
+    .toMatchObject({matches: expect.any(Array)})
   expect(() => getExternalMemoryView({address: 0, length: 1, space: "main", auxBank: 0}))
     .toThrow("Auxiliary bank is valid only for auxiliary memory")
 
@@ -34,6 +36,8 @@ test("physical memory inspection requires a stable paused worker", () => {
   expect(() => getExternalMemoryView({address: 0, length: 1, space: "active"}))
     .toThrow("Memory is available only while the emulator is paused")
   expect(() => getExternalMemoryView({address: 0, length: 1, space: "main"}))
+    .toThrow("Memory is available only while the emulator is paused")
+  expect(() => findExternalMemory({address: 0, length: 1, space: "main", bytes: [0]}))
     .toThrow("Memory is available only while the emulator is paused")
 
   doSetRunMode(RUN_MODE.PAUSED, false)
@@ -64,6 +68,10 @@ test("physical memory inspection preserves CPU and execution state", () => {
     expect(getExternalMachineState().runMode).toEqual(RUN_MODE.PAUSED)
 
     getExternalMemoryView({address: 0x03A4, length: 1, space: "aux", auxBank: 0})
+    expect(s6502).toEqual(expectedCpu)
+    expect(getExternalMachineState().runMode).toEqual(RUN_MODE.PAUSED)
+
+    findExternalMemory({address: 0x03A4, length: 1, space: "main", bytes: [0]})
     expect(s6502).toEqual(expectedCpu)
     expect(getExternalMachineState().runMode).toEqual(RUN_MODE.PAUSED)
   } finally {

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -47,7 +47,7 @@ import { doSnapshot, fixSaveStates, getGoBackwardIndex, getGoForwardIndex, getTe
 import { SoftCard } from "./devices/softcard"
 import { setSlotIOCallback } from "./memory"
 import { hasHardDriveMounted } from "./devices/drivestate"
-import { getMemoryView } from "./memory_view"
+import { findMemory, getMemoryView } from "./memory_view"
 
 let speedMode = 0
 let cpuSpeed = 0
@@ -85,6 +85,13 @@ export const getExternalMemoryView = (request: MemoryViewRequest) => {
     throw new Error("Memory is available only while the emulator is paused")
   }
   return getMemoryView(request)
+}
+
+export const findExternalMemory = (request: MemorySearchRequest) => {
+  if (cpuRunMode !== RUN_MODE.PAUSED) {
+    throw new Error("Memory is available only while the emulator is paused")
+  }
+  return findMemory(request)
 }
 
 const startSiriusJoyportResetTimer = () => {

--- a/src/worker/worker2main.ts
+++ b/src/worker/worker2main.ts
@@ -14,7 +14,7 @@ import { doSetRunMode, doSetSpeedMode,
   setTracing,
   doExecuteBasicCommand,
   doSetCyclesToRun,
-  getExternalMemoryView} from "./motherboard"
+  getExternalMemoryView, findExternalMemory} from "./motherboard"
 import { doSetEmuDriveNewData, doSetEmuDriveProps } from "./devices/drivestate"
 import { apple2KeyRelease, setKeyboardState, sendTextToEmulator } from "./devices/keyboard"
 import { pressAppleCommandKey, setGamepads, setReverseYAxis } from "./devices/joystick"
@@ -240,6 +240,20 @@ if (typeof self !== "undefined") {
             e.data.operationId,
             undefined,
             getExternalMemoryView(e.data.payload as MemoryViewRequest),
+          )
+        } catch (error) {
+          passWorkerOperationResult(
+            e.data.operationId,
+            error instanceof Error ? error.message : String(error),
+          )
+        }
+        break
+      case MSG_MAIN.FIND_MEMORY:
+        try {
+          passWorkerOperationResult(
+            e.data.operationId,
+            undefined,
+            findExternalMemory(e.data.payload as MemorySearchRequest),
           )
         } catch (error) {
           passWorkerOperationResult(


### PR DESCRIPTION
## Goal

The end goal is for an MCP client to start and control an Apple2TS emulator per issue #218. This slice lets external controllers search a bounded memory range for an exact byte pattern without transferring the scanned bytes.

## Cross-repository change

This change will be paired with an Apple2TS Server change that exposes the capability as `find_memory` through stdio MCP.

## What was implemented in this slice

- Search one coherent memory view while the emulator is paused, using the existing `active`, `main`, and `aux` mapping semantics, including explicit auxiliary banks.
- Return overlapping matching addresses in ascending order, with a caller-selected cap, total match count, truncation status, and mapping metadata.
- Route the operation through the existing worker and remote-control path. Running emulators are rejected without changing execution state.

## Verification

- Covered physical and active mappings, overlapping and truncated results, invalid bounds, and pause preservation.
- The production build and full test suite pass.
