### PR TITLE
fix(i18n): preserve PO formatting during catalog updates

### DIFF
--- a/.github/workflows/pull-request-build-only.yml
+++ b/.github/workflows/pull-request-build-only.yml
@@ -25,4 +25,8 @@ jobs:
     - run: npm ci --ignore-scripts
     - run: npm run lint
     - run: npm run build
+    - name: Install GNU gettext
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes gettext
     - run: npm test

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -112,9 +112,12 @@ a check for every language to accommodate one intentional translation.
    cross-key fuzzy matching because the stable `msgctxt`, not similar English
    wording, identifies a message. Each locale is staged before replacement; a
    failure preserves the affected original and reports any earlier catalogs
-   already updated. Catalogs use UTF-8 without a byte-order mark. An update
-   preserves the header and entries whose source text and metadata did not
-   change byte-for-byte, and repeating it produces no diff.
+   already updated. To prevent formatting churn and avoidable translation-file
+   conflicts, the pre-merge step never recompiles a complete translation
+   catalog: it preserves the header and unrelated entries byte-for-byte and
+   rewrites only entries whose English source changed before `msgmerge`.
+   Catalogs use UTF-8 without a byte-order mark, and regression tests require a
+   repeated update to produce no diff.
 3. Review the affected `msgstr` values. Clear fuzzy only after confirming a
    translation against current English. Leave missing translations empty so
    runtime fallback remains visible; do not copy English merely to complete

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -112,7 +112,9 @@ a check for every language to accommodate one intentional translation.
    cross-key fuzzy matching because the stable `msgctxt`, not similar English
    wording, identifies a message. Each locale is staged before replacement; a
    failure preserves the affected original and reports any earlier catalogs
-   already updated.
+   already updated. Catalogs use UTF-8 without a byte-order mark. An update
+   preserves the header and entries whose source text and metadata did not
+   change byte-for-byte, and repeating it produces no diff.
 3. Review the affected `msgstr` values. Clear fuzzy only after confirming a
    translation against current English. Leave missing translations empty so
    runtime fallback remains visible; do not copy English merely to complete

--- a/tools/i18n/catalog-config.test.mjs
+++ b/tools/i18n/catalog-config.test.mjs
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os"
 import { basename, extname, join, relative, resolve } from "node:path"
 import { describe, it } from "node:test"
+import { TextDecoder } from "node:util"
 import ts from "typescript"
 
 import {
@@ -94,6 +95,16 @@ describe("catalog configuration", () => {
       fileStems(outputDirectory, ".ts"),
       [...configured, "registry"].sort(),
     )
+  })
+
+  it("keeps every tracked catalog in the shared UTF-8 format", () => {
+    const inputs = new Set([sourceCatalog, ...catalogs.map(({input}) => input)])
+    for (const input of inputs) {
+      const bytes = readFileSync(input)
+      assert.notDeepEqual([...bytes.subarray(0, 3)], [0xef, 0xbb, 0xbf], input)
+      const source = new TextDecoder("utf-8", {fatal: true}).decode(bytes)
+      assert.match(source, /Content-Type: text\/plain; charset=UTF-8/i, input)
+    }
   })
 
   it("registers every generated language catalog for the runtime", () => {

--- a/tools/i18n/fixtures/weblate-formatted.po
+++ b/tools/i18n/fixtures/weblate-formatted.po
@@ -1,0 +1,42 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Apple2TS\n"
+"PO-Revision-Date: 2026-09-06 02:51+0000\n"
+"Last-Translator: Weblate Translator <translator@example.com>\n"
+"Language-Team: French <https://hosted.weblate.org/projects/apple2ts/browser-"
+"emulator/fr/>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2026.9.1.dev0\n"
+
+#. Keep the translator note and placeholder translation.
+msgctxt "disk.save"
+msgid "Save disk {{name}}"
+msgstr "Enregistrer le disque « {{name}} »"
+
+#, fuzzy, javascript-format
+#| msgid "Earlier unchanged source"
+msgctxt "tour.unchanged"
+msgid ""
+"A long unchanged source message that Weblate wrapped in its normal style."
+msgstr ""
+"Un texte français inchangé suffisamment long pour conserver exactement son "
+"formatage Weblate."
+
+#, javascript-format
+#, fuzzy
+#| msgid "Earlier empty source"
+msgctxt "disk.empty"
+msgid "Old empty source"
+msgstr ""
+
+msgctxt "removed.entry"
+msgid "Removed source"
+msgstr "Traduction supprimée"
+
+#~ msgctxt "obsolete.entry"
+#~ msgid "Already obsolete"
+#~ msgstr "Déjà obsolète"

--- a/tools/i18n/fixtures/weblate-source-after.pot
+++ b/tools/i18n/fixtures/weblate-source-after.pot
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#. Keep the translator note and placeholder translation.
+msgctxt "disk.save"
+msgid "Save image {{name}}"
+msgstr ""
+
+#, javascript-format
+msgctxt "tour.unchanged"
+msgid "A long unchanged source message that Weblate wrapped in its normal style."
+msgstr ""
+
+#, javascript-format
+msgctxt "disk.empty"
+msgid "New empty source"
+msgstr ""

--- a/tools/i18n/fixtures/weblate-source-before.pot
+++ b/tools/i18n/fixtures/weblate-source-before.pot
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#. Keep the translator note and placeholder translation.
+msgctxt "disk.save"
+msgid "Save disk {{name}}"
+msgstr ""
+
+#, javascript-format
+msgctxt "tour.unchanged"
+msgid "A long unchanged source message that Weblate wrapped in its normal style."
+msgstr ""
+
+#, javascript-format
+msgctxt "disk.empty"
+msgid "Old empty source"
+msgstr ""
+
+msgctxt "removed.entry"
+msgid "Removed source"
+msgstr ""

--- a/tools/i18n/po-catalog.mjs
+++ b/tools/i18n/po-catalog.mjs
@@ -214,6 +214,9 @@ export const preparePoCatalogForMerge = (sourceCatalog, translationCatalog) => {
     block,
     message: readPoBlock(translationBlocks[0], block),
   }))
