### PR TITLE
feat(linkBuilder): support slot card configuration for custom software-hardware pairings

### DIFF
--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -2510,6 +2510,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Steckplatzkarten konfigurieren"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Slot {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Keine (leer)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/en@pirate.po
+++ b/src/i18n/catalogs/en@pirate.po
@@ -2310,6 +2310,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Rig yer slot cards"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Slot {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "None (empty)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr "First Mate"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -2498,6 +2498,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Configurar tarjetas de ranura"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Ranura {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Ninguna (vacía)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -2510,6 +2510,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Configurer les cartes d'extension"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Slot {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Aucune (vide)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -2500,6 +2500,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Configura schede slot"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Slot {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Nessuna (vuota)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -2483,6 +2483,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "スロットカードの設定"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "スロット {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "なし (空)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -2480,6 +2480,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "슬롯 카드 설정"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "슬롯 {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "없음 (비어 있음)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -2148,6 +2148,18 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr ""
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr ""
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr ""
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -2480,6 +2480,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Slotkaarten configureren"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Slot {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Geen (leeg)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -2490,6 +2490,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Configurar placas de slot"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Slot {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Nenhuma (vazia)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -2501,6 +2501,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Настройка карт расширения"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Слот {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Нет (пусто)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -2490,6 +2490,19 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr ""
 
+
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "Konfigurera kortplatser"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "Kortplats {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "Ingen (tom)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr ""

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -2461,7 +2461,18 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr "64 (默认)"
 
-#, fuzzy
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "配置插槽扩展卡"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "插槽 {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "无 (空)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr "AI 代理"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -2529,7 +2529,18 @@ msgctxt "linkBuilder.ramDiskSizes.default"
 msgid "64 (default)"
 msgstr "64 (預設)"
 
-#, fuzzy
+msgctxt "linkBuilder.slots.configure"
+msgid "Configure slot cards"
+msgstr "設定插槽擴充卡"
+
+msgctxt "linkBuilder.slots.slot"
+msgid "Slot {{slot}}:"
+msgstr "插槽 {{slot}}:"
+
+msgctxt "linkBuilder.slots.cardNone"
+msgid "None (empty)"
+msgstr "無 (空)"
+
 msgctxt "agent.tabTitle"
 msgid "Agent"
 msgstr "AI 代理"

--- a/src/ui/controls/linkbuilder.tsx
+++ b/src/ui/controls/linkbuilder.tsx
@@ -6,10 +6,11 @@ import { Droplist } from "../panels/droplist"
 import { diskImages } from "../devices/disk/diskimages"
 import CheckBox from "../panels/checkbox"
 import { getLowercaseMode, getColorMode, getCrtDistortion, getGhosting, getShowScanlines, getTheme, isEmbedMode, isGameMode } from "../ui_settings"
-import { UI_THEMES } from "../../common/utility"
+import { DEFAULT_SLOT_CONFIG, UI_THEMES } from "../../common/utility"
 import { isAudioEnabled } from "../devices/audio/speaker"
-import { handleGetIsDebugging, handleGetMachineName, handleGetMemSize, handleGetSpeedMode } from "../main2worker"
+import { handleGetIsDebugging, handleGetMachineName, handleGetMemSize, handleGetSpeedMode, handleGetSlotConfig } from "../main2worker"
 import { useTranslation } from "../../i18n/useTranslation"
+import { SLOT_NUMBERS, getSlotOptions } from "../devices/machineconfig"
 
 export enum TAB {
   DISK,
@@ -71,12 +72,32 @@ const LinkBuilder = () => {
   const [speed, setSpeed] = useState("")
   const [theme, setTheme] = useState("")
   const [tabSection, setTabSection] = useState(TAB.DISK)
+  const [slotConfig, setSlotConfig] = useState<SlotConfig>({ ...DEFAULT_SLOT_CONFIG })
+
+  // Short display labels for cards in the Link Builder slot dropdowns
+  const cardShortLabels: Record<SLOT_CARD_ID, string> = {
+    none: t("linkBuilder.slots.cardNone"),
+    ssc: "SSC",
+    softcard: "SoftCard (Z80)",
+    aux: "Aux/80Col",
+    videoterm: "VideoTerm",
+    vidhd: "VidHD",
+    mockingboard: "Mockingboard",
+    mouse: "Mouse",
+    vera: "VERA",
+    passport: "Passport",
+    disk2: "Disk II",
+    smartport: "SmartPort",
+  }
 
   const machineValues = [
     t("linkBuilder.machines.enhanced"),
     t("linkBuilder.machines.unenhanced"),
     t("linkBuilder.machines.apple2p")
   ]
+  // Derive MACHINE_NAME from local machine state so slot options stay in sync
+  const lbMachineName: MACHINE_NAME = machine === machineValues[2] ? "APPLE2P"
+    : machine === machineValues[1] ? "APPLE2EU" : "APPLE2EE"
 
   const ramdiskValues = [
     t("linkBuilder.ramDiskSizes.default"),
@@ -151,7 +172,7 @@ const LinkBuilder = () => {
     }
 
     const ramIndex = ramdiskValues.indexOf(ramdisk)
-    if (ramIndex > 0) {
+    if (slotConfig[3] === "aux" && ramIndex > 0) {
       params.push("ramdisk=" + ramdiskParams[ramIndex])
     }
 
@@ -173,6 +194,20 @@ const LinkBuilder = () => {
     const themeIndex = themeValues.indexOf(theme)
     if (themeIndex > 0) {
       params.push(`theme=${themeParams[themeIndex]}`)
+    }
+
+    // Slot configuration params: emit slotN=card for any non-default slot
+    let hasVera = false
+    SLOT_NUMBERS.forEach(slot => {
+      const card = slotConfig[slot]
+      if (card !== DEFAULT_SLOT_CONFIG[slot]) {
+        params.push(`slot${slot}=${card}`)
+        if (card === "vera") hasVera = true
+      }
+    })
+    // Auto-add tab=vera when VERA is configured, for convenience
+    if (hasVera) {
+      params.push("tab=vera")
     }
 
     for (let i = 0; i < params.length; i++) {
@@ -226,6 +261,7 @@ const LinkBuilder = () => {
     setSelectedDisk("")
     setSpeed(speedNames[2])
     setTheme(themeValues[0])
+    setSlotConfig({ ...DEFAULT_SLOT_CONFIG })
   }
 
   const retrieveFromEmulatorSettings = () => {
@@ -270,6 +306,9 @@ const LinkBuilder = () => {
     } else {
       setAppmode(gameModes[0])
     }
+
+    // Retrieve current slot config from emulator
+    setSlotConfig({ ...handleGetSlotConfig() })
   }
 
   return (
@@ -281,7 +320,7 @@ const LinkBuilder = () => {
             if (event.key === "Escape") setShowBuilder(false)
           }}>
           <div className="floating-dialog flex-column"
-            style={{ left: "35%", top: "10%", width: "70%", maxWidth: "600px" }}>
+            style={{ left: "35%", top: "5%", width: "70%", maxWidth: "600px", maxHeight: "90vh", overflowX: "hidden", overflowY: "auto" }}>
             <div className="flex-row-space-between" style={{ marginLeft: "10px", marginRight: "10px" }}>
               <div className="dialog-title" style={{ padding: 0, paddingTop: "6px" }}>{t("linkBuilder.title")}</div>
               <button className="push-button"
@@ -302,7 +341,19 @@ const LinkBuilder = () => {
                 <Droplist name={t("linkBuilder.machine")}
                   value={machine}
                   values={machineValues}
-                  setValue={setMachine} />
+                  setValue={(val: string) => {
+                    setMachine(val)
+                    // Adjust slot 3 when crossing between II+ and IIe families
+                    const newIsIIp = val === machineValues[2]
+                    const wasIIp = lbMachineName === "APPLE2P"
+                    if (newIsIIp !== wasIIp) {
+                      setSlotConfig(prev => ({
+                        ...prev,
+                        3: newIsIIp ? "videoterm" : "aux"
+                      }))
+                      if (!newIsIIp) setRamdisk(ramdiskValues[0]) // reset to 64KB default
+                    }
+                  }} />
 
                 <Droplist name={t("linkBuilder.colorMode")}
                   value={colormode}
@@ -312,7 +363,13 @@ const LinkBuilder = () => {
                 <Droplist name={t("linkBuilder.ramDiskSize")}
                   value={ramdisk}
                   values={ramdiskValues}
-                  setValue={setRamdisk} />
+                  setValue={(val: string) => {
+                    setRamdisk(val)
+                    const rIdx = ramdiskValues.indexOf(val)
+                    if (rIdx > 0 && lbMachineName !== "APPLE2P" && slotConfig[3] !== "aux") {
+                      setSlotConfig(prev => ({ ...prev, 3: "aux" }))
+                    }
+                  }} />
 
                 <Droplist name={t("linkBuilder.emulatorSpeed")}
                   value={speed !== "" ? speed : speedNames[2]}
@@ -344,6 +401,78 @@ const LinkBuilder = () => {
                   checked={!soundoff}
                   setChecked={(on: boolean) => { setSoundoff(!on) }} />
               </div>
+            </div>
+
+            <div className="horiz-rule" style={{ marginTop: "15px" }}></div>
+
+            {/* Slot Configuration – always visible */}
+            <div className="dialog-title" style={{ marginBottom: "4px" }}>{t("linkBuilder.slots.configure")}</div>
+            <div className="flex-row" style={{ flexWrap: "wrap", gap: "0 20px", marginBottom: "8px" }}>
+              {SLOT_NUMBERS.map(slot => {
+                const rawOptions = getSlotOptions(slot, lbMachineName)
+                // Filter out cards already installed in another slot (unless card is none or mockingboard)
+                const options = rawOptions.filter(o => {
+                  if (o.card === "none" || o.card === "mockingboard") return true
+                  if (slotConfig[slot] === o.card) return true
+                  return !SLOT_NUMBERS.some(otherSlot => otherSlot !== slot && slotConfig[otherSlot] === o.card)
+                })
+
+                // Build display label for each option (aux entries include RAM size)
+                const getOptionLabel = (o: typeof options[0]) => {
+                  if (o.card === "aux" && o.ramSizeKb !== undefined) {
+                    if (o.ramSizeKb <= 64) return "Aux/80Col (64KB)"
+                    const sizeStr = o.ramSizeKb >= 1024 ? `${o.ramSizeKb / 1024}MB` : `${o.ramSizeKb}KB`
+                    return `AE RamWorks (${sizeStr})`
+                  }
+                  return cardShortLabels[o.card]
+                }
+                const cardLabels = options.map(getOptionLabel)
+
+                // Current label: for slot 3 aux, reflect currently chosen ramdisk size
+                const currentCard = slotConfig[slot]
+                let currentLabel = cardShortLabels[currentCard]
+                if (slot === 3 && currentCard === "aux") {
+                  const ramIdx = ramdiskValues.indexOf(ramdisk)
+                  const ramSizeKb = parseInt(ramdiskParams[Math.max(ramIdx, 0)]) || 64
+                  currentLabel = ramSizeKb <= 64 ? "Aux/80Col (64KB)"
+                    : `AE RamWorks (${ramSizeKb >= 1024 ? `${ramSizeKb / 1024}MB` : `${ramSizeKb}KB`})`
+                }
+
+                return (
+                  <Droplist
+                    key={slot}
+                    name={t("linkBuilder.slots.slot", { slot: String(slot) })}
+                    value={currentLabel}
+                    values={cardLabels}
+                    setValue={(label: string) => {
+                      const idx = cardLabels.indexOf(label)
+                      if (idx >= 0) {
+                        const chosen = options[idx]
+                        setSlotConfig(prev => {
+                          const next = { ...prev, [slot]: chosen.card }
+                          if (chosen.card !== "none" && chosen.card !== "mockingboard") {
+                            SLOT_NUMBERS.forEach(otherSlot => {
+                              if (otherSlot !== slot && next[otherSlot] === chosen.card) {
+                                next[otherSlot] = "none"
+                              }
+                            })
+                          }
+                          return next
+                        })
+                        // For slot 3: sync or reset ramdisk
+                        if (slot === 3) {
+                          if (chosen.card === "aux" && chosen.ramSizeKb !== undefined) {
+                            const paramStr = String(chosen.ramSizeKb)
+                            const ramIdx = ramdiskParams.indexOf(paramStr)
+                            if (ramIdx >= 0) setRamdisk(ramdiskValues[ramIdx])
+                          } else {
+                            setRamdisk(ramdiskValues[0])
+                          }
+                        }
+                      }
+                    }} />
+                )
+              })}
             </div>
 
             <div className="horiz-rule" style={{ marginTop: "15px" }}></div>
@@ -380,7 +509,7 @@ const LinkBuilder = () => {
             </div>
 
             {tabSection === TAB.DISK &&
-              <div style={{ minHeight: "150px" }}>
+              <div>
                 <Droplist name={t("linkBuilder.diskImageToLoad")}
                   value={selectedDisk}
                   values={diskNames}
@@ -401,7 +530,6 @@ const LinkBuilder = () => {
                   setValue={setLoadBlock}
                   placeholder="CHOP"
                   width="15em" />
-
               </div>
             }
 
@@ -441,9 +569,7 @@ const LinkBuilder = () => {
                   setChecked={(on: boolean) => { setRunprogoff(!on) }} />
               </div>
             }
-
-
-            <div className="horiz-rule" style={{ marginTop: "20px" }}></div>
+            <div className="horiz-rule" style={{ marginTop: "10px" }}></div>
 
             {/* Show final link, readonly textarea for now */}
             <div className="flex-row-space-between" style={{ marginRight: "10px" }}>
@@ -457,7 +583,7 @@ const LinkBuilder = () => {
             <textarea
               className="link-builder-textarea"
               style={{ backgroundColor: "var(--input-bg-color)" }}
-              rows={5}
+              rows={8}
               value={link}
               readOnly
             />

--- a/src/ui/devices/machineconfig.tsx
+++ b/src/ui/devices/machineconfig.tsx
@@ -24,7 +24,7 @@ type SlotOption = {
   ramSizeKb?: typeof RAM_OPTIONS[number]
 }
 
-const getSlotOptions = (slot: SlotNumber, machine: MACHINE_NAME): SlotOption[] => {
+export const getSlotOptions = (slot: SlotNumber, machine: MACHINE_NAME): SlotOption[] => {
   if (slot === 3) {
     return machine === "APPLE2P"
       ? [{ card: "none" }, { card: "videoterm" }, { card: "vidhd" }]


### PR DESCRIPTION
## Summary

This PR enhances the **Link Builder** tool by adding a dedicated **Slot Configuration** section (Slots 1–7). With this update, users and content creators can generate shareable URLs that precisely define which expansion / interface cards an Apple II software title requires to run at its best.

<img width="1086" height="842" alt="image" src="https://github.com/user-attachments/assets/faeba6d7-557a-4ea1-9536-9fe603e53d69" />

When a user clicks the generated link, Apple2TS automatically provisions and maps the exact hardware slot setup before booting, delivering an out-of-the-box, plug-and-play experience without requiring manual emulator adjustments.

## Highlights & Use Cases

- **Custom Hardware & Software Pairing**:
  - Pair VERA titles (e.g., VERA slideshows, *Time Pilot*) directly with `slot2=vera` or `slot4=vera` (with automatic `tab=vera`).
  - Configure *Total Replay* or *Pitch Dark* with `slot3=vidhd` for Super Hi-Res artwork.
  - Set up dual Mockingboards (`slot4=mockingboard&slot5=mockingboard`) for enhanced stereo sound in titles like *Ultima V*.
  - Assign specific memory expansion sizes on Slot 3 (RamWorks III up to 8MB) or choose VideoTerm on Apple II+.
  - Easily attach or remove peripheral cards such as Mouse, SSC, and Z80 SoftCard.

## Key Features

1. **Integrated Slot Card Pickers**:
   - Always-visible slot selector for Slots 1 to 7 inside the Link Builder dialog.
   - Accurately reflects current emulator settings when clicking *“Retrieve from current emulator settings”*.
2. **Card Mutual Exclusion**:
   - Unique expansion cards (e.g., VERA, Mouse, Z80 SoftCard) cannot be duplicated across slots. Selecting VERA in Slot 2 immediately removes it from Slot 4’s dropdown options (and vice versa).
   - Legitimate multi-card setups (such as dual Mockingboards) remain fully supported.

<img width="1362" height="866" alt="image" src="https://github.com/user-attachments/assets/296355ac-8e42-469a-821d-3586ef323429" />

3. **Smart Slot 3 & RamDisk Parameter Handling**:
   - Slot 3 automatically adapts to the chosen machine architecture (Aux/RamWorks on IIe variants vs. VideoTerm on II+).
   - The `ramdisk=` query parameter is only emitted when Slot 3 is configured with an Aux memory card. Selecting `vidhd`, `none`, or `videoterm` cleanly omits `ramdisk=` and resets memory to defaults.

<img width="855" height="869" alt="image" src="https://github.com/user-attachments/assets/5f1d774a-6090-4652-b147-9f126763eb06" />


4. **URL Optimization**:
   - Only non-default slot configurations (`slot1=...` to `slot7=...`) are serialized into the query string to keep generated links compact.
5. **Full Internationalization (i18n)**:
   - Added translation keys and translated catalogs across all 13 supported languages (including Traditional Chinese, Simplified Chinese, Japanese, German, French, Spanish, etc.).

## Verification

- [x] Verified slot option mutual exclusion (VERA, Mouse, SoftCard) dynamically updates dropdown availability.
- [x] Verified `ramdisk=` query param is suppressed when Slot 3 is `vidhd` or `none`.
- [x] Verified machine model switching correctly adapts Slot 3 options and syncs state.
- [x] Ran unit tests (`npx jest src/ui/inputparams.test.ts`) and production build (`npm run build`).
- [x] Validated i18n catalogs compilation with `npm run check-i18n-catalogs`.

