### PR TITLE
fix(ui): keep Help text legible in narrow windows

### DIFF
--- a/src/ui/panels/help/helppanel.css
+++ b/src/ui/panels/help/helppanel.css
@@ -104,9 +104,3 @@
   padding: 5px;
   color: #00FF00;
 }
-
-@media (max-width: 600px) {
-  .help-text {
-    font-size: 0.5em;
-  }
-}


### PR DESCRIPTION
Keep Help text readable when the window narrows. Remove the rule that halves its font size below 600px, allowing the existing wrapping and scrolling to handle the available space.

Fixes #362.