+  if (blocks.some(({block, message}) => !message && block.body.trim().length > 0)) {
+    throw new Error("Translation catalog must keep comments with their PO entry")
+  }
   if (blocks.filter(({message}) => message).length !== countParsedMessages(translation)) {
     throw new Error("Translation catalog must separate PO entries with blank lines")
   }

--- a/tools/i18n/po-catalog.mjs
+++ b/tools/i18n/po-catalog.mjs
@@ -62,21 +62,6 @@ const isFuzzy = item => (
     .some(flag => flag.trim() === "fuzzy") ?? false
 )
 
-const setFuzzy = (item, fuzzy) => {
-  const flags = new Set(
-    item.comments?.flag?.split(/[,\s]+/).filter(Boolean) ?? [],
-  )
-  if (fuzzy) flags.add("fuzzy")
-  else flags.delete("fuzzy")
-
-  if (flags.size > 0) {
-    item.comments = {...item.comments, flag: [...flags].join(", ")}
-  } else if (item.comments) {
-    delete item.comments.flag
-    if (Object.keys(item.comments).length === 0) delete item.comments
-  }
-}
-
 const previousSource = item => {
   const previous = item?.comments?.previous
   if (!previous) return undefined
@@ -145,53 +130,126 @@ const readParsedActiveMessages = po => {
   return messages
 }
 
+const splitPoBlocks = catalog => {
+  const blocks = []
+  const separatorPattern = /\r?\n(?:\r?\n)+/g
+  let start = 0
+  let prefix = ""
+  for (const match of catalog.matchAll(separatorPattern)) {
+    blocks.push({prefix, body: catalog.slice(start, match.index)})
+    prefix = match[0]
+    start = match.index + match[0].length
+  }
+  blocks.push({prefix, body: catalog.slice(start)})
+  return blocks
+}
+
+const readPoBlock = (header, block) => {
+  const parsed = poParser.parse(
+    Buffer.from(`${header.body}${block.prefix}${block.body}`),
+    {validation: true},
+  )
+  const active = []
+  const obsolete = []
+  for (const [context, entries] of Object.entries(parsed.translations)) {
+    for (const item of Object.values(entries)) {
+      if (item.msgid.length > 0) active.push({context, item})
+    }
+  }
+  for (const [context, entries] of Object.entries(parsed.obsolete ?? {})) {
+    for (const item of Object.values(entries)) obsolete.push({context, item})
+  }
+  if (active.length + obsolete.length > 1) {
+    throw new Error("PO block contains multiple messages")
+  }
+  if (active[0]) return {...active[0], obsolete: false, parsed}
+  if (obsolete[0]) return {...obsolete[0], obsolete: true, parsed}
+  return undefined
+}
+
+const countParsedMessages = parsed => (
+  Object.values(parsed.translations).reduce((count, entries) => (
+    count + Object.values(entries).filter(item => item.msgid.length > 0).length
+  ), 0)
+  + Object.values(parsed.obsolete ?? {}).reduce((count, entries) => (
+    count + Object.keys(entries).length
+  ), 0)
+)
+
+const updateMessage = (message, msgid, eol) => {
+  const translated = (message.item.msgstr?.[0] ?? "").length > 0
+  const comments = {...message.item.comments}
+  const flags = [...new Set(
+    (comments.flag ?? "").split(/[,\s]+/).filter(Boolean),
+  )].filter(flag => flag !== "fuzzy")
+  if (translated) flags.push("fuzzy")
+  if (flags.length > 0) comments.flag = flags.join(", ")
+  else delete comments.flag
+  if (translated) comments.previous = `msgid ${JSON.stringify(message.item.msgid)}`
+  else delete comments.previous
+
+  const entries = message.parsed.translations[message.context]
+  delete entries[message.item.msgid]
+  message.item.msgid = msgid
+  message.item.comments = comments
+  entries[msgid] = message.item
+
+  const compiled = poParser.compile(message.parsed, {eol, foldLength: 77}).toString("utf8")
+  const blocks = splitPoBlocks(compiled)
+  const messageBlocks = blocks.slice(1).filter(block => block.body.length > 0)
+  if (messageBlocks.length !== 1) {
+    throw new Error(`Unable to compile one PO message block: ${message.context}`)
+  }
+  const body = messageBlocks[0].body
+  return body.endsWith(eol) ? body.slice(0, -eol.length) : body
+}
+
 export const preparePoCatalogForMerge = (sourceCatalog, translationCatalog) => {
   const source = poParser.parse(sourceCatalog, {validation: true})
   const translation = poParser.parse(translationCatalog, {validation: true})
   const sourceMessages = readParsedActiveMessages(source)
   readParsedActiveMessages(translation)
+  const translationBlocks = splitPoBlocks(translationCatalog)
+  const blocks = translationBlocks.slice(1).map(block => ({
+    block,
+    message: readPoBlock(translationBlocks[0], block),
+  }))
+  if (blocks.filter(({message}) => message).length !== countParsedMessages(translation)) {
+    throw new Error("Translation catalog must separate PO entries with blank lines")
+  }
   let changed = false
-
-  for (const [context, entries] of Object.entries(translation.translations)) {
-    if (!context) continue
-    const sourceItem = sourceMessages.get(context)
-    if (!sourceItem) {
-      delete translation.translations[context]
+  const retainedBlocks = [translationBlocks[0]]
+  for (const {block, message} of blocks) {
+    if (!message) {
+      retainedBlocks.push(block)
+      continue
+    }
+    const sourceItem = sourceMessages.get(message.context)
+    if (!sourceItem || message.obsolete) {
       changed = true
       continue
     }
-
-    for (const [storedMsgid, item] of Object.entries(entries)) {
-      if (item.msgid === sourceItem.msgid) continue
-
-      const oldSource = item.msgid
-      delete entries[storedMsgid]
-      item.msgid = sourceItem.msgid
-      entries[item.msgid] = item
-      changed = true
-
-      if ((item.msgstr?.[0] ?? "").length > 0) {
-        item.comments = {
-          ...item.comments,
-          previous: `msgid ${JSON.stringify(oldSource)}`,
-        }
-        setFuzzy(item, true)
-      } else {
-        if (item.comments) {
-          delete item.comments.previous
-          if (Object.keys(item.comments).length === 0) delete item.comments
-        }
-        setFuzzy(item, false)
-      }
+    if (message.item.msgid === sourceItem.msgid) {
+      retainedBlocks.push(block)
+      continue
     }
-  }
-
-  if (Object.keys(translation.obsolete ?? {}).length > 0) {
-    delete translation.obsolete
+    retainedBlocks.push({
+      ...block,
+      body: updateMessage(
+        message,
+        sourceItem.msgid,
+        block.body.includes("\r\n") ? "\r\n" : "\n",
+      ),
+    })
     changed = true
   }
 
-  return changed ? poParser.compile(translation).toString() : translationCatalog
+  if (!changed) return translationCatalog
+  const updated = retainedBlocks.map(block => `${block.prefix}${block.body}`).join("")
+  const finalEol = translationCatalog.endsWith("\r\n")
+    ? "\r\n"
+    : translationCatalog.endsWith("\n") ? "\n" : ""
+  return finalEol && !updated.endsWith(finalEol) ? `${updated}${finalEol}` : updated
 }
 
 const readObsoleteMessages = source => {

--- a/tools/i18n/update-catalogs-lib.mjs
+++ b/tools/i18n/update-catalogs-lib.mjs
@@ -17,8 +17,8 @@ export const stageCatalogUpdate = ({input, source}) => {
     writeFileSync(
       stagedInput,
       preparePoCatalogForMerge(
-        readFileSync(source),
-        readFileSync(input),
+        readFileSync(source, "utf8"),
+        readFileSync(input, "utf8"),
       ),
       {flag: "wx"},
     )

--- a/tools/i18n/update-catalogs.test.mjs
+++ b/tools/i18n/update-catalogs.test.mjs
@@ -1,13 +1,26 @@
 import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
 import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { afterEach, describe, it } from "node:test"
 
-import { updateCatalogs } from "./update-catalogs-lib.mjs"
+import { stageCatalogUpdate, updateCatalogs } from "./update-catalogs-lib.mjs"
 import { analyzePoCatalog, compilePoCatalog } from "./po-catalog.mjs"
 
 const temporaryDirectories = []
+const weblateFixture = readFileSync(
+  new URL("./fixtures/weblate-formatted.po", import.meta.url),
+  "utf8",
+)
+const weblateSourceBefore = readFileSync(
+  new URL("./fixtures/weblate-source-before.pot", import.meta.url),
+  "utf8",
+)
+const weblateSourceAfter = readFileSync(
+  new URL("./fixtures/weblate-source-after.pot", import.meta.url),
+  "utf8",
+)
 const unchangedStage = ({input}) => ({
   input,
   commit() {},
@@ -117,6 +130,7 @@ msgstr "Enregistrer le disque"
 
     assert.equal(code, 0)
     const updated = readFileSync(input, "utf8")
+    assert.ok(updated.endsWith("\n"))
     assert.deepEqual(compilePoCatalog(updated, {sourceCatalog: sourceText}), {
       disk: {save: "Enregistrer le disque"},
     })
@@ -131,6 +145,117 @@ msgstr "Enregistrer le disque"
         previousSource: "Save Disk",
       },
     )
+  })
+
+  it("needs stable-key preparation before msgmerge", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-negative-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    writeFileSync(source, `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "disk.save"
+msgid "Completely unrelated replacement wording"
+msgstr ""
+`)
+    writeFileSync(input, `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "disk.save"
+msgid "Save Disk"
+msgstr "Enregistrer le disque"
+`)
+
+    const result = spawnSync("msgmerge", [
+      "--previous",
+      "--no-fuzzy-matching",
+      "--update",
+      "--backup=none",
+      input,
+      source,
+    ])
+
+    assert.equal(result.status, 0)
+    const updated = readFileSync(input, "utf8")
+    assert.match(updated, /msgid "Completely unrelated replacement wording"\nmsgstr ""/)
+    assert.match(updated, /#~ msgstr "Enregistrer le disque"/)
+  })
+
+  it("changes semantic entries without reformatting unrelated Weblate content", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-weblate-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    writeFileSync(source, weblateSourceAfter)
+    writeFileSync(input, weblateFixture)
+    const header = weblateFixture.slice(0, weblateFixture.indexOf("#. Keep"))
+    const unchanged = weblateFixture.slice(
+      weblateFixture.indexOf("#, fuzzy, javascript-format"),
+      weblateFixture.indexOf("#, javascript-format\n#, fuzzy\n#| msgid \"Earlier empty source\""),
+    )
+    assert.deepEqual(
+      analyzePoCatalog(weblateSourceBefore, weblateFixture).entries
+        .map(({key, status}) => ({key, status})),
+      [
+        {key: "disk.empty", status: "missing"},
+        {key: "disk.save", status: "translated"},
+        {key: "removed.entry", status: "translated"},
+        {key: "tour.unchanged", status: "translated"},
+      ],
+    )
+
+    const run = (command, arguments_) => {
+      assert.equal(command, "msgmerge")
+      if (arguments_[0] !== "--version") {
+        const staged = readFileSync(arguments_.at(-2), "utf8")
+        assert.equal(staged.slice(0, staged.indexOf("#. Keep")), header)
+        assert.ok(staged.includes(unchanged))
+      }
+      return {status: 0}
+    }
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run,
+    }), 0)
+
+    const updated = readFileSync(input, "utf8")
+    assert.match(updated, /#, fuzzy\n#\| msgid "Save disk \{\{name\}\}"\nmsgctxt "disk\.save"\nmsgid "Save image \{\{name\}\}"/)
+    assert.match(updated, /msgstr "Enregistrer le disque « \{\{name\}\} »"/)
+    assert.match(updated, /#, javascript-format\nmsgctxt "disk\.empty"\nmsgid "New empty source"\nmsgstr ""/)
+    assert.doesNotMatch(updated, /Earlier empty source|removed\.entry|obsolete\.entry/)
+    assert.equal(updated.slice(0, updated.indexOf("#. Keep")), header)
+    assert.ok(updated.includes(unchanged))
+    assert.deepEqual(compilePoCatalog(updated, {sourceCatalog: weblateSourceAfter}), {
+      disk: {
+        save: "Enregistrer le disque « {{name}} »",
+      },
+      tour: {
+        unchanged: "Un texte français inchangé suffisamment long pour conserver exactement son formatage Weblate.",
+      },
+    })
+    const save = analyzePoCatalog(weblateSourceAfter, updated).entries
+      .find(entry => entry.key === "disk.save")
+    assert.deepEqual(save, {
+      key: "disk.save",
+      status: "translated",
+      source: "Save image {{name}}",
+      translation: "Enregistrer le disque « {{name}} »",
+      fuzzy: true,
+      previousSource: "Save disk {{name}}",
+    })
+
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run,
+    }), 0)
+    assert.equal(readFileSync(input, "utf8"), updated)
   })
 
   it("removes messages absent from the source instead of making them obsolete", () => {
@@ -214,6 +339,151 @@ msgstr "Enregistrer le disque"
     })
 
     assert.equal(code, 1)
