### PR TITLE
Control panel: Split Drives from Disks menu + added more than two levels of menu hierarchy

### DIFF
--- a/src/ui/devices/disk/demozoo_retro.test.ts
+++ b/src/ui/devices/disk/demozoo_retro.test.ts
@@ -40,7 +40,7 @@ describe("retro DemoZoo screen", () => {
     const children = screen.children as (items?: never[]) => ReturnType<typeof registry.resolve>
     let items = children()
 
-    expect(screen.submenuTitle).toBe("DemoZoo")
+    expect(screen.submenuTitle).toBe("disk.loadDiskFromDemoZoo")
     expect(screen.actionLabel).toBe("Search")
     expect(items.map(item => item.label)).toEqual(["Type", "Title"])
 

--- a/src/ui/devices/disk/internetarchive_retro.test.ts
+++ b/src/ui/devices/disk/internetarchive_retro.test.ts
@@ -45,7 +45,7 @@ describe("retro Internet Archive screen", () => {
     const children = screen.children as (items?: never[]) => ReturnType<typeof registry.resolve>
     let items = children()
 
-    expect(screen.submenuTitle).toBe("Internet Archive")
+    expect(screen.submenuTitle).toBe("disk.loadDiskFromInternetArchive")
     expect(screen.actionLabel).toBe("Search")
     expect(items.map(item => item.label)).toEqual(["Collection", "Title"])
     expect(items[0].options?.map(option => option.label)).toEqual(["Collection One", "Collection Two"])

--- a/src/ui/devices/printer/imagewriter.tsx
+++ b/src/ui/devices/printer/imagewriter.tsx
@@ -148,10 +148,11 @@ const ImageWriter = ({ showLauncher = true }: { showLauncher?: boolean }) => {
   })
 
   useEffect(() => {
+    if (showLauncher) return
     const openDialog = () => setOpen(true)
     window.addEventListener(OPEN_IMAGEWRITER_EVENT, openDialog)
     return () => window.removeEventListener(OPEN_IMAGEWRITER_EVENT, openDialog)
-  }, [])
+  }, [showLauncher])
 
   const img1 = isPrinting ? iwiion : iwiioff
   const isTouchDevice = "ontouchstart" in document.documentElement

--- a/src/ui/devices/printer/printerdialog.tsx
+++ b/src/ui/devices/printer/printerdialog.tsx
@@ -43,7 +43,8 @@ const PrinterDialog = (props: PrinterDialogProps) => {
   const { open } = props
   const { t } = useTranslation()
   const dialogRef = useRef<HTMLDivElement>(null)
-  const [offset, setOffset] = useState([0, 0])
+  const dragOffsetRef = useRef([0, 0])
+  const dragPositionRef = useRef<[number, number] | null>(null)
   const [dragging, setDragging] = useState(false)
   const printerDialogPosition = getPreferencePrinterDialogPosition()
   const [dialogPositionX, setDialogPositionX] = useState(printerDialogPosition.x < 0 ? window.outerWidth / 2 - 275 : printerDialogPosition.x)
@@ -59,37 +60,40 @@ const PrinterDialog = (props: PrinterDialogProps) => {
     return () => clearInterval(interval)
   }, [open, props.printer])
 
-  const setDialogPosition = (x: number, y: number) => {
-    setDialogPositionX(x)
-    setDialogPositionY(y)
-    // Save the position to local storage
-    setPreferencePrinterDialogPosition({ x, y })
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dialogRef.current || event.button !== 0 || (event.target as Element).closest("button")) return
+    event.preventDefault()
+    event.stopPropagation()
+    event.currentTarget.setPointerCapture(event.pointerId)
+    dragOffsetRef.current = [
+      event.clientX - dialogRef.current.offsetLeft,
+      event.clientY - dialogRef.current.offsetTop,
+    ]
+    dragPositionRef.current = [dialogPositionX, dialogPositionY]
+    setDragging(true)
   }
 
