### PR TITLE
Fix: Control panel clock formatting

### DIFF
--- a/src/ui/retro/retrocontrolpanel.css
+++ b/src/ui/retro/retrocontrolpanel.css
@@ -394,21 +394,21 @@
 }
 
 .retro-clock-border>.retro-border-glyph-left {
-  left: calc(3 * var(--retro-cell-width));
+  left: calc(4 * var(--retro-cell-width));
 }
 
 .retro-clock-border>.retro-border-glyph-top,
 .retro-clock-border>.retro-border-glyph-bottom {
-  left: calc(3 * var(--retro-cell-width));
+  left: calc(4 * var(--retro-cell-width));
 }
 
 .retro-clock-border>.retro-border-notch-top-left,
 .retro-clock-border>.retro-border-notch-bottom-left {
-  left: calc(3 * var(--retro-cell-width));
+  left: calc(4 * var(--retro-cell-width));
 }
 
 .retro-panel.retro-skin-apple-iiplus .retro-clock {
-  grid-column: 24 / 38;
+  grid-column: 25 / 38;
 }
 
 .retro-panel.retro-skin-apple-iiplus .retro-clock-border>.retro-border-glyph-left,
@@ -424,7 +424,7 @@
 
 .retro-clock time {
   box-sizing: border-box;
-  grid-column: 5 / -2;
+  grid-column: 6 / -1;
   line-height: 1;
   overflow: hidden;
   white-space: nowrap;
@@ -432,12 +432,13 @@
 
 .retro-clock time:nth-of-type(1) {
   grid-row: 2;
-  text-align: center;
+  text-align: left;
 }
 
 .retro-clock time:nth-of-type(2) {
-  grid-column: 5 / -2;
+  grid-column: 6 / -1;
   grid-row: 3;
+  text-align: left;
 }
 
 .retro-panel.retro-skin-apple-iiplus .retro-clock time:nth-of-type(2) {

--- a/src/ui/retro/retromenurenderer.tsx
+++ b/src/ui/retro/retromenurenderer.tsx
@@ -15,8 +15,10 @@ import { formatControlLabel } from "../controls/controlregistry"
 import { useRetroMenuHost } from "./retromenuhost"
 import {
   actionHintWidth,
+  centerControlTextOffset,
   controlTextWidth,
   fitControlText,
+  formatClockDate,
   formatClockTime,
   menuItemTextWidth,
   mouseTextGlyphs,
@@ -1162,6 +1164,12 @@ const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => 
     ? truncateControlText(currentFrame.title, submenuTitleWidth, language)
     : ""
   const visibleSubmenuTitleWidth = controlTextWidth(visibleSubmenuTitle, language)
+  const clockTime = formatClockTime(now, language)
+  const clockDate = formatClockDate(now, language, isAppleIIPlus ? "_" : " ")
+  const clockTextWidth = isAppleIIPlus ? 12 : 11
+  const clockTimeOffset = centerControlTextOffset(clockTime, clockTextWidth, language)
+  const clockDateOffset = centerControlTextOffset(clockDate, clockTextWidth, language) +
+    (isAppleIIPlus ? -1 : 1)
 
   return (
     <>
@@ -1222,16 +1230,16 @@ const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => 
           <RetroBorder
             appleIIPlus={isAppleIIPlus}
             className="retro-clock-border"
-            columns={isAppleIIPlus ? 14 : 17}
+            columns={isAppleIIPlus ? 13 : 17}
             notchedCorners
             rows={4}
           />
-          <time>{formatClockTime(now, language)}</time>
-          <time><span>{now.toLocaleDateString(language, {
-            month: "numeric",
-            day: "numeric",
-            year: "2-digit",
-          })}</span></time>
+          <time><span style={{ marginInlineStart: `calc(${clockTimeOffset} * var(--retro-cell-width))` }}>
+            {clockTime}
+          </span></time>
+          <time><span style={{ marginInlineStart: `calc(${clockDateOffset} * var(--retro-cell-width))` }}>
+            {clockDate}
+          </span></time>
         </div>,
         menu: <div className={`retro-menu${currentFrame ? " retro-submenu-menu" : " retro-root-menu"}`} role="menu">
           {visibleMenu.map((item, visibleIndex) => {

--- a/src/ui/retro/retrotext.test.ts
+++ b/src/ui/retro/retrotext.test.ts
@@ -1,7 +1,9 @@
 import {
   actionHintWidth,
+  centerControlTextOffset,
   controlTextWidth,
   fitControlText,
+  formatClockDate,
   formatClockTime,
   menuItemTextWidth,
   mouseTextGlyphs,
@@ -21,6 +23,17 @@ describe("Retro control-panel text", () => {
     expect(formatClockTime(new Date(2020, 0, 1, 6, 7, 8), "en-US")).toMatch(/^\u20076:/)
     expect(formatClockTime(new Date(2020, 0, 1, 12, 7, 8), "en-US")).toMatch(/^12:/)
     expect(formatClockTime(new Date(2020, 0, 1, 18, 7, 8), "en-US")).toMatch(/ PM$/)
+  })
+
+  test("pads single-digit clock date fields to two cells", () => {
+    expect(formatClockDate(new Date(2026, 8, 6), "en-US")).toBe(" 9/ 6/26")
+    expect(formatClockDate(new Date(2026, 8, 6), "en-US", "_")).toBe("_9/_6/26")
+    expect(formatClockDate(new Date(2026, 10, 16), "en-US")).toBe("11/16/26")
+  })
+
+  test("centers clock text on whole control-panel cells", () => {
+    expect(centerControlTextOffset("12:07:08 PM", 11, "en-US")).toBe(0)
+    expect(centerControlTextOffset(" 9/ 6/26", 11, "en-US")).toBe(1)
   })
 
   test("truncates at grapheme boundaries with three dots", () => {

--- a/src/ui/retro/retrotext.ts
+++ b/src/ui/retro/retrotext.ts
@@ -40,8 +40,22 @@ export const formatClockTime = (date: Date, locale: string) => {
   return `${hour.length === 1 ? "\u2007" : ""}${formatter.format(date)}`
 }
 
+export const formatClockDate = (date: Date, locale: string, padding = " ") => {
+  const formatter = new Intl.DateTimeFormat(locale, {
+    month: "numeric",
+    day: "numeric",
+    year: "2-digit",
+  })
+  return formatter.formatToParts(date).map(part =>
+    part.type === "month" || part.type === "day" ? part.value.padStart(2, padding) : part.value,
+  ).join("")
+}
+
 export const controlTextWidth = (text: string, locale: string) =>
   graphemes(text, locale).reduce((width, grapheme) => width + (wideCharacter.test(grapheme) ? 2 : 1), 0)
+
+export const centerControlTextOffset = (text: string, availableWidth: number, locale: string) =>
+  Math.max(0, Math.floor((availableWidth - controlTextWidth(text, locale)) / 2))
 
 export const shouldUseCompactLatinFooter = (
   texts: readonly string[],


### PR DESCRIPTION
<img width="2400" height="1528" alt="image" src="https://github.com/user-attachments/assets/b55ecb30-7520-4fb4-9617-ff2f0b02db08" />
<img width="2400" height="1528" alt="image" src="https://github.com/user-attachments/assets/5547e1f5-7940-4124-b57c-fb5753d367ea" />

# Changes:
- Fixed control panel clock to use monospace font
- Matched clock formatting across all skins

# Verified
- Verified clock renders consistently across all skins
- Tested on multiple platforms (Windows, Mac OS) and browsers (Chrome, Edge)