+    assert.equal(readFileSync(input, "utf8"), original)
+    assert.deepEqual(readdirSync(directory).sort(), ["fr.po", "messages.pot"])
+  })
+
+  it("rejects valid PO entries without supported blank-line separation", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-layout-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    const sourceText = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "disk.save"
+msgid "Save Disk"
+msgstr ""
+`
+    const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+msgctxt "disk.save"
+msgid "Save Disk"
+msgstr "Enregistrer"
+`
+    writeFileSync(source, sourceText)
+    writeFileSync(input, original)
+    let message = ""
+
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run: () => ({status: 0}),
+      stderr: {write(value) { message += value }},
+    }), 1)
+    assert.match(message, /must separate PO entries with blank lines/)
+    assert.equal(readFileSync(input, "utf8"), original)
+    assert.deepEqual(readdirSync(directory).sort(), ["fr.po", "messages.pot"])
+  })
+
+  it("rejects active plural entries without modifying the original", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-plural-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\\n"
+
+msgctxt "disk.count"
+msgid "One disk"
+msgid_plural "{{count}} disks"
+msgstr[0] "Un disque"
+msgstr[1] "{{count}} disques"
+`
+    writeFileSync(source, original)
+    writeFileSync(input, original)
+    let message = ""
+
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run: () => ({status: 0}),
+      stderr: {write(value) { message += value }},
+    }), 1)
+    assert.match(message, /Plural messages are not supported: disk\.count/)
+    assert.equal(readFileSync(input, "utf8"), original)
+    assert.deepEqual(readdirSync(directory).sort(), ["fr.po", "messages.pot"])
+  })
+
+  it("leaves metadata-only changes raw until msgmerge", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-metadata-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+#: old.ts:1
+#, fuzzy
+#| msgid "Earlier wording"
+msgctxt "disk.save"
+msgid "Save Disk"
+msgstr "Enregistrer"
+`
+    writeFileSync(source, original.replace("#: old.ts:1", "#: new.ts:2"))
+    writeFileSync(input, original)
+
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      stage(arguments_) {
+        const staged = stageCatalogUpdate(arguments_)
+        assert.equal(readFileSync(staged.input, "utf8"), original)
+        return staged
+      },
+    }), 0)
+    const updated = readFileSync(input, "utf8")
+    assert.match(updated, /#: new\.ts:2/)
+    assert.deepEqual(
+      analyzePoCatalog(readFileSync(source, "utf8"), updated).entries[0],
+      {
+        key: "disk.save",
+        status: "translated",
+        source: "Save Disk",
+        translation: "Enregistrer",
+        fuzzy: true,
+        previousSource: "Earlier wording",
+      },
+    )
+  })
+
+  it("cleans staging and preserves the original after replacement fails", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-replace-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "disk.save"
+msgid "Save Disk"
+msgstr "Enregistrer"
+`
+    writeFileSync(source, original.replace("Save Disk", "Load Disk"))
+    writeFileSync(input, original)
+    let message = ""
+
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run: () => ({status: 0}),
+      stage(arguments_) {
+        const staged = stageCatalogUpdate(arguments_)
+        return {...staged, commit() { throw new Error("replacement denied") }}
+      },
+      stderr: {write(value) { message += value }},
+    }), 1)
+    assert.match(message, /Unable to replace fr\.po: replacement denied/)
     assert.equal(readFileSync(input, "utf8"), original)
     assert.deepEqual(readdirSync(directory).sort(), ["fr.po", "messages.pot"])
   })

--- a/tools/i18n/update-catalogs.test.mjs
+++ b/tools/i18n/update-catalogs.test.mjs
@@ -379,6 +379,38 @@ msgstr "Enregistrer"
     assert.deepEqual(readdirSync(directory).sort(), ["fr.po", "messages.pot"])
   })
 
+  it("rejects comments separated from their PO entry", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-comments-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    const sourceText = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+`
+    const original = `${sourceText}
+# Translator note for removed.entry
+
+msgctxt "removed.entry"
+msgid "Removed"
+msgstr "Supprimé"
+`
+    writeFileSync(source, sourceText)
+    writeFileSync(input, original)
+    let message = ""
+
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run: () => ({status: 0}),
+      stderr: {write(value) { message += value }},
+    }), 1)
+    assert.match(message, /must keep comments with their PO entry/)
+    assert.equal(readFileSync(input, "utf8"), original)
+    assert.deepEqual(readdirSync(directory).sort(), ["fr.po", "messages.pot"])
+  })
+
   it("rejects active plural entries without modifying the original", () => {
     const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-plural-"))
     temporaryDirectories.push(directory)


### PR DESCRIPTION
## Motivation

Apple2TS translation catalogs receive changes from both GitHub contributions
and Weblate. Small English-message changes were causing unrelated portions of
the PO files to be reformatted, increasing the likelihood and size of conflicts
when those two streams met, as seen in #443.

## Background

English source messages live in `messages.pot`. Running
`npm run update-i18n-catalogs` reconciles that source catalog with each
translated PO file:

1. The catalog-update script matches existing PO entries to `messages.pot`
   using stable `msgctxt` keys. It prepares changed entries so their
   translations survive the merge.
2. GNU `msgmerge` adds and orders source entries and updates source metadata.
3. Project checks compile the resulting PO catalogs into the TypeScript
   catalogs used at runtime.

Separately, Weblate submits translation and header updates to the same PO files
through GitHub pull requests. Previously, Apple2TS's preparation step parsed
and recompiled each complete PO file with `gettext-parser`. Its formatting
could differ from Weblate and `msgmerge`, producing large unrelated diffs
before the real changes were merged.

## Resolution

The preparation step now preserves complete raw PO blocks for unchanged
messages and recompiles only entries whose English source changed.
Translations continue to follow their stable `msgctxt`; changed translations
retain their previous English source and become fuzzy for review.

GNU `msgmerge` remains responsible for source metadata and ordering.
Source-deleted and obsolete entries are removed, ambiguous layouts are rejected
before replacement, and failures preserve the original catalog and clean up
staging files.

## Verification

Regression coverage uses a representative Weblate-formatted catalog to verify:

- changed messages retain translations, placeholders, Unicode, fuzzy state,
  and previous-source text;
- unchanged headers, translations, comments, flags, and entries remain
  byte-identical;
- removed and obsolete entries do not survive;
- failures preserve the original catalog and remove staging files; and
- running the update again produces no diff.

CI installs GNU gettext as a test dependency so the complete catalog
integration suite runs on every pull request targeting `main`.

The focused catalog tests pass using GNU gettext 1.0. Catalog consistency,
lint, all 857 project tests, and the production build also pass.