-  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if (dialogRef.current) {
-      e.preventDefault() // Prevent text selection
-      setDragging(true)
-      const div = dialogRef.current as HTMLDivElement
-      // Offset of the mouse down event within the dialog title bar.
-      // This way we drag the window from where the user clicked.
-      setOffset([e.clientX - div.offsetLeft, e.clientY - div.offsetTop])
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture(event.pointerId) || !dialogRef.current) return
+    event.preventDefault()
+    event.stopPropagation()
+    const left = event.clientX - dragOffsetRef.current[0]
+    const top = event.clientY - dragOffsetRef.current[1]
+    dragPositionRef.current = [left, top]
+    dialogRef.current.style.left = `${left}px`
+    dialogRef.current.style.top = `${top}px`
+  }
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+    event.currentTarget.releasePointerCapture(event.pointerId)
+    const position = dragPositionRef.current
+    if (position) {
+      setDialogPositionX(position[0])
+      setDialogPositionY(position[1])
+      setPreferencePrinterDialogPosition({ x: position[0], y: position[1] })
     }
-  }
-
-  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if (dragging && dialogRef.current) {
-      e.preventDefault() // Prevent text selection
-      const div = dialogRef.current as HTMLDivElement
-      const left = e.clientX - offset[0]
-      const top = e.clientY - offset[1]
-      setDialogPosition(left, top)
-      div.style.left = `${left}px`
-      div.style.top = `${top}px`
-    }
-  }
-
-  const handleMouseUp = () => {
+    dragPositionRef.current = null
     setDragging(false)
   }
 
