### PR TITLE
fix(mockingboard): correct second VIA Timer 2 latch offset

### DIFF
--- a/src/worker/devices/mockingboard.ts
+++ b/src/worker/devices/mockingboard.ts
@@ -43,7 +43,7 @@ const IER = [0xE, 0x8E]
 
 // these are not part of 6522 registers, but store them in our ROM
 // so they get saved with the state.
-const T2LL = [0x10, 0x91]
+const T2LL = [0x10, 0x90]
 const REG_LATCH = [0x11, 0x91]
 const TIMER_FIRED = [0x12, 0x92]
 const TIMER_STARTED = [0x13, 0x93]

--- a/src/worker/save_restore_card.test.ts
+++ b/src/worker/save_restore_card.test.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_SLOT_CONFIG } from "../common/utility"
 import { interruptRequest } from "./cpu6502"
 import { memGetSlotROM, memSetSlotROM } from "./memory"
-import { resetMockingboard } from "./devices/mockingboard"
+import { handleMockingboard, resetMockingboard } from "./devices/mockingboard"
 import { configureMachine, doSetSlotConfig } from "./motherboard"
 import { getApple2State, setApple2State } from "./save_restore"
 import { setIsTesting } from "./worker2main"
@@ -20,6 +20,8 @@ test("v2 save state preserves Mockingboard registers and timers", () => {
   memSetSlotROM(4, 0x13, 0x40)
   memSetSlotROM(4, 0x0D, 0x40)
   memSetSlotROM(4, 0x0E, 0x40)
+  handleMockingboard(0xC488, 0x37) // second VIA's Timer 2 low latch
+  memSetSlotROM(4, 0x91, 3) // independent sound-register selection
 
   const saved = getApple2State()
   resetMockingboard(4)
@@ -31,4 +33,7 @@ test("v2 save state preserves Mockingboard registers and timers", () => {
   expect(memGetSlotROM(4, 0x13)).toBe(0x40)
   expect(memGetSlotROM(4, 0x0D)).toBe(0xC0)
   expect(s6502.flagIRQ & (1 << 4)).not.toBe(0)
+  handleMockingboard(0xC489, 0x12) // load Timer 2 from the restored latch
+  expect(memGetSlotROM(4, 0x88)).toBe(0x37)
+  expect(memGetSlotROM(4, 0x91)).toBe(3)
 })


### PR DESCRIPTION
The second VIA’s Timer 2 latch used `$91`, the same internal storage offset as its sound-register selection. Correct it to `$90`, matching the first VIA’s separate latch layout.

Extend the existing save/restore test to check that both values remain independent.