### PR TITLE
fix(debugger): preserve HGR magnifier pixel proportions

### DIFF
--- a/src/ui/canvas.css
+++ b/src/ui/canvas.css
@@ -37,6 +37,8 @@
 }
 
 .hgr-view {
+  align-items: flex-start;
+  width: max-content;
   position: absolute;
   user-select: none;
   pointer-events: none;


### PR DESCRIPTION
Keep magnified HGR pixels at consistent proportions as the pointer moves toward the monitor edge. Prevent the address list from wrapping and stretching the adjacent pixel grid vertically.

Fixes #455.