@@ -116,20 +120,7 @@ const PrinterDialog = (props: PrinterDialogProps) => {
     <div
       className="printer-dialog-host"
       tabIndex={0} // Make the div focusable
-      onMouseMove={(e) => handleMouseMove(e)}
-      onMouseUp={handleMouseUp}
-      style={{
-        cursor: dragging ? "move" : "default",
-        ...(dragging && {
-          position: "fixed",
-          top: 0,
-          left: 0,
-          width: "100vw",
-          height: "100vh",
-          zIndex: 9999,
-        }),
-      }}
-      >
+      style={{ cursor: dragging ? "move" : "default" }}>
       <div className="floating-dialog flex-column"
         ref={dialogRef}
         style={{
@@ -138,9 +129,11 @@ const PrinterDialog = (props: PrinterDialogProps) => {
         onClick={(e) => e.stopPropagation()}>
         <div className="flex-column">
           <div className="flex-row-space-between flexwrap printer-controls"
-            onMouseDown={(e) => handleMouseDown(e)}
-            onMouseMove={(e) => handleMouseMove(e)}
-            onMouseUp={handleMouseUp}>
+            onPointerCancel={handlePointerUp}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            style={{ touchAction: "none" }}>
             <svg height="28" width="120" style={{ marginLeft: "15px" }}>{imagewriter2}</svg>
             <div className="flex-row">
               {/* <button className="push-button"

--- a/src/ui/retro/retrocontrolmetadata.test.ts
+++ b/src/ui/retro/retrocontrolmetadata.test.ts
@@ -67,9 +67,9 @@ describe("retro control panel metadata", () => {
   })
 
   it.each([
-    ["internetArchive", "Internet Archive"],
-    ["demoZoo", "DemoZoo"],
-  ])("preserves static metadata for the %s disk template", (source, submenuTitle) => {
+    ["internetArchive", "disk.loadDiskFromInternetArchive"],
+    ["demoZoo", "disk.loadDiskFromDemoZoo"],
+  ])("hydrates the joined title for the %s disk template", (source, submenuTitleKey) => {
     const control = controlFromJson(
       "diskTemplates",
       `diskDrives.{{driveIndex}}.load.${source}`,
@@ -78,7 +78,9 @@ describe("retro control panel metadata", () => {
     )
 
     expect(control.id).toBe(`diskDrives.2.load.${source}`)
-    expect(control.submenuTitle).toBe(submenuTitle)
+    expect(typeof control.submenuTitle).toBe("function")
+    expect((control.submenuTitle as (context: RetroMenuContext) => string)(createContext().context))
+      .toBe(`translated:${submenuTitleKey}`)
     expect(control.actionLabel).toBe("Search")
   })
 })

--- a/src/ui/retro/retrocontrolpanel.css
+++ b/src/ui/retro/retrocontrolpanel.css
@@ -290,6 +290,14 @@
   white-space: nowrap;
 }
 
+.retro-submenu-title-level-3 {
+  grid-row: 5 / 8;
+}
+
+.retro-submenu-title-level-4 {
+  grid-row: 7 / 10;
+}
+
 .retro-submenu-title::before {
   background: var(--retro-foreground);
   content: "";
@@ -298,6 +306,10 @@
   position: absolute;
   right: 0;
   top: var(--retro-row-height);
+}
+
+.retro-submenu-title:not(.retro-active-title)::before {
+  display: none;
 }
 
 .retro-submenu-title>.retro-submenu-title-text {
@@ -317,6 +329,10 @@
   position: absolute;
   right: var(--retro-cell-width);
   top: var(--retro-row-height);
+}
+
+.retro-submenu-title:not(.retro-active-title) .retro-submenu-title-value {
+  color: var(--retro-foreground);
 }
 
 .retro-text-cursor {
@@ -356,6 +372,11 @@
   background: var(--retro-foreground);
   color: var(--retro-background);
   display: inline-block;
+}
+
+.retro-panel.retro-skin-apple-iiplus .retro-submenu-title:not(.retro-active-title) .retro-inverse-space {
+  background: var(--retro-background);
+  color: var(--retro-foreground);
 }
 
 .retro-submenu-title-row {
@@ -490,6 +511,16 @@
 
 .retro-submenu-menu {
   grid-column: 2 / 37;
+}
+
+.retro-menu.retro-menu-title-level-3 {
+  grid-row: 8 / 22;
+  grid-template-rows: repeat(14, var(--retro-row-height));
+}
+
+.retro-menu.retro-menu-title-level-4 {
+  grid-row: 10 / 22;
+  grid-template-rows: repeat(12, var(--retro-row-height));
 }
 
 .retro-menu-item {

--- a/src/ui/retro/retrocontrolpanel.json
+++ b/src/ui/retro/retrocontrolpanel.json
@@ -625,22 +625,21 @@
     },
     {
       "group": "disk",
-      "id": "diskCollection.drivesSeparator",
-      "parentId": "diskCollection",
-      "order": 4,
+      "id": "diskDrives",
+      "parentId": null,
+      "order": 1.5,
       "tourTargets": [
         "#tour-floppy-disks"
       ],
       "labelKey": "retroControl.diskDrives",
-      "separator": true,
-      "selectable": false
+      "actionLabelKey": "retroControl.open"
     },
     {
       "group": "disk",
       "id": "diskDrives.none",
       "binding": "diskDrives.none",
-      "parentId": "diskCollection",
-      "order": 5,
+      "parentId": "diskDrives",
+      "order": 0,
       "labelKey": "retroControl.noDiskDrivesAvailable",
       "selectable": false
     },
@@ -648,29 +647,29 @@
       "group": "disk",
       "id": "diskDrives.0",
       "binding": "diskDrives.0",
-      "parentId": "diskCollection",
-      "order": 6
+      "parentId": "diskDrives",
+      "order": 1
     },
     {
       "group": "disk",
       "id": "diskDrives.1",
       "binding": "diskDrives.1",
-      "parentId": "diskCollection",
-      "order": 7
+      "parentId": "diskDrives",
+      "order": 2
     },
     {
       "group": "disk",
       "id": "diskDrives.2",
       "binding": "diskDrives.2",
-      "parentId": "diskCollection",
-      "order": 8
+      "parentId": "diskDrives",
+      "order": 3
     },
     {
       "group": "disk",
       "id": "diskDrives.3",
       "binding": "diskDrives.3",
-      "parentId": "diskCollection",
-      "order": 9
+      "parentId": "diskDrives",
+      "order": 4
     },
     {
       "group": "diskTemplates",
@@ -690,7 +689,7 @@
       "id": "diskDrives.{{driveIndex}}.load.internetArchive",
       "binding": "diskDrives.load.internetArchive",
       "labelKey": "disk.InternetArchive",
-      "submenuTitle": "Internet Archive",
+      "submenuTitleKey": "disk.loadDiskFromInternetArchive",
       "actionLabel": "Search"
     },
     {
@@ -698,7 +697,7 @@
       "id": "diskDrives.{{driveIndex}}.load.demoZoo",
       "binding": "diskDrives.load.demoZoo",
       "labelKey": "disk.DemoZoo",
-      "submenuTitle": "DemoZoo",
+      "submenuTitleKey": "disk.loadDiskFromDemoZoo",
       "actionLabel": "Search"
     },
     {
@@ -708,7 +707,7 @@
       "providerId": "OneDrive",
       "providerName": "OneDrive",
       "labelKey": "disk.OneDrive",
-      "submenuTitle": "OneDrive",
+      "submenuTitleKey": "disk.loadDiskFromOneDrive",
       "actionLabelKey": "retroControl.open"
     },
     {
@@ -718,7 +717,7 @@
       "providerId": "GoogleDrive",
       "providerName": "Google Drive",
       "labelKey": "disk.GoogleDrive",
-      "submenuTitle": "Google Drive",
+      "submenuTitleKey": "disk.loadDiskFromGoogleDrive",
       "actionLabelKey": "retroControl.open"
     },
     {

--- a/src/ui/retro/retromenucomposition.test.ts
+++ b/src/ui/retro/retromenucomposition.test.ts
@@ -466,9 +466,9 @@ describe("Retro menu metadata structure", () => {
   test("refreshes an ejected disk drive label to Empty", () => {
     const context = createControlContext(undefined, (key, params) =>
       key === "retroControl.drive" ? params?.disk ?? "" : key, "en", () => undefined)
-    const diskCollection = retroMenuRegistry.resolve(context)
-      .find(control => control.id === "diskCollection")
-    const children = diskCollection?.children as (() => RetroResolvedControl[]) | undefined
+    const drives = retroMenuRegistry.resolve(context, null)
+      .find(control => control.id === "diskDrives")
+    const children = drives?.children as (() => RetroResolvedControl[]) | undefined
 
     mockHandleGetDriveProps.mockReturnValue({ diskHasChanges: false, filename: "Disk.po" })
     mockHandleGetFilename.mockReturnValue("Disk.po")
@@ -741,6 +741,7 @@ describe("Retro menu metadata structure", () => {
     expect(retroMenuRegistry.getIds(null)).toEqual([
       "machine",
       "diskCollection",
+      "diskDrives",
       "display",
       "sound",
       "keyboard",
@@ -773,7 +774,8 @@ describe("Retro menu metadata structure", () => {
       "diskCollection.newReleases",
       "diskCollection.favorites",
       "diskCollection.export",
-      "diskCollection.drivesSeparator",
+    ])
+    expect(retroMenuRegistry.getIds("diskDrives")).toEqual([
       "diskDrives.none",
       "diskDrives.0",
       "diskDrives.1",

--- a/src/ui/retro/retromenurenderer.tsx
+++ b/src/ui/retro/retromenurenderer.tsx
@@ -404,6 +404,68 @@ const restoreMenuFramePreview = (frame: RetroMenuFrame) => {
   })
 }
 
+const RetroSubmenuTitle = ({
+  active,
+  frame,
+  isAppleIIPlus,
+  language,
+  levelIndex,
+  titleValue,
+}: {
+  active: boolean
+  frame: RetroMenuFrame
+  isAppleIIPlus: boolean
+  language: string
+  levelIndex: number
+  titleValue?: string
+}) => {
+  const titleValueWidth = titleValue ? controlTextWidth(titleValue, language) : 0
+  const titleWidth = Math.max(0, submenuTitleContentWidth - titleValueWidth - (titleValue ? 1 : 0))
+  const visibleTitle = truncateControlText(frame.title, titleWidth, language)
+  const visibleTitleWidth = controlTextWidth(visibleTitle, language)
+  const titleClasses = [
+    "retro-submenu-title",
+    isAppleIIPlus ? "retro-text-submenu-title" : "",
+    active ? "retro-active-title" : "",
+    `retro-submenu-title-level-${levelIndex + 2}`,
+  ].filter(Boolean).join(" ")
+
+  return isAppleIIPlus
+    ? <div className={titleClasses}>
+      <RetroBorder
+        appleIIPlus
+        appleIIPlusFullHeightSides
+        className="retro-submenu-title-border"
+        columns={38}
+        rows={3}
+      />
+      <span className="retro-submenu-title-row">
+        <span className={retroFontSupports(frame.title) ? undefined : "retro-browser-font"}>
+          {visibleTitle.replaceAll(" ", "_")}_
+        </span>
+        <span className="retro-inverse-space" aria-hidden="true">
+          {fixedWidthSpace.repeat(Math.max(
+            0,
+            submenuTitleContentWidth - visibleTitleWidth - titleValueWidth,
+          ))}
+          {titleValue}
+          {fixedWidthSpace}
+        </span>
+      </span>
+    </div>
+    : <div className={titleClasses}>
+      <RetroBorder className="retro-submenu-title-border" columns={38} rows={3} />
+      <span className={`retro-submenu-title-text${retroFontSupports(frame.title) ? "" : " retro-browser-font"}`}>
+        <span className="retro-submenu-title-content">
+          {visibleTitle}{fixedWidthSpace}
+        </span>
+      </span>
+      {titleValue && <span className="retro-submenu-title-value">
+        {titleValue}
+      </span>}
+    </div>
+}
+
 const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => {
   const [manualIsOpen, setIsOpen] = useState(false)
   const [manualMenuStack, setMenuStack] = useState<RetroMenuFrame[]>([])
@@ -468,7 +530,15 @@ const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => 
     setMenuStack([])
     setSelectedIndex(0)
   }, [menuStack])
-  const maxVisibleMenuItems = 16
+  const previousFrame = menuStack[menuStack.length - 2]
+  const joinsLoadProviderTitle = Boolean(
+    currentFrame && previousFrame?.menuId.endsWith(".load.from"),
+  )
+  const visibleTitleFrames = joinsLoadProviderTitle
+    ? menuStack.filter(frame => frame !== previousFrame).slice(-3)
+    : menuStack.slice(-3)
+  const titleLevelCount = visibleTitleFrames.length
+  const maxVisibleMenuItems = 16 - Math.max(0, titleLevelCount - 1) * 2
   const visibleMenuStart = currentFrame
     ? Math.min(
       Math.max(0, selectedIndex - maxVisibleMenuItems + 1),
@@ -1084,6 +1154,7 @@ const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => 
     currentMenu,
     hasOpenDialog,
     isOpen,
+    maxVisibleMenuItems,
     menuStack,
     open,
     runTour,
@@ -1153,17 +1224,6 @@ const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => 
   ])
   const submenuTitleValue = selectedItem?.contextualSubmenuTitleValue
     ?? currentFrame?.submenuTitleValue?.(currentFrame.items, currentFrame.values)
-  const submenuTitleValueWidth = submenuTitleValue
-    ? controlTextWidth(submenuTitleValue, language)
-    : 0
-  const submenuTitleWidth = currentFrame
-    ? Math.max(0, submenuTitleContentWidth - submenuTitleValueWidth -
-      (submenuTitleValue ? 1 : 0))
-    : submenuTitleContentWidth
-  const visibleSubmenuTitle = currentFrame
-    ? truncateControlText(currentFrame.title, submenuTitleWidth, language)
-    : ""
-  const visibleSubmenuTitleWidth = controlTextWidth(visibleSubmenuTitle, language)
   const clockTime = formatClockTime(now, language)
   const clockDate = formatClockDate(now, language, isAppleIIPlus ? "_" : " ")
   const clockTextWidth = isAppleIIPlus ? 12 : 11
@@ -1192,40 +1252,23 @@ const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => 
             </>
             : <span>{"Apple2TS Control Panel "}&#8198;</span>}
         </header>,
-        submenu: currentFrame && (isAppleIIPlus
-          ? <div className="retro-submenu-title retro-text-submenu-title">
-            <RetroBorder
-              appleIIPlus
-              appleIIPlusFullHeightSides
-              className="retro-submenu-title-border"
-              columns={38}
-              rows={3}
+        submenu: currentFrame && <>
+          {visibleTitleFrames.map((frame, levelIndex) => {
+            const active = levelIndex === visibleTitleFrames.length - 1
+            const titleValue = active
+              ? submenuTitleValue
+              : frame.submenuTitleValue?.(frame.items, frame.values)
+            return <RetroSubmenuTitle
+              active={active}
+              frame={frame}
+              isAppleIIPlus={isAppleIIPlus}
+              key={frame.menuId}
+              language={language}
+              levelIndex={levelIndex}
+              titleValue={titleValue}
             />
-            <span className="retro-submenu-title-row">
-              <span className={retroFontSupports(currentFrame.title) ? undefined : "retro-browser-font"}>
-                {visibleSubmenuTitle.replaceAll(" ", "_")}_
-              </span>
-              <span className="retro-inverse-space" aria-hidden="true">
-                {fixedWidthSpace.repeat(Math.max(
-                  0,
-                  submenuTitleContentWidth - visibleSubmenuTitleWidth - submenuTitleValueWidth,
-                ))}
-                {submenuTitleValue}
-                {fixedWidthSpace}
-              </span>
-            </span>
-          </div>
-          : <div className="retro-submenu-title">
-            <RetroBorder className="retro-submenu-title-border" columns={38} rows={3} />
-            <span className={`retro-submenu-title-text${retroFontSupports(currentFrame.title) ? "" : " retro-browser-font"}`}>
-              <span className="retro-submenu-title-content">
-                {visibleSubmenuTitle}{fixedWidthSpace}
-              </span>
-            </span>
-            {submenuTitleValue && <span className="retro-submenu-title-value">
-              {submenuTitleValue}
-            </span>}
-          </div>),
+          })}
+        </>,
         clock: menuStack.length === 0 && <div className="retro-clock" aria-label={`${now.toLocaleTimeString(language)} ${now.toLocaleDateString(language)}`}>
           <RetroBorder
             appleIIPlus={isAppleIIPlus}
@@ -1241,7 +1284,7 @@ const RetroMenuRenderer = ({ displayProps }: { displayProps: DisplayProps }) => 
             {clockDate}
           </span></time>
         </div>,
-        menu: <div className={`retro-menu${currentFrame ? " retro-submenu-menu" : " retro-root-menu"}`} role="menu">
+        menu: <div className={`retro-menu${currentFrame ? " retro-submenu-menu" : " retro-root-menu"} retro-menu-title-level-${titleLevelCount + 1}`} role="menu">
           {visibleMenu.map((item, visibleIndex) => {
             const index = visibleMenuStart + visibleIndex
             const valueIndex = currentFrame?.values[index] ?? item.optionIndex ?? -1


### PR DESCRIPTION
<img width="1832" height="1521" alt="image" src="https://github.com/user-attachments/assets/cb757529-66e2-403e-898b-28be6db68992" />
<img width="1832" height="1521" alt="image" src="https://github.com/user-attachments/assets/9145debd-a18d-429d-9716-c0b119824b4c" />
<img width="1832" height="1521" alt="image" src="https://github.com/user-attachments/assets/b3155f31-3a24-469b-97cd-23b94c0ea467" />
<img width="1832" height="1521" alt="image" src="https://github.com/user-attachments/assets/55cd4449-906e-4d46-a700-3f4757b6b722" />
<img width="1832" height="1521" alt="image" src="https://github.com/user-attachments/assets/0b31e899-3b83-4403-a1ff-700a3308aec1" />

# Changes:
- Moved Drives menu out of Disks to top-level menu
- Added support for more than two levels on menu hierarchy
- Fixed ImageWriter popup/canvas mouse event conflicts

# Verification:
- Verified new Drives menu works as expected
- Verified all existing control panel screens work as expected
- Tested on multiple platforms (Mac OS, Windows) and browsers (Chrome, Edge)