### PR TITLE
fix(ui): position editor controls consistently on small desktop screens

### DIFF
--- a/src/ui/panels/agent/agent_tab.tsx
+++ b/src/ui/panels/agent/agent_tab.tsx
@@ -256,11 +256,8 @@ const AgentTab = () => {
         </div>
       ))
 
-  const isLandscape = (window.innerWidth > window.innerHeight)
-  const height = isLandscape ? Math.max((window.innerHeight - 170), 600) : 560
-
   return (
-    <div className="flex-column-gap debug-section agent-container" style={{ height: `${height}px` }}>
+    <div className="flex-column-gap debug-section agent-container editor-workspace">
       <div className="agent-messages" ref={messagesContainerRef}>
         {initialMessage}
         

--- a/src/ui/panels/basic/basic_editorview.tsx
+++ b/src/ui/panels/basic/basic_editorview.tsx
@@ -234,11 +234,8 @@ const BasicEditor = (props: EditorProps) => {
     }
   }, [props.breakpoints, handleBreakpointToggle])
 
-  const isLandscape = (window.innerWidth > window.innerHeight)
-  const height = isLandscape ? Math.max((window.innerHeight - 270), 350) : 560
-
-  return <div ref={editorRef} style={{
-    height: `${height}px`, width: "693px",
+  return <div ref={editorRef} className="editor-content" style={{
+    width: "693px",
     overflowY: "hidden"
   }} />
 }

--- a/src/ui/panels/basic/basic_tab.tsx
+++ b/src/ui/panels/basic/basic_tab.tsx
@@ -267,9 +267,9 @@ const BasicTab = (props: { updateDisplay: UpdateDisplay }) => {
 
   return (
     <div className="flex-column-gap debug-section">
+      <div className="flex-column-gap editor-workspace">
       <BasicEditor value={programText} setValue={setProgramText}
         highlightLine={highlightLine} readOnly={running} />
-      <BasicDebugView/>
       <div className="flex-row">
         <div className="flex-row">
           <button
@@ -377,6 +377,8 @@ const BasicTab = (props: { updateDisplay: UpdateDisplay }) => {
         style={{ gridColumn: "span 2" }}
         title={programError}
         className="dbg-program-error">❌ {programError}</div>}
+      </div>
+      <BasicDebugView/>
     </div>
   )
 }

--- a/src/ui/panels/expectin/editorview.tsx
+++ b/src/ui/panels/expectin/editorview.tsx
@@ -103,8 +103,8 @@ const CodeMirrorEditor = (props: EditorProps) => {
     }
   }, [])
 
-  return <div ref={editorRef} style={{
-    height: "760px", width: "693px",
+  return <div ref={editorRef} className="editor-content" style={{
+    width: "693px",
     overflowY: "hidden"
   }} />
 }

--- a/src/ui/panels/expectin/expectintab.tsx
+++ b/src/ui/panels/expectin/expectintab.tsx
@@ -35,11 +35,8 @@ const ExpectinTab = () => {
     }
   }
 
-  const isLandscape = (window.innerWidth > window.innerHeight)
-  const height = isLandscape ? Math.max((window.innerHeight - 170), 450) : 560
-
   return (
-    <div className="flex-column-gap debug-section" style={{ height: `${height}px` }}>
+    <div className="flex-column-gap debug-section editor-workspace">
       <CodeMirrorEditor value={expectinText} setValue={setExpectinText} />
       <div className="flex-row-gap">
         {expectinError === "" ?

--- a/src/ui/panels/panels.css
+++ b/src/ui/panels/panels.css
@@ -605,6 +605,26 @@ body.dark-mode .icon-text {
   padding-top: 0px;
 }
 
+/* Keep editor controls below the scrolling content, above BASIC variables. */
+.debug-section .editor-workspace,
+.debug-section.editor-workspace {
+  height: 560px;
+}
+
+#debug-section.flex-row .editor-workspace {
+  height: max(200px, calc(100dvh - 20px));
+}
+
+.editor-workspace > * {
+  flex-shrink: 0;
+}
+
+.editor-workspace > .editor-content,
+.editor-workspace > .agent-messages {
+  flex: 1;
+  min-height: 0;
+}
+
 .dbg-tab-row {
   padding-bottom: 0px;
 }


### PR DESCRIPTION
Ready access to Run and the other actions is important when using the BASIC, exPectin, and Agent panels, especially on small desktop screens. Keeping their controls consistently positioned below the working area makes them easier to find and use.

A shared flex rule lets the editor or conversation fill the available height in the side-by-side layout, with controls beneath it.

<img width="1440" height="800" alt="agent-action-row" src="https://github.com/user-attachments/assets/61368a9b-77e3-4557-8bb5-00f986d00c62" />
<img width="1440" height="800" alt="expectin-action-row" src="https://github.com/user-attachments/assets/05c3e9e9-8dc2-4583-959b-2d9042b2fd00" />
<img width="1440" height="800" alt="basic-action-row" src="https://github.com/user-attachments/assets/8c73bda3-1f41-4dcc-8988-d8f0dd68be9b" />
